### PR TITLE
fix(design): k3 - design token audit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,98 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+**Nuotti** is a real-time interactive quiz and show platform (.NET 10 / C# 13). It has multiple UIs served simultaneously: a Blazor WASM audience app, a Blazor Server performer/host app, an Avalonia desktop projector, a SvelteKit static site, and a console audio engine.
+
+## Commands
+
+### .NET (Backend, Audience, Performer, Projector, etc.)
+
+```bash
+dotnet build Nuotti.sln
+dotnet test                                          # all test projects
+dotnet test tests/Nuotti.UnitTests/                 # specific project
+dotnet test tests/Nuotti.IntegrationTests/
+dotnet test tests/Nuotti.E2E/
+dotnet test --filter "FullyQualifiedName~MyTestName" # single test
+dotnet format --verify-no-changes                    # lint/format check
+dotnet format                                        # auto-fix formatting
+```
+
+### Web (SvelteKit — `web/` directory)
+
+```bash
+cd web && npm install
+npm run dev      # dev server
+npm run build    # production build
+npm run lint     # ESLint
+npm run format   # Prettier
+```
+
+### Local Docker (PowerShell scripts in `tools/`)
+
+```bash
+pwsh tools/up-local.ps1    # build images and start all services
+pwsh tools/down-local.ps1  # stop and clean up
+```
+
+Local service ports: Backend `5210`, Audience `5280`, Web `5380`.
+
+## Architecture
+
+### Services & Projects
+
+| Project | Type | Role |
+|---|---|---|
+| `Nuotti.Backend` | ASP.NET Core | REST API + SignalR hubs (`QuizHub`, `GameHub`, `LogHub`) |
+| `Nuotti.Contracts` | Class library | Shared DTOs, events, reducers, design tokens — **no dependencies** |
+| `Nuotti.Audience` | Blazor WASM | Participant-facing UI |
+| `Nuotti.Performer` | Blazor Server | Host/presenter control panel |
+| `Nuotti.Projector` | Avalonia 11 | Native desktop display app |
+| `Nuotti.AudioEngine` | Console app | PortAudio-based audio playback |
+| `Nuotti.SimKit` | Console app | CLI automation/simulation tool |
+| `ServiceDefaults` | Class library | Shared Serilog + OpenTelemetry setup |
+| `web/` | SvelteKit | Static marketing/landing site |
+
+### Communication & State
+
+- **SignalR** (real-time): all clients connect to `GameHub` / `QuizHub` for live state sync
+- **JSON serialization**: two conventions — camelCase for REST (`ContractsJson.RestOptions`), PascalCase for SignalR hubs (`ContractsJson.HubOptions`)
+- **In-memory stores**: `ISessionStore` and `IGameStateStore` — not persisted, designed for single-node operation
+- **Event bus**: `InMemoryEventBus` in Backend with typed subscribers; domain events live in `Nuotti.Contracts/V1/Event/`
+
+### Contracts (`Nuotti.Contracts`)
+
+The contracts library is the hub of inter-service communication. It is versioned (MAJOR.MINOR.PATCH):
+- MAJOR bump = breaking change; MINOR = backward-compatible addition
+- All message types, enums, reducers, and the design system live here
+- Reducers under `V1/Reducer/` and `V1/Eventing/` process domain events into state
+
+### Testing
+
+Tests use **xUnit** + **Verify** (snapshot testing). Integration tests use `Microsoft.AspNetCore.Mvc.Testing` for in-process hosting. SignalR tests use FakeClient/FakeClientProxy helpers.
+
+```
+tests/Nuotti.UnitTests/            # pure logic, contracts, reducers
+tests/Nuotti.IntegrationTests/     # service-level, in-process API
+tests/Nuotti.E2E/                  # Playwright full-system flows
+Nuotti.Backend.Tests/              # API + hub tests
+Nuotti.Contracts.Tests/            # serialization + reducer tests
+```
+
+### CI/CD
+
+- **test.yml**: runs dotnet test, dotnet format, ESLint/Prettier on every push/PR to main
+- **build-and-push.yml**: builds Docker images for Backend, Audience, and Web; pushes to GHCR (`ghcr.io/sifterstudios/nuotti-*`)
+- Self-hosted runner on Unraid; images deployed via Docker Compose
+
+## Key Conventions
+
+- `global.json` pins .NET 10 RC — use `rollForward: latestMajor` with `allowPrerelease: true`
+- All projects reference `ServiceDefaults` for consistent logging and telemetry setup
+- Options pattern (`NuottiOptions`) for app configuration with `NUOTTI_` env var prefix in deployment
+- Design tokens and theming live in `Nuotti.Contracts/V1/Design/`; see `Nuotti.Audience/README.md` and `Nuotti.Projector/README_THEMING.md` for theming docs
+- Structured audit logs and runtime feature flags are part of the ops layer — see `docs/ops-runbook.md`
+- Flaky tests are tracked in `docs/FLAKY_TESTS.md` and marked with `[Trait("Flaky", "true")]`

--- a/Nuotti.Contracts.Tests/V1/Design/ProjectorAxamlSyncTests.cs
+++ b/Nuotti.Contracts.Tests/V1/Design/ProjectorAxamlSyncTests.cs
@@ -1,0 +1,90 @@
+using System.Xml.Linq;
+using Nuotti.Contracts.V1.Design;
+using Xunit;
+
+namespace Nuotti.Contracts.Tests.V1.Design;
+
+/// <summary>
+/// Verifies that the color values hardcoded in Nuotti.Projector/App.axaml
+/// stay in sync with the canonical DesignTokens in Nuotti.Contracts.
+/// Avalonia cannot reference C# constants from XAML, so the values are
+/// duplicated there — these tests catch any drift.
+/// Note: Projector only supports Light and Dark (no HighContrast — it's a TV display app).
+/// </summary>
+public class ProjectorAxamlSyncTests
+{
+    [Fact]
+    public void LightTheme_ColorsMatchDesignTokens()
+        => AssertThemeMatches("Light", DesignTokens.LightPalette);
+
+    [Fact]
+    public void DarkTheme_ColorsMatchDesignTokens()
+        => AssertThemeMatches("Dark", DesignTokens.DarkPalette);
+
+    // -------------------------------------------------------------------------
+
+    private static void AssertThemeMatches(string themeKey, ColorPalette palette)
+    {
+        var dict = LoadThemeDictionary(themeKey);
+
+        AssertColor(dict, themeKey, "PrimaryColor",      palette.Primary);
+        AssertColor(dict, themeKey, "SecondaryColor",    palette.Secondary);
+        AssertColor(dict, themeKey, "TertiaryColor",     palette.Tertiary);
+        AssertColor(dict, themeKey, "InfoColor",         palette.Info);
+        AssertColor(dict, themeKey, "SuccessColor",      palette.Success);
+        AssertColor(dict, themeKey, "WarningColor",      palette.Warning);
+        AssertColor(dict, themeKey, "ErrorColor",        palette.Error);
+        AssertColor(dict, themeKey, "BackgroundColor",   palette.Background);
+        AssertColor(dict, themeKey, "SurfaceColor",      palette.Surface);
+        AssertColor(dict, themeKey, "TextPrimaryColor",  palette.TextPrimary);
+        AssertColor(dict, themeKey, "TextSecondaryColor",palette.TextSecondary);
+        AssertColor(dict, themeKey, "DividerColor",      palette.Divider);
+    }
+
+    private static XElement LoadThemeDictionary(string themeKey)
+    {
+        var axaml = LoadAxaml();
+        XNamespace x = "http://schemas.microsoft.com/winfx/2006/xaml";
+
+        var dict = axaml.Descendants()
+            .Where(e => e.Name.LocalName == "ResourceDictionary"
+                     && e.Attribute(x + "Key")?.Value == themeKey)
+            .FirstOrDefault();
+
+        Assert.True(dict != null,
+            $"Could not find ThemeDictionary with x:Key=\"{themeKey}\" in App.axaml");
+        return dict!;
+    }
+
+    private static void AssertColor(XElement dict, string theme, string key, string expectedHex)
+    {
+        XNamespace x = "http://schemas.microsoft.com/winfx/2006/xaml";
+
+        var el = dict.Elements()
+            .FirstOrDefault(e => e.Name.LocalName == "Color"
+                              && e.Attribute(x + "Key")?.Value == key);
+
+        Assert.True(el != null,
+            $"[{theme}] Color '{key}' not found in App.axaml");
+
+        var actual   = el!.Value.Trim().ToUpperInvariant();
+        var expected = expectedHex.ToUpperInvariant();
+
+        Assert.True(actual == expected,
+            $"[{theme}] {key}: App.axaml has '{actual}' but DesignTokens says '{expected}'");
+    }
+
+    private static XDocument LoadAxaml()
+    {
+        var dir = AppContext.BaseDirectory;
+        while (dir != null && !File.Exists(Path.Combine(dir, "Nuotti.sln")))
+            dir = Directory.GetParent(dir)?.FullName;
+
+        Assert.True(dir != null, "Could not locate solution root from AppContext.BaseDirectory");
+
+        var path = Path.Combine(dir!, "Nuotti.Projector", "App.axaml");
+        Assert.True(File.Exists(path), $"App.axaml not found at expected path: {path}");
+
+        return XDocument.Load(path);
+    }
+}

--- a/Nuotti.Performer/Services/ThemeService.cs
+++ b/Nuotti.Performer/Services/ThemeService.cs
@@ -53,7 +53,7 @@ public class ThemeService : IAsyncDisposable
         _objRef = DotNetObjectReference.Create(this);
         
         // Check for saved preference, otherwise use system preference
-        var savedPreference = await _jsRuntime.InvokeAsync<string?>("localStorage.getItem", "theme-preference");
+        var savedPreference = await runtime.InvokeAsync<string?>("localStorage.getItem", "theme-preference");
         
         if (!string.IsNullOrEmpty(savedPreference))
         {

--- a/Nuotti.Performer/wwwroot/css/site.css
+++ b/Nuotti.Performer/wwwroot/css/site.css
@@ -37,7 +37,7 @@ html, body {
 
 .loading-spinner {
     border: 4px solid #f3f3f3;
-    border-top: 4px solid #594ae2;
+    border-top: 4px solid var(--mud-palette-primary);
     border-radius: 50%;
     width: 40px;
     height: 40px;

--- a/Nuotti.Projector/App.axaml
+++ b/Nuotti.Projector/App.axaml
@@ -37,6 +37,9 @@
                     <SolidColorBrush x:Key="SecondaryBrush" Color="{StaticResource SecondaryColor}" />
                     <SolidColorBrush x:Key="TertiaryBrush" Color="{StaticResource TertiaryColor}" />
                     <SolidColorBrush x:Key="SuccessBrush" Color="{StaticResource SuccessColor}" />
+                    <SolidColorBrush x:Key="InfoBrush" Color="{StaticResource InfoColor}" />
+                    <SolidColorBrush x:Key="WarningBrush" Color="{StaticResource WarningColor}" />
+                    <SolidColorBrush x:Key="ErrorBrush" Color="{StaticResource ErrorColor}" />
                     <SolidColorBrush x:Key="BackgroundBrush" Color="{StaticResource BackgroundColor}" />
                     <SolidColorBrush x:Key="SurfaceBrush" Color="{StaticResource SurfaceColor}" />
                     <SolidColorBrush x:Key="TextPrimaryBrush" Color="{StaticResource TextPrimaryColor}" />
@@ -65,6 +68,9 @@
                     <SolidColorBrush x:Key="SecondaryBrush" Color="{StaticResource SecondaryColor}" />
                     <SolidColorBrush x:Key="TertiaryBrush" Color="{StaticResource TertiaryColor}" />
                     <SolidColorBrush x:Key="SuccessBrush" Color="{StaticResource SuccessColor}" />
+                    <SolidColorBrush x:Key="InfoBrush" Color="{StaticResource InfoColor}" />
+                    <SolidColorBrush x:Key="WarningBrush" Color="{StaticResource WarningColor}" />
+                    <SolidColorBrush x:Key="ErrorBrush" Color="{StaticResource ErrorColor}" />
                     <SolidColorBrush x:Key="BackgroundBrush" Color="{StaticResource BackgroundColor}" />
                     <SolidColorBrush x:Key="SurfaceBrush" Color="{StaticResource SurfaceColor}" />
                     <SolidColorBrush x:Key="TextPrimaryBrush" Color="{StaticResource TextPrimaryColor}" />


### PR DESCRIPTION
## Summary
- Fix `Performer ThemeService` bug: `InitializeAsync` was calling `_jsRuntime` directly on line 56 instead of the local `runtime` variable (which respected the optional parameter)
- Fix Performer loading spinner color from hardcoded MudBlazor default purple `#594ae2` to `var(--mud-palette-primary)`
- Add `InfoBrush`, `WarningBrush`, `ErrorBrush` to Projector `App.axaml` Light and Dark theme dictionaries (colors existed, brushes were missing)
- Add `ProjectorAxamlSyncTests` — 2 facts that parse `App.axaml` at test time and assert every named `<Color>` matches `DesignTokens` — prevents silent drift
- Add `CLAUDE.md` with project commands and architecture overview

## Notes
- Projector does not include HighContrast (upstream removed it in k2 — TV display app doesn't need it)
- Audience and Performer already correctly consumed `DesignTokens` — no changes needed there

🤖 Generated with [Claude Code](https://claude.ai/claude-code)