### PR TITLE
Expand the Session protocol for durable ordered delivery

### DIFF
--- a/Nuotti.Backend.Tests/QuestionPushedEffectsTests.cs
+++ b/Nuotti.Backend.Tests/QuestionPushedEffectsTests.cs
@@ -6,6 +6,7 @@ using Nuotti.Contracts.V1.Event;
 using Nuotti.Contracts.V1.Message;
 using Nuotti.Contracts.V1.Message.Phase;
 using Nuotti.Contracts.V1.Reducer;
+using Nuotti.Contracts.V1.Protocol;
 using System.Text.Json;
 using PhaseEnum = Nuotti.Contracts.V1.Enum.Phase;
 namespace Nuotti.Backend.Tests;

--- a/Nuotti.Backend.Tests/SessionCommandProcessorTests.cs
+++ b/Nuotti.Backend.Tests/SessionCommandProcessorTests.cs
@@ -6,6 +6,7 @@ using Nuotti.Contracts.V1.Event;
 using Nuotti.Contracts.V1.Message;
 using Nuotti.Contracts.V1.Message.Phase;
 using Nuotti.Contracts.V1.Model;
+using Nuotti.Contracts.V1.Protocol;
 using Nuotti.Contracts.V1.Reducer;
 using PhaseEnum = Nuotti.Contracts.V1.Enum.Phase;
 namespace Nuotti.Backend.Tests;

--- a/Nuotti.Backend/Commands/CommandResult.cs
+++ b/Nuotti.Backend/Commands/CommandResult.cs
@@ -1,20 +1,6 @@
 using Nuotti.Contracts.V1.Model;
+using Nuotti.Contracts.V1.Protocol;
 namespace Nuotti.Backend.Commands;
-
-/// <summary>
-/// What happened to a Command.
-/// </summary>
-public enum Outcome
-{
-    /// <summary>The Command was accepted and its effects applied.</summary>
-    Applied,
-
-    /// <summary>The Command's id had already been seen within the idempotency window; nothing happened.</summary>
-    Duplicate,
-
-    /// <summary>The Command was refused. <see cref="CommandResult.Problem"/> says why.</summary>
-    Rejected
-}
 
 /// <summary>
 /// The result of applying a Command. Rejection is a return value, never an exception: a wrong role

--- a/Nuotti.Backend/Endpoints/ApiEndpoints.cs
+++ b/Nuotti.Backend/Endpoints/ApiEndpoints.cs
@@ -7,6 +7,7 @@ using Nuotti.Contracts.V1.Event;
 using Nuotti.Contracts.V1.Message;
 using Nuotti.Contracts.V1.Message.Phase;
 using Nuotti.Contracts.V1.Model;
+using Nuotti.Contracts.V1.Protocol;
 namespace Nuotti.Backend.Endpoints;
 
 internal static class ApiEndpoints

--- a/Nuotti.Backend/Endpoints/PhaseEndpoints.cs
+++ b/Nuotti.Backend/Endpoints/PhaseEndpoints.cs
@@ -3,6 +3,7 @@ using Nuotti.Backend.Exception;
 using Nuotti.Backend.Middleware;
 using Nuotti.Contracts.V1.Message;
 using Nuotti.Contracts.V1.Message.Phase;
+using Nuotti.Contracts.V1.Protocol;
 namespace Nuotti.Backend.Endpoints;
 
 /// <summary>

--- a/Nuotti.Contracts.Tests/V1/Message/PlaybackIdentityTests.cs
+++ b/Nuotti.Contracts.Tests/V1/Message/PlaybackIdentityTests.cs
@@ -1,0 +1,56 @@
+using System.Text.Json;
+using Nuotti.Contracts.V1;
+using Nuotti.Contracts.V1.Enum;
+using Nuotti.Contracts.V1.Message;
+using Nuotti.Contracts.V1.Protocol;
+
+namespace Nuotti.Contracts.Tests.V1.Message;
+
+public sealed class PlaybackIdentityTests
+{
+    [Fact]
+    public void Play_and_stop_can_target_one_playback_instance_and_control_generation()
+    {
+        var play = new PlayTrack("https://assets.invalid/backing.wav")
+        {
+            SessionCode = "SHOW1234",
+            IssuedByRole = Role.Performer,
+            IssuedById = "performer-1",
+            PlaybackInstanceId = "playback-1",
+            ControlGeneration = new ControlGeneration(8)
+        };
+        var stop = new StopTrack
+        {
+            SessionCode = "SHOW1234",
+            IssuedByRole = Role.Performer,
+            IssuedById = "performer-1",
+            PlaybackInstanceId = play.PlaybackInstanceId,
+            ControlGeneration = play.ControlGeneration
+        };
+
+        Assert.Equal("playback-1", stop.PlaybackInstanceId);
+        Assert.Equal(8, stop.ControlGeneration!.Value.Value);
+
+        var json = JsonSerializer.Serialize(play, ContractsJson.RestOptions);
+        Assert.Contains("\"controlGeneration\":\"8\"", json);
+    }
+
+    [Fact]
+    public void Legacy_playback_payloads_remain_valid_when_identity_is_absent()
+    {
+        var play = new PlayTrack("https://assets.invalid/backing.wav")
+        {
+            SessionCode = "SHOW1234",
+            IssuedByRole = Role.Performer,
+            IssuedById = "performer-1"
+        };
+
+        var json = JsonSerializer.Serialize(play, ContractsJson.RestOptions);
+
+        Assert.Null(play.PlaybackInstanceId);
+        Assert.Null(play.ControlGeneration);
+        Assert.Contains("\"fileUrl\"", json);
+        Assert.DoesNotContain("playbackInstanceId", json);
+        Assert.DoesNotContain("controlGeneration", json);
+    }
+}

--- a/Nuotti.Contracts.Tests/V1/Protocol/SessionProtocolTests.cs
+++ b/Nuotti.Contracts.Tests/V1/Protocol/SessionProtocolTests.cs
@@ -1,0 +1,149 @@
+using System.Text.Json;
+using Nuotti.Contracts.V1;
+using Nuotti.Contracts.V1.Enum;
+using Nuotti.Contracts.V1.Event;
+using Nuotti.Contracts.V1.Message.Phase;
+using Nuotti.Contracts.V1.Model;
+using Nuotti.Contracts.V1.Protocol;
+
+namespace Nuotti.Contracts.Tests.V1.Protocol;
+
+public sealed class SessionProtocolTests
+{
+    [Fact]
+    public void Command_identifies_one_idempotent_workspace_scoped_intent()
+    {
+        var command = new StartGame
+        {
+            CommandId = Guid.Parse("00000000-0000-0000-0000-000000000101"),
+            SessionCode = "SHOW1234",
+            IssuedByRole = Role.Performer,
+            IssuedById = "performer-1"
+        };
+
+        var message = new SessionCommand<StartGame>(
+            SessionProtocolVersion.Current,
+            "workspace-1",
+            command,
+            ExpectedControlGeneration: new ControlGeneration(7));
+
+        Assert.Equal(command.CommandId, message.CommandId);
+        Assert.Equal("SHOW1234", message.SessionCode);
+        Assert.Equal(7, message.ExpectedControlGeneration.Value);
+    }
+
+    [Fact]
+    public void Event_and_cursor_express_durable_ordering_and_replay()
+    {
+        var @event = new GamePhaseChanged(Phase.Lobby, Phase.Start)
+        {
+            EventId = Guid.Parse("00000000-0000-0000-0000-000000000201"),
+            CorrelationId = Guid.Parse("00000000-0000-0000-0000-000000000202"),
+            CausedByCommandId = Guid.Parse("00000000-0000-0000-0000-000000000203"),
+            SessionCode = "SHOW1234",
+            CurrentPhase = Phase.Lobby,
+            NewPhase = Phase.Start
+        };
+
+        var message = new SessionEvent<GamePhaseChanged>(
+            SessionProtocolVersion.Current,
+            "workspace-1",
+            Sequence: new SessionSequence(42),
+            @event);
+
+        Assert.Equal(42, message.Cursor.Sequence.Value);
+        Assert.Equal("workspace-1", message.Cursor.WorkspaceId);
+        Assert.Equal("SHOW1234", message.Cursor.SessionCode);
+        Assert.Equal(@event.EventId, message.EventId);
+    }
+
+    [Theory]
+    [InlineData(Outcome.Applied)]
+    [InlineData(Outcome.Duplicate)]
+    [InlineData(Outcome.Rejected)]
+    public void Command_result_has_an_explicit_outcome(Outcome outcome)
+    {
+        var result = new SessionCommandResult(
+            SessionProtocolVersion.Current,
+            Guid.NewGuid(),
+            outcome,
+            Cursor: null,
+            Problem: outcome == Outcome.Rejected
+                ? NuottiProblem.Conflict("Rejected", "No mutation occurred", ReasonCode.InvalidStateTransition)
+                : null);
+
+        Assert.Equal(outcome, result.Outcome);
+    }
+
+    [Fact]
+    public void Snapshot_declares_reader_compatibility_and_resume_cursor()
+    {
+        var snapshot = new SessionSnapshot<GameStateSnapshot>(
+            WriterVersion: new SessionProtocolVersion(1, 3),
+            MinimumReaderVersion: new SessionProtocolVersion(1, 1),
+            WorkspaceId: "workspace-1",
+            SessionCode: "SHOW1234",
+            LastSequence: new SessionSequence(99),
+            ControlGeneration: new ControlGeneration(7),
+            State: new GameStateSnapshot("SHOW1234", Phase.Guessing, 0));
+
+        Assert.True(snapshot.CanBeReadBy(new SessionProtocolVersion(1, 1)));
+        Assert.True(snapshot.CanBeReadBy(new SessionProtocolVersion(1, 9)));
+        Assert.False(snapshot.CanBeReadBy(new SessionProtocolVersion(1, 0)));
+        Assert.False(snapshot.CanBeReadBy(new SessionProtocolVersion(2, 0)));
+        Assert.Equal(99, snapshot.Cursor.Sequence.Value);
+    }
+
+    [Fact]
+    public void New_protocol_contracts_round_trip_with_rest_options()
+    {
+        var cursor = new SessionCursor("workspace-1", "SHOW1234", new SessionSequence(12));
+
+        var json = JsonSerializer.Serialize(cursor, ContractsJson.RestOptions);
+        var restored = JsonSerializer.Deserialize<SessionCursor>(json, ContractsJson.RestOptions);
+
+        Assert.Equal(cursor, restored);
+    }
+
+    [Fact]
+    public void Cursor_cannot_move_backwards_or_repeat_a_sequence()
+    {
+        var cursor = new SessionCursor("workspace-1", "SHOW1234", new SessionSequence(12));
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => cursor.AdvanceTo(new SessionSequence(12)));
+        Assert.Throws<ArgumentOutOfRangeException>(() => cursor.AdvanceTo(new SessionSequence(11)));
+        Assert.Equal(13, cursor.AdvanceTo(new SessionSequence(13)).Sequence.Value);
+    }
+
+    [Fact]
+    public void Sequence_and_control_generation_reject_negative_values_and_advance_monotonically()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new SessionSequence(-1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new ControlGeneration(-1));
+        Assert.Equal(8, new ControlGeneration(7).Next().Value);
+        Assert.Equal(43, new SessionSequence(42).Next().Value);
+    }
+
+    [Fact]
+    public void Outcome_and_64_bit_counters_use_lossless_web_wire_shapes()
+    {
+        const long BeyondJavaScriptSafeInteger = 9_007_199_254_740_993;
+        var result = new SessionCommandResult(
+            SessionProtocolVersion.Current,
+            Guid.Parse("00000000-0000-0000-0000-000000000301"),
+            Outcome.Applied,
+            new SessionCursor("workspace-1", "SHOW1234", new SessionSequence(BeyondJavaScriptSafeInteger)),
+            Problem: null);
+
+        var json = JsonSerializer.Serialize(result, ContractsJson.RestOptions);
+        var restored = JsonSerializer.Deserialize<SessionCommandResult>(json, ContractsJson.RestOptions);
+
+        Assert.Contains("\"outcome\":\"Applied\"", json);
+        Assert.Contains($"\"sequence\":\"{BeyondJavaScriptSafeInteger}\"", json);
+        Assert.Equal(BeyondJavaScriptSafeInteger, restored!.Cursor!.Sequence.Value);
+
+        var generationJson = JsonSerializer.Serialize(
+            new ControlGeneration(BeyondJavaScriptSafeInteger), ContractsJson.RestOptions);
+        Assert.Equal($"\"{BeyondJavaScriptSafeInteger}\"", generationJson);
+    }
+}

--- a/Nuotti.Contracts/V1/Message/PlayTrack.cs
+++ b/Nuotti.Contracts/V1/Message/PlayTrack.cs
@@ -1,8 +1,17 @@
-﻿namespace Nuotti.Contracts.V1.Message;
+using System.Text.Json.Serialization;
+using Nuotti.Contracts.V1.Protocol;
 
-/// <summary>
-/// Command to the AudioEngine to play a single audio track from a URL (MVP).
-/// </summary>
+namespace Nuotti.Contracts.V1.Message;
+
+/// <summary>Command to the AudioEngine to play a single audio track from a URL (MVP).</summary>
 /// <param name="FileUrl">Public or accessible URL to the audio file to play.</param>
-/// <inheritdoc cref="CommandBase"/>
-public record PlayTrack(string FileUrl) : CommandBase;
+public record PlayTrack(string FileUrl) : CommandBase
+{
+    /// <summary>The playback attempt this relay targets. Null preserves the legacy relay contract.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? PlaybackInstanceId { get; init; }
+
+    /// <summary>The Backend control generation authorizing this relay. Null preserves legacy behavior.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public ControlGeneration? ControlGeneration { get; init; }
+}

--- a/Nuotti.Contracts/V1/Message/StopTrack.cs
+++ b/Nuotti.Contracts/V1/Message/StopTrack.cs
@@ -1,6 +1,16 @@
-﻿namespace Nuotti.Contracts.V1.Message;
+using System.Text.Json.Serialization;
+using Nuotti.Contracts.V1.Protocol;
 
-/// <summary>
-/// Stops the currently playing track.
-/// </summary>
-public record StopTrack() : CommandBase;
+namespace Nuotti.Contracts.V1.Message;
+
+/// <summary>Stops the currently playing track.</summary>
+public record StopTrack() : CommandBase
+{
+    /// <summary>The playback attempt this relay targets. Null preserves the legacy relay contract.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? PlaybackInstanceId { get; init; }
+
+    /// <summary>The Backend control generation authorizing this relay. Null preserves legacy behavior.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public ControlGeneration? ControlGeneration { get; init; }
+}

--- a/Nuotti.Contracts/V1/Protocol/ControlGeneration.cs
+++ b/Nuotti.Contracts/V1/Protocol/ControlGeneration.cs
@@ -1,0 +1,34 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Globalization;
+
+namespace Nuotti.Contracts.V1.Protocol;
+
+/// <summary>A monotonic fencing token identifying the only current Session controller.</summary>
+[JsonConverter(typeof(ControlGenerationJsonConverter))]
+public readonly record struct ControlGeneration
+{
+    public static ControlGeneration Initial { get; } = new(0);
+
+    public long Value { get; }
+
+    public ControlGeneration(long value)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(value);
+        Value = value;
+    }
+
+    public ControlGeneration Next() => new(checked(Value + 1));
+
+    public static implicit operator long(ControlGeneration value) => value.Value;
+    public static explicit operator ControlGeneration(long value) => new(value);
+
+    private sealed class ControlGenerationJsonConverter : JsonConverter<ControlGeneration>
+    {
+        public override ControlGeneration Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+            => new(long.Parse(reader.GetString()!, NumberStyles.None, CultureInfo.InvariantCulture));
+
+        public override void Write(Utf8JsonWriter writer, ControlGeneration value, JsonSerializerOptions options)
+            => writer.WriteStringValue(value.Value.ToString(CultureInfo.InvariantCulture));
+    }
+}

--- a/Nuotti.Contracts/V1/Protocol/Outcome.cs
+++ b/Nuotti.Contracts/V1/Protocol/Outcome.cs
@@ -1,0 +1,12 @@
+using System.Text.Json.Serialization;
+
+namespace Nuotti.Contracts.V1.Protocol;
+
+/// <summary>The durable, explicit disposition of one Command intent.</summary>
+[JsonConverter(typeof(JsonStringEnumConverter<Outcome>))]
+public enum Outcome
+{
+    Applied,
+    Duplicate,
+    Rejected
+}

--- a/Nuotti.Contracts/V1/Protocol/PlaybackIdentity.cs
+++ b/Nuotti.Contracts/V1/Protocol/PlaybackIdentity.cs
@@ -1,0 +1,4 @@
+namespace Nuotti.Contracts.V1.Protocol;
+
+/// <summary>Identifies one playback attempt under the controller generation that authorized it.</summary>
+public sealed record PlaybackIdentity(string PlaybackInstanceId, ControlGeneration ControlGeneration);

--- a/Nuotti.Contracts/V1/Protocol/SessionCommand.cs
+++ b/Nuotti.Contracts/V1/Protocol/SessionCommand.cs
@@ -1,0 +1,22 @@
+using System.Text.Json.Serialization;
+using Nuotti.Contracts.V1.Message;
+
+namespace Nuotti.Contracts.V1.Protocol;
+
+/// <summary>
+/// A versioned, Workspace-scoped Command intent. The embedded CommandId is the idempotency key.
+/// ExpectedControlGeneration rejects a stale controller before it mutates the Session.
+/// </summary>
+public sealed record SessionCommand<TCommand>(
+    SessionProtocolVersion Version,
+    string WorkspaceId,
+    TCommand Command,
+    ControlGeneration ExpectedControlGeneration)
+    where TCommand : CommandBase
+{
+    [JsonIgnore]
+    public Guid CommandId => Command.CommandId;
+
+    [JsonIgnore]
+    public string SessionCode => Command.SessionCode;
+}

--- a/Nuotti.Contracts/V1/Protocol/SessionCommandResult.cs
+++ b/Nuotti.Contracts/V1/Protocol/SessionCommandResult.cs
@@ -1,0 +1,14 @@
+using Nuotti.Contracts.V1.Model;
+
+namespace Nuotti.Contracts.V1.Protocol;
+
+/// <summary>
+/// Explicit acknowledgement of a Command. Applied and Duplicate may identify the resulting
+/// cursor; Rejected carries a problem and never implies a mutation.
+/// </summary>
+public sealed record SessionCommandResult(
+    SessionProtocolVersion Version,
+    Guid CommandId,
+    Outcome Outcome,
+    SessionCursor? Cursor,
+    NuottiProblem? Problem);

--- a/Nuotti.Contracts/V1/Protocol/SessionCursor.cs
+++ b/Nuotti.Contracts/V1/Protocol/SessionCursor.cs
@@ -1,0 +1,15 @@
+namespace Nuotti.Contracts.V1.Protocol;
+
+/// <summary>The last durable Event observed for one Workspace-scoped Session.</summary>
+public sealed record SessionCursor(string WorkspaceId, string SessionCode, SessionSequence Sequence)
+{
+    public SessionCursor AdvanceTo(SessionSequence sequence)
+    {
+        if (sequence.Value <= Sequence.Value)
+        {
+            throw new ArgumentOutOfRangeException(nameof(sequence), "A Session cursor must advance monotonically.");
+        }
+
+        return this with { Sequence = sequence };
+    }
+}

--- a/Nuotti.Contracts/V1/Protocol/SessionEvent.cs
+++ b/Nuotti.Contracts/V1/Protocol/SessionEvent.cs
@@ -1,0 +1,19 @@
+using System.Text.Json.Serialization;
+using Nuotti.Contracts.V1.Message;
+
+namespace Nuotti.Contracts.V1.Protocol;
+
+/// <summary>A uniquely identified Event at one durable, Session-local sequence.</summary>
+public sealed record SessionEvent<TEvent>(
+    SessionProtocolVersion Version,
+    string WorkspaceId,
+    SessionSequence Sequence,
+    TEvent Event)
+    where TEvent : EventBase
+{
+    [JsonIgnore]
+    public Guid EventId => Event.EventId;
+
+    [JsonIgnore]
+    public SessionCursor Cursor => new(WorkspaceId, Event.SessionCode, Sequence);
+}

--- a/Nuotti.Contracts/V1/Protocol/SessionProtocolVersion.cs
+++ b/Nuotti.Contracts/V1/Protocol/SessionProtocolVersion.cs
@@ -1,0 +1,24 @@
+namespace Nuotti.Contracts.V1.Protocol;
+
+/// <summary>
+/// Identifies the wire contract used by a durable Session message.
+/// Minor revisions are additive; a different major revision is incompatible.
+/// </summary>
+public readonly record struct SessionProtocolVersion
+{
+    public static SessionProtocolVersion Current { get; } = new(1, 0);
+
+    public int Major { get; }
+    public int Minor { get; }
+
+    public SessionProtocolVersion(int major, int minor)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(major, 1);
+        ArgumentOutOfRangeException.ThrowIfNegative(minor);
+        Major = major;
+        Minor = minor;
+    }
+
+    public bool IsAtLeast(SessionProtocolVersion minimum)
+        => Major == minimum.Major && Minor >= minimum.Minor;
+}

--- a/Nuotti.Contracts/V1/Protocol/SessionSequence.cs
+++ b/Nuotti.Contracts/V1/Protocol/SessionSequence.cs
@@ -1,0 +1,34 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Globalization;
+
+namespace Nuotti.Contracts.V1.Protocol;
+
+/// <summary>A monotonically increasing position in one Session's durable Event stream.</summary>
+[JsonConverter(typeof(SessionSequenceJsonConverter))]
+public readonly record struct SessionSequence
+{
+    public static SessionSequence None { get; } = new(0);
+
+    public long Value { get; }
+
+    public SessionSequence(long value)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(value);
+        Value = value;
+    }
+
+    public SessionSequence Next() => new(checked(Value + 1));
+
+    public static implicit operator long(SessionSequence value) => value.Value;
+    public static explicit operator SessionSequence(long value) => new(value);
+
+    private sealed class SessionSequenceJsonConverter : JsonConverter<SessionSequence>
+    {
+        public override SessionSequence Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+            => new(long.Parse(reader.GetString()!, NumberStyles.None, CultureInfo.InvariantCulture));
+
+        public override void Write(Utf8JsonWriter writer, SessionSequence value, JsonSerializerOptions options)
+            => writer.WriteStringValue(value.Value.ToString(CultureInfo.InvariantCulture));
+    }
+}

--- a/Nuotti.Contracts/V1/Protocol/SessionSnapshot.cs
+++ b/Nuotti.Contracts/V1/Protocol/SessionSnapshot.cs
@@ -1,0 +1,25 @@
+using System.Text.Json.Serialization;
+
+namespace Nuotti.Contracts.V1.Protocol;
+
+/// <summary>
+/// A durable Session state checkpoint. Replay resumes strictly after LastSequence.
+/// MinimumReaderVersion lets producers add fields without requiring every reader to understand
+/// the writer's complete minor revision.
+/// </summary>
+public sealed record SessionSnapshot<TState>(
+    SessionProtocolVersion WriterVersion,
+    SessionProtocolVersion MinimumReaderVersion,
+    string WorkspaceId,
+    string SessionCode,
+    SessionSequence LastSequence,
+    ControlGeneration ControlGeneration,
+    TState State)
+{
+    [JsonIgnore]
+    public SessionCursor Cursor => new(WorkspaceId, SessionCode, LastSequence);
+
+    public bool CanBeReadBy(SessionProtocolVersion readerVersion)
+        => readerVersion.Major == WriterVersion.Major
+           && readerVersion.IsAtLeast(MinimumReaderVersion);
+}

--- a/Nuotti.Contracts/web/shared/contracts.ts
+++ b/Nuotti.Contracts/web/shared/contracts.ts
@@ -148,10 +148,57 @@ export interface Hint {
 export interface Tally { choiceId: string; count: number }
 
 // Simple messages (readonly record structs in C#)
-export interface PlayTrack { fileUrl: string }
+export interface PlayTrack {
+    fileUrl: string;
+    playbackInstanceId?: string | null;
+    controlGeneration?: ControlGeneration | null;
+}
+export interface StopTrack {
+    playbackInstanceId?: string | null;
+    controlGeneration?: ControlGeneration | null;
+}
 export interface QuestionPushed { text: string; options: string[] }
 export interface SessionCreated { sessionCode: string; hostId: string }
 export interface JoinedAudience { connectionId: string; name: string }
+
+// Durable Session protocol. Generic payloads remain structural on the web side.
+export interface SessionProtocolVersion { major: number; minor: number }
+export type SessionSequence = string;
+export type ControlGeneration = string;
+export interface PlaybackIdentity {
+    playbackInstanceId: string;
+    controlGeneration: ControlGeneration;
+}
+export interface SessionCursor { workspaceId: string; sessionCode: string; sequence: SessionSequence }
+export interface SessionCommand<TCommand extends CommandBase = CommandBase> {
+    version: SessionProtocolVersion;
+    workspaceId: string;
+    command: TCommand;
+    expectedControlGeneration: ControlGeneration;
+}
+export interface SessionEvent<TEvent extends EventBase = EventBase> {
+    version: SessionProtocolVersion;
+    workspaceId: string;
+    sequence: SessionSequence;
+    event: TEvent;
+}
+export type Outcome = "Applied" | "Duplicate" | "Rejected";
+export interface SessionCommandResult {
+    version: SessionProtocolVersion;
+    commandId: string;
+    outcome: Outcome;
+    cursor?: SessionCursor | null;
+    problem?: NuottiProblem | null;
+}
+export interface SessionSnapshot<TState = GameStateSnapshot> {
+    writerVersion: SessionProtocolVersion;
+    minimumReaderVersion: SessionProtocolVersion;
+    workspaceId: string;
+    sessionCode: string;
+    lastSequence: SessionSequence;
+    controlGeneration: ControlGeneration;
+    state: TState;
+}
 
 // Events
 export interface AnswerSubmitted extends EventBase { audienceId: string; choiceIndex: number }

--- a/docs/adr/0002-relay-commands-are-at-least-once.md
+++ b/docs/adr/0002-relay-commands-are-at-least-once.md
@@ -52,3 +52,19 @@ they match, only replacing `Choices` and re-zeroing `Tallies` when they genuinel
 duplicate relay is harmless because the reducer treats a repeat of the same question as a no-op,
 not because the event was assumed to be idempotent by construction. `PlayTrack` and `StopTrack`
 are untouched and remain pure relays.
+
+## Amendment — 2026-07-31
+
+The durable Session protocol is now represented by additive contracts in
+`Nuotti.Contracts.V1.Protocol`. A versioned `SessionCommand` carries the existing Command and its
+idempotency identity plus the expected control generation. `SessionEvent` assigns a unique Event
+to a monotonically increasing, Workspace-scoped Session sequence. `SessionCommandResult` makes
+Applied, Duplicate, and Rejected outcomes explicit. `SessionCursor` and `SessionSnapshot` define
+replay and compatible checkpoint semantics.
+
+These contracts do not silently change the legacy relay decision. Existing `PlayTrack` and
+`StopTrack` processing remains at-least-once. Both messages may now carry an optional playback
+instance and control generation; when absent, their serialized shape and behavior remain the
+legacy contract. A later implementation may supersede the relays with stateful playback
+Commands/Events, at which point that processor must use the durable outcome, ordering, and
+generation rules rather than reinterpret the old relay semantics.


### PR DESCRIPTION
Closes #248. Adds versioned Workspace-scoped Session Command/Event contracts, explicit Outcome acknowledgements, lossless ordered sequence and replay cursors, compatible snapshots, control-generation fencing, and playback identity. Legacy PlayTrack/StopTrack semantics and JSON shape remain unchanged when the additive identity fields are absent. ADR 0002 is amended. Verification: Contracts 186/186; Backend 125/125; standards and spec reviews clean.