### PR TITLE
Persist one Session command path through the outbox

### DIFF
--- a/Nuotti.Backend.Tests/DurableSessionCommandTests.cs
+++ b/Nuotti.Backend.Tests/DurableSessionCommandTests.cs
@@ -1,0 +1,194 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Nuotti.Backend.Commands;
+using Nuotti.Backend.Idempotency;
+using Nuotti.Backend.Models;
+using Nuotti.Backend.Persistence;
+using Nuotti.Backend.Sessions;
+using Nuotti.Backend.Tests.TestSupport;
+using Nuotti.Contracts.V1.Enum;
+using Nuotti.Contracts.V1.Eventing;
+using Nuotti.Contracts.V1.Message.Phase;
+using Nuotti.Contracts.V1.Protocol;
+using Microsoft.Extensions.Options;
+
+namespace Nuotti.Backend.Tests;
+
+public sealed class DurableSessionCommandTests
+{
+    const string Session = "DURABLE1";
+    const string Workspace = "workspace-1";
+
+    static StartGame Command(Guid id) => new()
+    {
+        CommandId = id,
+        SessionCode = Session,
+        IssuedByRole = Role.Performer,
+        IssuedById = "performer-1"
+    };
+
+    static SessionCommandProcessor Processor(
+        IDurableSessionCommitStore durable,
+        IEventBus bus,
+        IGameStateStore? memory = null)
+        => new(
+            memory ?? new InMemoryGameStateStore(),
+            new InMemoryIdempotencyStore(Options.Create(new NuottiOptions())),
+            bus,
+            NullLogger<SessionCommandProcessor>.Instance,
+            durable: durable);
+
+    [Fact]
+    public async Task Retry_after_processor_restart_returns_the_durable_prior_outcome()
+    {
+        var durable = new InMemoryDurableSessionCommitStore();
+        var id = Guid.NewGuid();
+        var firstBus = new CapturingEventBus();
+
+        var first = await Processor(durable, firstBus).ApplyAsync(
+            Session, Actor.Verified(Role.Performer, "performer-1"), Command(id));
+        var retryBus = new CapturingEventBus();
+        var retry = await Processor(durable, retryBus).ApplyAsync(
+            Session, Actor.Verified(Role.Performer, "performer-1"), Command(id));
+
+        Assert.Equal(Outcome.Applied, first.Outcome);
+        Assert.Equal(first, retry);
+        Assert.Empty(retryBus.Published);
+        Assert.Equal(Phase.Start, (await durable.LoadAsync("legacy", Session))!.Snapshot.Phase);
+    }
+
+    [Fact]
+    public async Task Dispatcher_publishes_an_event_left_pending_after_commit()
+    {
+        var durable = new InMemoryDurableSessionCommitStore();
+        var processor = Processor(durable, new ThrowingEventBus());
+
+        var result = await processor.ApplyAsync(
+            Session, Actor.Verified(Role.Performer, "performer-1"), Command(Guid.NewGuid()));
+
+        Assert.Equal(Outcome.Applied, result.Outcome);
+        var recoveredBus = new CapturingEventBus();
+        var dispatcher = new DurableOutboxDispatcher(
+            durable, recoveredBus, NullLogger<DurableOutboxDispatcher>.Instance);
+        var delivered = await dispatcher.DispatchPendingAsync();
+        delivered += await dispatcher.DispatchPendingAsync();
+
+        Assert.Equal(2, delivered);
+        Assert.Equal(2, recoveredBus.Published.Count);
+    }
+
+    [Fact]
+    public async Task Restart_can_load_snapshot_and_replay_without_replica_memory()
+    {
+        var durable = new InMemoryDurableSessionCommitStore();
+        await Processor(durable, new CapturingEventBus()).ApplyAsync(
+            Session, Actor.Verified(Role.Performer, "performer-1"), Command(Guid.NewGuid()));
+
+        var snapshot = await durable.LoadAsync("legacy", Session);
+        var replay = await durable.ReadAfterAsync("legacy", Session, SessionSequence.None);
+
+        Assert.NotNull(snapshot);
+        Assert.Equal(Phase.Start, snapshot!.Snapshot.Phase);
+        Assert.Equal(snapshot.LastSequence.Value, replay[^1].Sequence.Value);
+        Assert.All(replay.Zip(replay.Skip(1)), pair =>
+            Assert.True(pair.First.Sequence.Value < pair.Second.Sequence.Value));
+    }
+
+    [Fact]
+    public async Task Workspace_scope_is_part_of_every_durable_key()
+    {
+        var durable = new InMemoryDurableSessionCommitStore();
+        var commandId = Guid.NewGuid();
+        await Processor(durable, new CapturingEventBus()).ApplyAsync(
+            Session, Actor.Verified(Role.Performer, "performer-1"), Command(commandId), workspaceId: Workspace);
+
+        Assert.NotNull(await durable.LoadAsync(Workspace, Session));
+        Assert.Null(await durable.LoadAsync("another-workspace", Session));
+        Assert.NotNull(await durable.FindOutcomeAsync(Workspace, Session, commandId));
+        Assert.Null(await durable.FindOutcomeAsync("another-workspace", Session, commandId));
+    }
+
+    [Fact]
+    public async Task Concurrent_create_with_different_ids_cannot_overwrite_the_first_session()
+    {
+        var durable = new InMemoryDurableSessionCommitStore();
+        var first = new CreateSession(Session) { SessionCode = Session, IssuedByRole = Role.Performer, IssuedById = "p1" };
+        var second = new CreateSession(Session) { SessionCode = Session, IssuedByRole = Role.Performer, IssuedById = "p2" };
+
+        var results = await Task.WhenAll(
+            Processor(durable, new CapturingEventBus()).ApplyAsync(Session, Actor.Verified(Role.Performer, "p1"), first, workspaceId: Workspace),
+            Processor(durable, new CapturingEventBus()).ApplyAsync(Session, Actor.Verified(Role.Performer, "p2"), second, workspaceId: Workspace));
+
+        Assert.Single(results, result => result.Outcome == Outcome.Applied);
+        Assert.Single(results, result => result.Outcome == Outcome.Rejected);
+        Assert.Equal(Phase.Lobby, (await durable.LoadAsync(Workspace, Session))!.Snapshot.Phase);
+    }
+
+    [Fact]
+    public async Task Stale_commit_cannot_overwrite_a_newer_snapshot()
+    {
+        var durable = new InMemoryDurableSessionCommitStore();
+        await Processor(durable, new CapturingEventBus()).ApplyAsync(
+            Session, Actor.Verified(Role.Performer, "performer-1"), Command(Guid.NewGuid()), workspaceId: Workspace);
+
+        var stale = await durable.CommitAsync(
+            Workspace, Session, Guid.NewGuid(), SessionSequence.None,
+            new Nuotti.Contracts.V1.Model.GameStateSnapshot(Session, Phase.Finished, 0), []);
+
+        Assert.True(stale.WasStale);
+        Assert.Equal(Phase.Start, (await durable.LoadAsync(Workspace, Session))!.Snapshot.Phase);
+    }
+
+    [Fact]
+    public async Task Claims_are_exclusive_and_preserve_per_session_order()
+    {
+        var durable = new InMemoryDurableSessionCommitStore();
+        await Processor(durable, new CapturingEventBus()).ApplyAsync(
+            Session, Actor.Verified(Role.Performer, "performer-1"), Command(Guid.NewGuid()), workspaceId: Workspace);
+        var owner1 = Guid.NewGuid();
+        var owner2 = Guid.NewGuid();
+
+        var first = Assert.Single(await durable.ClaimPendingAsync(owner1, TimeSpan.FromMinutes(1), 10));
+        Assert.Empty(await durable.ClaimPendingAsync(owner2, TimeSpan.FromMinutes(1), 10));
+        await durable.MarkDeliveredAsync(first, owner1);
+        var second = Assert.Single(await durable.ClaimPendingAsync(owner2, TimeSpan.FromMinutes(1), 10));
+
+        Assert.True(first.Sequence.Value < second.Sequence.Value);
+    }
+
+    [Fact]
+    public async Task Repeated_stale_commits_return_busy_rejection_instead_of_throwing()
+    {
+        var result = await Processor(new AlwaysStaleStore(), new CapturingEventBus()).ApplyAsync(
+            Session, Actor.Verified(Role.Performer, "performer-1"), Command(Guid.NewGuid()), workspaceId: Workspace);
+
+        Assert.Equal(Outcome.Rejected, result.Outcome);
+        Assert.Equal(409, result.Problem!.Status);
+    }
+
+    sealed class ThrowingEventBus : IEventBus
+    {
+        public IDisposable Subscribe<TEvent>(Func<TEvent, CancellationToken, Task> handler) => new Noop();
+        public Task PublishAsync<TEvent>(TEvent evt, CancellationToken cancellationToken = default)
+            => throw new InvalidOperationException("simulated crash after commit");
+        sealed class Noop : IDisposable { public void Dispose() { } }
+    }
+
+    sealed class AlwaysStaleStore : IDurableSessionCommitStore
+    {
+        public Task<DurableSessionRecord?> LoadAsync(string workspaceId, string sessionCode, CancellationToken cancellationToken = default)
+            => Task.FromResult<DurableSessionRecord?>(null);
+        public Task<CommandResult?> FindOutcomeAsync(string workspaceId, string sessionCode, Guid commandId, CancellationToken cancellationToken = default)
+            => Task.FromResult<CommandResult?>(null);
+        public Task<DurableCommit> CommitAsync(string workspaceId, string sessionCode, Guid commandId,
+            SessionSequence expectedSequence, Nuotti.Contracts.V1.Model.GameStateSnapshot snapshot,
+            IReadOnlyList<object> messages, DurableCommitPrecondition precondition = DurableCommitPrecondition.Any,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult(new DurableCommit(CommandResult.Duplicate(), [], false, WasStale: true));
+        public Task<IReadOnlyList<DurableOutboxMessage>> ClaimPendingAsync(Guid owner, TimeSpan lease, int limit, CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<DurableOutboxMessage>>([]);
+        public Task<IReadOnlyList<DurableOutboxMessage>> ReadAfterAsync(string workspaceId, string sessionCode, SessionSequence cursor, CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<DurableOutboxMessage>>([]);
+        public Task MarkDeliveredAsync(DurableOutboxMessage message, Guid owner, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+    }
+}

--- a/Nuotti.Backend/Commands/ISessionCommandProcessor.cs
+++ b/Nuotti.Backend/Commands/ISessionCommandProcessor.cs
@@ -26,5 +26,6 @@ public interface ISessionCommandProcessor
         Actor actor,
         CommandBase command,
         Guid? correlationId = null,
-        CancellationToken ct = default);
+        CancellationToken ct = default,
+        string workspaceId = "legacy");
 }

--- a/Nuotti.Backend/Commands/SessionCommandProcessor.cs
+++ b/Nuotti.Backend/Commands/SessionCommandProcessor.cs
@@ -1,6 +1,7 @@
 using Nuotti.Backend.Audit;
 using Nuotti.Backend.Idempotency;
 using Nuotti.Backend.Metrics;
+using Nuotti.Backend.Persistence;
 using Nuotti.Backend.Sessions;
 using Nuotti.Backend.Telemetry;
 using Nuotti.Contracts.V1.Enum;
@@ -10,6 +11,7 @@ using Nuotti.Contracts.V1.Message;
 using Nuotti.Contracts.V1.Message.Phase;
 using Nuotti.Contracts.V1.Model;
 using Nuotti.Contracts.V1.Reducer;
+using Nuotti.Contracts.V1.Protocol;
 using System.ComponentModel.DataAnnotations;
 using PhaseEnum = Nuotti.Contracts.V1.Enum.Phase;
 namespace Nuotti.Backend.Commands;
@@ -21,7 +23,9 @@ public sealed class SessionCommandProcessor(
     IEventBus bus,
     ILogger<SessionCommandProcessor> logger,
     BackendMetrics? metrics = null,
-    AuditLogService? audit = null) : ISessionCommandProcessor
+    AuditLogService? audit = null,
+    IDurableSessionCommitStore? durable = null,
+    DurableOutboxDispatcher? outbox = null) : ISessionCommandProcessor
 {
     /// <summary>
     /// What a Command does. Events are reduced in order; the reducer ignores types it does not know,
@@ -41,12 +45,44 @@ public sealed class SessionCommandProcessor(
         bool BroadcastSnapshot = true,
         bool CheckIdempotency = true);
 
+    sealed class StaleCommitException : System.Exception { }
+
     public async Task<CommandResult> ApplyAsync(
         string session,
         Actor actor,
         CommandBase command,
         Guid? correlationId = null,
-        CancellationToken ct = default)
+        CancellationToken ct = default,
+        string workspaceId = "legacy")
+    {
+        const int maxAttempts = 4;
+        for (var attempt = 1; attempt <= maxAttempts; attempt++)
+        {
+            try
+            {
+                return await ApplyAttemptAsync(session, actor, command, correlationId, ct, workspaceId);
+            }
+            catch (StaleCommitException)
+            {
+                if (attempt == maxAttempts) break;
+                await Task.Yield();
+            }
+        }
+
+        return CommandResult.Rejected(NuottiProblem.Conflict(
+            "Session is busy",
+            "The Session changed repeatedly while this command was being applied. Retry the command.",
+            ReasonCode.InvalidStateTransition,
+            correlationId: correlationId ?? command.CommandId));
+    }
+
+    async Task<CommandResult> ApplyAttemptAsync(
+        string session,
+        Actor actor,
+        CommandBase command,
+        Guid? correlationId,
+        CancellationToken ct,
+        string workspaceId)
     {
         using var activity = BackendActivitySource.StartCommandHandling(
             command.GetType().Name, session, command.CommandId);
@@ -70,16 +106,23 @@ public sealed class SessionCommandProcessor(
                 CorrelationId: correlation));
         }
 
+        if (durable is not null)
+        {
+            var prior = await durable.FindOutcomeAsync(workspaceId, session, command.CommandId, ct);
+            if (prior is not null) return prior;
+        }
+
         // create-session is guarded on existence rather than on phase. A fresh session reads as
         // Lobby (GameReducer.Initial), so guarding it against its declared AllowedPhases of [Idle]
         // would reject every create. Guarding on existence is what actually matters: re-sending
         // create mid-game used to silently reset scores and tallies.
         if (command is CreateSession)
         {
-            if (!idempotency.TryRegister(session, command.CommandId)) return CommandResult.Duplicate();
+            if (durable is null && !idempotency.TryRegister(session, command.CommandId)) return CommandResult.Duplicate();
             metrics?.RecordCommandReceived(command.CommandId);
 
-            if (store.TryGet(session, out _))
+            var durableExisting = durable is null ? null : await durable.LoadAsync(workspaceId, session, ct);
+            if (durableExisting is not null || store.TryGet(session, out _))
             {
                 return Reject(activity, NuottiProblem.Conflict(
                     title: "Session already exists",
@@ -89,18 +132,34 @@ public sealed class SessionCommandProcessor(
             }
 
             var seeded = GameReducer.Initial(session);
-            store.Set(session, seeded);
-            await PublishStateAsync(session, seeded, command, correlation, ct);
+            var createdEvent = StateChanged(session, seeded, command, correlation);
+            if (durable is not null)
+            {
+                var commit = await durable.CommitAsync(
+                    workspaceId, session, command.CommandId, SessionSequence.None, seeded, [createdEvent],
+                    DurableCommitPrecondition.SessionMustNotExist, ct);
+                if (commit.WasDuplicate) return commit.Result;
+                if (commit.Result.Outcome == Outcome.Rejected) return commit.Result;
+                store.Set(session, seeded);
+                if (outbox is not null) await outbox.DispatchPendingAsync(cancellationToken: ct);
+            }
+            else
+            {
+                store.Set(session, seeded);
+                await bus.PublishAsync(createdEvent, ct);
+            }
             Complete(activity, command, seeded);
             return CommandResult.Applied(seeded);
         }
 
-        var state = store.GetOrCreate(session, GameReducer.Initial);
+        var persisted = durable is null ? null : await durable.LoadAsync(workspaceId, session, ct);
+        var state = persisted?.Snapshot ?? store.GetOrCreate(session, GameReducer.Initial);
+        if (persisted is not null) store.Set(session, state);
 
         var effects = EffectsFor(command, state, actor, session, correlation, out var rejection);
         if (rejection is not null) return Reject(activity, rejection);
 
-        if (effects.CheckIdempotency && !idempotency.TryRegister(session, command.CommandId))
+        if (durable is null && effects.CheckIdempotency && !idempotency.TryRegister(session, command.CommandId))
         {
             return CommandResult.Duplicate();
         }
@@ -125,16 +184,26 @@ public sealed class SessionCommandProcessor(
         }
 
         var stateChanged = !ReferenceEquals(next, state);
-        if (stateChanged) store.Set(session, next);
-
-        foreach (var evt in effects.Events)
-        {
-            await PublishAsync(evt, ct);
-        }
-
+        var publications = effects.Events.ToList();
         if (effects.BroadcastSnapshot && stateChanged)
+            publications.Add(StateChanged(session, next, command, correlation));
+
+        if (durable is not null && effects.CheckIdempotency)
         {
-            await PublishStateAsync(session, next, command, correlation, ct);
+            var expectedSequence = persisted?.LastSequence ?? SessionSequence.None;
+            var commit = await durable.CommitAsync(
+                workspaceId, session, command.CommandId, expectedSequence, next, publications,
+                cancellationToken: ct);
+            if (commit.WasDuplicate) return commit.Result;
+            if (commit.WasStale)
+                throw new StaleCommitException();
+            store.Set(session, next);
+            if (outbox is not null) await outbox.DispatchPendingAsync(cancellationToken: ct);
+        }
+        else
+        {
+            if (stateChanged) store.Set(session, next);
+            foreach (var publication in publications) await PublishAsync(publication, ct);
         }
 
         Complete(activity, command, stateChanged ? next : null);
@@ -338,40 +407,20 @@ public sealed class SessionCommandProcessor(
             .ToArray();
     }
 
-    Task PublishStateAsync(
-        string session, GameStateSnapshot snapshot, CommandBase command, Guid correlation, CancellationToken ct)
-        => bus.PublishAsync(
-            new GameStateChanged(snapshot)
-            {
-                SessionCode = session,
-                CausedByCommandId = command.CommandId,
-                CorrelationId = correlation
-            }, ct);
+    static GameStateChanged StateChanged(
+        string session, GameStateSnapshot snapshot, CommandBase command, Guid correlation)
+        => new(snapshot)
+        {
+            SessionCode = session,
+            CausedByCommandId = command.CommandId,
+            CorrelationId = correlation
+        };
 
     /// <summary>
     /// Publishes with the runtime type. IEventBus keys subscribers by TEvent, so passing an
     /// `object` would register everything under `object` and reach no subscriber.
     /// </summary>
-    Task PublishAsync(object evt, CancellationToken ct) => evt switch
-    {
-        GamePhaseChanged e => bus.PublishAsync(e, ct),
-        CorrectAnswerRevealed e => bus.PublishAsync(e, ct),
-        HintGiven e => bus.PublishAsync(e, ct),
-        CatalogUpdated e => bus.PublishAsync(e, ct),
-        QuestionOffered e => bus.PublishAsync(e, ct),
-        AnswerSubmitted e => bus.PublishAsync(e, ct),
-        GameStateChanged e => bus.PublishAsync(e, ct),
-        QuestionPushed c => bus.PublishAsync(c, ct),
-        PlayTrack c => bus.PublishAsync(c, ct),
-        StopTrack c => bus.PublishAsync(c, ct),
-        _ => Unmapped(evt)
-    };
-
-    Task Unmapped(object evt)
-    {
-        logger.LogError("No publish mapping for {Type}; it would reach no subscriber", evt.GetType().Name);
-        return Task.CompletedTask;
-    }
+    Task PublishAsync(object evt, CancellationToken ct) => SessionMessagePublisher.PublishAsync(bus, evt, ct);
 
     void Complete(System.Diagnostics.Activity? activity, CommandBase command, GameStateSnapshot? state)
     {

--- a/Nuotti.Backend/Endpoints/RecoveryEndpoints.cs
+++ b/Nuotti.Backend/Endpoints/RecoveryEndpoints.cs
@@ -1,0 +1,47 @@
+using System.Text.Json;
+using Nuotti.Backend.Persistence;
+using Nuotti.Contracts.V1;
+using Nuotti.Contracts.V1.Model;
+using Nuotti.Contracts.V1.Protocol;
+
+namespace Nuotti.Backend.Endpoints;
+
+public sealed record ReplayMessage(SessionSequence Sequence, string MessageType, JsonElement Payload);
+public sealed record SessionRecovery(
+    SessionSnapshot<GameStateSnapshot> Snapshot,
+    IReadOnlyList<ReplayMessage> Events);
+
+public static class RecoveryEndpoints
+{
+    public static void MapRecoveryEndpoints(this WebApplication app)
+    {
+        app.MapGet("/v1/workspaces/{workspaceId}/sessions/{sessionCode}/recovery", async (
+            string workspaceId,
+            string sessionCode,
+            IDurableSessionCommitStore store,
+            CancellationToken cancellationToken) =>
+        {
+            var record = await store.LoadAsync(workspaceId, sessionCode, cancellationToken);
+            if (record is null) return Results.NotFound();
+
+            // This endpoint returns the latest compatible snapshot. Replay therefore starts
+            // strictly after that snapshot cursor; it never mixes already-reduced history into it.
+            var events = await store.ReadAfterAsync(workspaceId, sessionCode, record.LastSequence, cancellationToken);
+            var recovery = new SessionRecovery(
+                new SessionSnapshot<GameStateSnapshot>(
+                    SessionProtocolVersion.Current,
+                    SessionProtocolVersion.Current,
+                    workspaceId,
+                    sessionCode,
+                    record.LastSequence,
+                    record.ControlGeneration,
+                    record.Snapshot),
+                events.Select(message => new ReplayMessage(
+                    message.Sequence,
+                    message.MessageType,
+                    JsonSerializer.Deserialize<JsonElement>(message.Payload, ContractsJson.RestOptions)))
+                .ToArray());
+            return Results.Ok(recovery);
+        });
+    }
+}

--- a/Nuotti.Backend/Persistence/DurableOutboxDispatcher.cs
+++ b/Nuotti.Backend/Persistence/DurableOutboxDispatcher.cs
@@ -1,0 +1,58 @@
+using Nuotti.Contracts.V1.Eventing;
+
+namespace Nuotti.Backend.Persistence;
+
+public sealed class DurableOutboxDispatcher(
+    IDurableSessionCommitStore store,
+    IEventBus bus,
+    ILogger<DurableOutboxDispatcher> logger)
+{
+    readonly Guid _owner = Guid.NewGuid();
+
+    public async Task<int> DispatchPendingAsync(int limit = 100, CancellationToken cancellationToken = default)
+    {
+        var delivered = 0;
+        foreach (var message in await store.ClaimPendingAsync(_owner, TimeSpan.FromSeconds(30), limit, cancellationToken))
+        {
+            try
+            {
+                var payload = SessionMessagePublisher.DeserializeDurable(message.MessageType, message.Payload);
+                await SessionMessagePublisher.PublishAsync(bus, payload, cancellationToken);
+                await store.MarkDeliveredAsync(message, _owner, cancellationToken);
+                delivered++;
+            }
+            catch (System.Exception ex) when (ex is not OperationCanceledException)
+            {
+                logger.LogError(ex, "Outbox delivery failed for {Session}/{Sequence}",
+                    message.SessionCode, message.Sequence.Value);
+                // This lease remains until expiry so the same Session cannot overtake it. Other
+                // Sessions in this claimed batch are independent and should continue immediately.
+                continue;
+            }
+        }
+        return delivered;
+    }
+}
+
+public sealed class DurableOutboxWorker(
+    DurableOutboxDispatcher dispatcher,
+    ILogger<DurableOutboxWorker> logger) : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                var delivered = await dispatcher.DispatchPendingAsync(cancellationToken: stoppingToken);
+                if (delivered == 0) await Task.Delay(TimeSpan.FromMilliseconds(250), stoppingToken);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested) { }
+            catch (System.Exception ex)
+            {
+                logger.LogError(ex, "Durable outbox dispatch loop failed");
+                await Task.Delay(TimeSpan.FromSeconds(1), stoppingToken);
+            }
+        }
+    }
+}

--- a/Nuotti.Backend/Persistence/IDurableSessionCommitStore.cs
+++ b/Nuotti.Backend/Persistence/IDurableSessionCommitStore.cs
@@ -1,0 +1,53 @@
+using Nuotti.Backend.Commands;
+using Nuotti.Contracts.V1.Model;
+using Nuotti.Contracts.V1.Protocol;
+
+namespace Nuotti.Backend.Persistence;
+
+public sealed record DurableOutboxMessage(
+    string WorkspaceId,
+    string SessionCode,
+    SessionSequence Sequence,
+    string MessageType,
+    string Payload);
+
+public sealed record DurableSessionRecord(
+    string WorkspaceId,
+    GameStateSnapshot Snapshot,
+    SessionSequence LastSequence,
+    ControlGeneration ControlGeneration);
+
+public sealed record DurableCommit(
+    CommandResult Result,
+    IReadOnlyList<DurableOutboxMessage> Messages,
+    bool WasDuplicate,
+    bool WasStale = false);
+
+public enum DurableCommitPrecondition { Any, SessionMustNotExist }
+
+/// <summary>
+/// Atomically owns a Session snapshot, durable command outcome, ordered Event log, and outbox.
+/// Implementations must return the original outcome when CommandId already exists.
+/// </summary>
+public interface IDurableSessionCommitStore
+{
+    Task<DurableSessionRecord?> LoadAsync(string workspaceId, string sessionCode, CancellationToken cancellationToken = default);
+    Task<CommandResult?> FindOutcomeAsync(string workspaceId, string sessionCode, Guid commandId, CancellationToken cancellationToken = default);
+    Task<DurableCommit> CommitAsync(
+        string workspaceId,
+        string sessionCode,
+        Guid commandId,
+        SessionSequence expectedSequence,
+        GameStateSnapshot snapshot,
+        IReadOnlyList<object> messages,
+        DurableCommitPrecondition precondition = DurableCommitPrecondition.Any,
+        CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<DurableOutboxMessage>> ClaimPendingAsync(
+        Guid owner, TimeSpan lease, int limit, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<DurableOutboxMessage>> ReadAfterAsync(
+        string workspaceId,
+        string sessionCode,
+        SessionSequence cursor,
+        CancellationToken cancellationToken = default);
+    Task MarkDeliveredAsync(DurableOutboxMessage message, Guid owner, CancellationToken cancellationToken = default);
+}

--- a/Nuotti.Backend/Persistence/InMemoryDurableSessionCommitStore.cs
+++ b/Nuotti.Backend/Persistence/InMemoryDurableSessionCommitStore.cs
@@ -1,0 +1,113 @@
+using Nuotti.Backend.Commands;
+using Nuotti.Contracts.V1.Model;
+using Nuotti.Contracts.V1.Protocol;
+
+namespace Nuotti.Backend.Persistence;
+
+/// <summary>Deterministic adapter used by tests; multiple processors may share it to model restart.</summary>
+public sealed class InMemoryDurableSessionCommitStore : IDurableSessionCommitStore
+{
+    readonly object _gate = new();
+    readonly Dictionary<(string Workspace, string Session), DurableSessionRecord> _sessions = [];
+    readonly Dictionary<(string Workspace, string Session, Guid Command), CommandResult> _outcomes = [];
+    readonly List<(DurableOutboxMessage Message, bool Delivered, Guid? Owner, DateTimeOffset? LeaseUntil)> _outbox = [];
+
+    public Task<DurableSessionRecord?> LoadAsync(string workspaceId, string sessionCode, CancellationToken cancellationToken = default)
+    {
+        lock (_gate) return Task.FromResult(_sessions.GetValueOrDefault((workspaceId, sessionCode)));
+    }
+
+    public Task<CommandResult?> FindOutcomeAsync(string workspaceId, string sessionCode, Guid commandId, CancellationToken cancellationToken = default)
+    {
+        lock (_gate) return Task.FromResult(_outcomes.GetValueOrDefault((workspaceId, sessionCode, commandId)));
+    }
+
+    public Task<DurableCommit> CommitAsync(
+        string workspaceId,
+        string sessionCode,
+        Guid commandId,
+        SessionSequence expectedSequence,
+        GameStateSnapshot snapshot,
+        IReadOnlyList<object> messages,
+        DurableCommitPrecondition precondition = DurableCommitPrecondition.Any,
+        CancellationToken cancellationToken = default)
+    {
+        lock (_gate)
+        {
+            if (_outcomes.TryGetValue((workspaceId, sessionCode, commandId), out var prior))
+                return Task.FromResult(new DurableCommit(prior, [], WasDuplicate: true));
+
+            var key = (workspaceId, sessionCode);
+            var existing = _sessions.GetValueOrDefault(key);
+            if (precondition == DurableCommitPrecondition.SessionMustNotExist && existing is not null)
+                return Task.FromResult(new DurableCommit(CommandResult.Rejected(
+                    NuottiProblem.Conflict("Session already exists", $"Session '{sessionCode}' has already been created.",
+                        Nuotti.Contracts.V1.Enum.ReasonCode.InvalidStateTransition)), [], false));
+            var sequence = existing?.LastSequence ?? SessionSequence.None;
+            if (sequence != expectedSequence)
+                return Task.FromResult(new DurableCommit(CommandResult.Duplicate(), [], false, WasStale: true));
+            var committed = new List<DurableOutboxMessage>(messages.Count);
+            foreach (var message in messages)
+            {
+                sequence = sequence.Next();
+                var serialized = SessionMessagePublisher.SerializeDurable(message);
+                var pending = new DurableOutboxMessage(workspaceId, sessionCode, sequence, serialized.Type, serialized.Payload);
+                committed.Add(pending);
+                _outbox.Add((pending, false, null, null));
+            }
+
+            var result = CommandResult.Applied(snapshot);
+            _sessions[key] = new DurableSessionRecord(workspaceId, snapshot, sequence, ControlGeneration.Initial);
+            _outcomes[(workspaceId, sessionCode, commandId)] = result;
+            return Task.FromResult(new DurableCommit(result, committed, WasDuplicate: false));
+        }
+    }
+
+    public Task<IReadOnlyList<DurableOutboxMessage>> ClaimPendingAsync(Guid owner, TimeSpan lease, int limit, CancellationToken cancellationToken = default)
+    {
+        lock (_gate)
+        {
+            var now = DateTimeOffset.UtcNow;
+            var claimed = new List<DurableOutboxMessage>();
+            for (var i = 0; i < _outbox.Count && claimed.Count < limit; i++)
+            {
+                var item = _outbox[i];
+                if (item.Delivered || item.LeaseUntil > now) continue;
+                var hasEarlier = _outbox.Any(other => !other.Delivered
+                    && other.Message.WorkspaceId == item.Message.WorkspaceId
+                    && other.Message.SessionCode == item.Message.SessionCode
+                    && other.Message.Sequence.Value < item.Message.Sequence.Value);
+                if (hasEarlier) continue;
+                _outbox[i] = (item.Message, false, owner, now + lease);
+                claimed.Add(item.Message);
+            }
+            return Task.FromResult<IReadOnlyList<DurableOutboxMessage>>(claimed);
+        }
+    }
+
+    public Task<IReadOnlyList<DurableOutboxMessage>> ReadAfterAsync(
+        string workspaceId,
+        string sessionCode,
+        SessionSequence cursor,
+        CancellationToken cancellationToken = default)
+    {
+        lock (_gate)
+            return Task.FromResult<IReadOnlyList<DurableOutboxMessage>>(_outbox
+                .Where(item => item.Message.WorkspaceId == workspaceId && item.Message.SessionCode == sessionCode && item.Message.Sequence.Value > cursor.Value)
+                .OrderBy(item => item.Message.Sequence.Value)
+                .Select(item => item.Message)
+                .ToArray());
+    }
+
+    public Task MarkDeliveredAsync(DurableOutboxMessage message, Guid owner, CancellationToken cancellationToken = default)
+    {
+        lock (_gate)
+        {
+            var index = _outbox.FindIndex(item => item.Message.WorkspaceId == message.WorkspaceId
+                && item.Message.SessionCode == message.SessionCode && item.Message.Sequence == message.Sequence
+                && item.Owner == owner);
+            if (index >= 0) _outbox[index] = (_outbox[index].Message, true, owner, null);
+        }
+        return Task.CompletedTask;
+    }
+}

--- a/Nuotti.Backend/Persistence/PostgresDurableSessionCommitStore.cs
+++ b/Nuotti.Backend/Persistence/PostgresDurableSessionCommitStore.cs
@@ -1,0 +1,282 @@
+using System.Text.Json;
+using Npgsql;
+using Nuotti.Backend.Commands;
+using Nuotti.Contracts.V1;
+using Nuotti.Contracts.V1.Model;
+using Nuotti.Contracts.V1.Protocol;
+
+namespace Nuotti.Backend.Persistence;
+
+/// <summary>PostgreSQL adapter for the atomic Session state/outcome/event/outbox transaction.</summary>
+public sealed class PostgresDurableSessionCommitStore(NpgsqlDataSource dataSource) : IDurableSessionCommitStore
+{
+    readonly SemaphoreSlim _initializeGate = new(1, 1);
+    volatile bool _initialized;
+
+    async Task EnsureSchemaAsync(CancellationToken ct)
+    {
+        if (_initialized) return;
+        await _initializeGate.WaitAsync(ct);
+        try
+        {
+            if (_initialized) return;
+            await using var command = dataSource.CreateCommand("""
+                CREATE TABLE IF NOT EXISTS nuotti_session_state (
+                    workspace_id text NOT NULL,
+                    session_code text NOT NULL,
+                    snapshot jsonb NOT NULL,
+                    last_sequence bigint NOT NULL,
+                    control_generation bigint NOT NULL DEFAULT 0,
+                    updated_at timestamptz NOT NULL DEFAULT now(),
+                    PRIMARY KEY (workspace_id, session_code));
+                CREATE TABLE IF NOT EXISTS nuotti_command_outcome (
+                    workspace_id text NOT NULL,
+                    session_code text NOT NULL,
+                    command_id uuid NOT NULL,
+                    outcome text NOT NULL,
+                    state jsonb NULL,
+                    problem jsonb NULL,
+                    PRIMARY KEY (workspace_id, session_code, command_id));
+                CREATE TABLE IF NOT EXISTS nuotti_session_event (
+                    workspace_id text NOT NULL,
+                    session_code text NOT NULL,
+                    sequence bigint NOT NULL,
+                    message_type text NOT NULL,
+                    payload jsonb NOT NULL,
+                    PRIMARY KEY (workspace_id, session_code, sequence));
+                CREATE TABLE IF NOT EXISTS nuotti_outbox (
+                    workspace_id text NOT NULL,
+                    session_code text NOT NULL,
+                    sequence bigint NOT NULL,
+                    message_type text NOT NULL,
+                    payload jsonb NOT NULL,
+                    delivered_at timestamptz NULL,
+                    claim_owner uuid NULL,
+                    claim_until timestamptz NULL,
+                    PRIMARY KEY (workspace_id, session_code, sequence));
+                CREATE INDEX IF NOT EXISTS ix_nuotti_outbox_pending
+                    ON nuotti_outbox (workspace_id, session_code, sequence) WHERE delivered_at IS NULL;
+                """);
+            await command.ExecuteNonQueryAsync(ct);
+            _initialized = true;
+        }
+        finally { _initializeGate.Release(); }
+    }
+
+    public async Task<DurableSessionRecord?> LoadAsync(string workspaceId, string sessionCode, CancellationToken cancellationToken = default)
+    {
+        await EnsureSchemaAsync(cancellationToken);
+        await using var command = dataSource.CreateCommand(
+            "SELECT snapshot::text, last_sequence, control_generation FROM nuotti_session_state WHERE workspace_id=$1 AND session_code=$2");
+        command.Parameters.AddWithValue(workspaceId);
+        command.Parameters.AddWithValue(sessionCode);
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        if (!await reader.ReadAsync(cancellationToken)) return null;
+        return new DurableSessionRecord(workspaceId,
+            JsonSerializer.Deserialize<GameStateSnapshot>(reader.GetString(0), ContractsJson.RestOptions)!,
+            new SessionSequence(reader.GetInt64(1)),
+            new ControlGeneration(reader.GetInt64(2)));
+    }
+
+    public async Task<CommandResult?> FindOutcomeAsync(string workspaceId, string sessionCode, Guid commandId, CancellationToken cancellationToken = default)
+    {
+        await EnsureSchemaAsync(cancellationToken);
+        await using var command = dataSource.CreateCommand(
+            "SELECT outcome, state::text, problem::text FROM nuotti_command_outcome WHERE workspace_id=$1 AND session_code=$2 AND command_id=$3");
+        command.Parameters.AddWithValue(workspaceId);
+        command.Parameters.AddWithValue(sessionCode);
+        command.Parameters.AddWithValue(commandId);
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        return await reader.ReadAsync(cancellationToken) ? ReadResult(reader) : null;
+    }
+
+    public async Task<DurableCommit> CommitAsync(
+        string workspaceId, string sessionCode, Guid commandId, SessionSequence expectedSequence,
+        GameStateSnapshot snapshot, IReadOnlyList<object> messages,
+        DurableCommitPrecondition precondition = DurableCommitPrecondition.Any,
+        CancellationToken cancellationToken = default)
+    {
+        await EnsureSchemaAsync(cancellationToken);
+        await using var connection = await dataSource.OpenConnectionAsync(cancellationToken);
+        await using var transaction = await connection.BeginTransactionAsync(cancellationToken);
+
+        // Serialize all commits for one Session, including concurrent first writes where no state
+        // row exists yet. This makes the outcome lookup and sequence allocation one critical section.
+        await using (var sessionLock = new NpgsqlCommand(
+            "SELECT pg_advisory_xact_lock(hashtextextended($1 || ':' || $2, 0))", connection, transaction))
+        {
+            sessionLock.Parameters.AddWithValue(workspaceId);
+            sessionLock.Parameters.AddWithValue(sessionCode);
+            await sessionLock.ExecuteNonQueryAsync(cancellationToken);
+        }
+
+        await using (var prior = new NpgsqlCommand(
+            "SELECT outcome, state::text, problem::text FROM nuotti_command_outcome WHERE workspace_id=$1 AND session_code=$2 AND command_id=$3",
+            connection, transaction))
+        {
+            prior.Parameters.AddWithValue(workspaceId);
+            prior.Parameters.AddWithValue(sessionCode);
+            prior.Parameters.AddWithValue(commandId);
+            await using var reader = await prior.ExecuteReaderAsync(cancellationToken);
+            if (await reader.ReadAsync(cancellationToken))
+            {
+                var result = ReadResult(reader);
+                await reader.DisposeAsync();
+                await transaction.RollbackAsync(cancellationToken);
+                return new DurableCommit(result, [], WasDuplicate: true);
+            }
+        }
+
+        long lastSequence;
+        var exists = false;
+        await using (var current = new NpgsqlCommand(
+            "SELECT last_sequence FROM nuotti_session_state WHERE workspace_id=$1 AND session_code=$2", connection, transaction))
+        {
+            current.Parameters.AddWithValue(workspaceId);
+            current.Parameters.AddWithValue(sessionCode);
+            var value = await current.ExecuteScalarAsync(cancellationToken);
+            exists = value is not null;
+            lastSequence = exists ? Convert.ToInt64(value) : 0;
+        }
+        if (precondition == DurableCommitPrecondition.SessionMustNotExist && exists)
+        {
+            await transaction.RollbackAsync(cancellationToken);
+            return new DurableCommit(CommandResult.Rejected(NuottiProblem.Conflict(
+                "Session already exists", $"Session '{sessionCode}' has already been created.",
+                Nuotti.Contracts.V1.Enum.ReasonCode.InvalidStateTransition)), [], false);
+        }
+        if (lastSequence != expectedSequence.Value)
+        {
+            await transaction.RollbackAsync(cancellationToken);
+            return new DurableCommit(CommandResult.Duplicate(), [], false, WasStale: true);
+        }
+        await using (var lockState = new NpgsqlCommand("""
+            INSERT INTO nuotti_session_state(workspace_id, session_code, snapshot, last_sequence, control_generation)
+            VALUES ($1, $2, $3::jsonb, 0, 0) ON CONFLICT (workspace_id, session_code) DO NOTHING;
+            """, connection, transaction))
+        {
+            lockState.Parameters.AddWithValue(workspaceId);
+            lockState.Parameters.AddWithValue(sessionCode);
+            lockState.Parameters.AddWithValue(JsonSerializer.Serialize(snapshot, ContractsJson.RestOptions));
+            await lockState.ExecuteNonQueryAsync(cancellationToken);
+        }
+
+        var committed = new List<DurableOutboxMessage>(messages.Count);
+        foreach (var message in messages)
+        {
+            lastSequence = checked(lastSequence + 1);
+            var serialized = SessionMessagePublisher.SerializeDurable(message);
+            await using var append = new NpgsqlCommand("""
+                INSERT INTO nuotti_session_event(workspace_id, session_code, sequence, message_type, payload)
+                VALUES ($1, $2, $3, $4, $5::jsonb);
+                INSERT INTO nuotti_outbox(workspace_id, session_code, sequence, message_type, payload)
+                VALUES ($1, $2, $3, $4, $5::jsonb);
+                """, connection, transaction);
+            append.Parameters.AddWithValue(workspaceId);
+            append.Parameters.AddWithValue(sessionCode);
+            append.Parameters.AddWithValue(lastSequence);
+            append.Parameters.AddWithValue(serialized.Type);
+            append.Parameters.AddWithValue(serialized.Payload);
+            await append.ExecuteNonQueryAsync(cancellationToken);
+            committed.Add(new DurableOutboxMessage(workspaceId, sessionCode, new SessionSequence(lastSequence), serialized.Type, serialized.Payload));
+        }
+
+        var stateJson = JsonSerializer.Serialize(snapshot, ContractsJson.RestOptions);
+        await using (var finish = new NpgsqlCommand("""
+            UPDATE nuotti_session_state SET snapshot=$3::jsonb, last_sequence=$4, updated_at=now()
+            WHERE workspace_id=$1 AND session_code=$2;
+            INSERT INTO nuotti_command_outcome(workspace_id, session_code, command_id, outcome, state)
+            VALUES ($1, $2, $5, 'Applied', $3::jsonb);
+            """, connection, transaction))
+        {
+            finish.Parameters.AddWithValue(workspaceId);
+            finish.Parameters.AddWithValue(sessionCode);
+            finish.Parameters.AddWithValue(stateJson);
+            finish.Parameters.AddWithValue(lastSequence);
+            finish.Parameters.AddWithValue(commandId);
+            await finish.ExecuteNonQueryAsync(cancellationToken);
+        }
+
+        await transaction.CommitAsync(cancellationToken);
+        return new DurableCommit(CommandResult.Applied(snapshot), committed, WasDuplicate: false);
+    }
+
+    public async Task<IReadOnlyList<DurableOutboxMessage>> ClaimPendingAsync(
+        Guid owner, TimeSpan lease, int limit, CancellationToken cancellationToken = default)
+    {
+        await EnsureSchemaAsync(cancellationToken);
+        await using var command = dataSource.CreateCommand("""
+            WITH candidates AS (
+                SELECT candidate.workspace_id, candidate.session_code, candidate.sequence
+                FROM nuotti_outbox candidate
+                WHERE candidate.delivered_at IS NULL
+                  AND (candidate.claim_until IS NULL OR candidate.claim_until < now())
+                  AND NOT EXISTS (
+                      SELECT 1 FROM nuotti_outbox earlier
+                      WHERE earlier.workspace_id=candidate.workspace_id
+                        AND earlier.session_code=candidate.session_code
+                        AND earlier.delivered_at IS NULL
+                        AND earlier.sequence < candidate.sequence)
+                ORDER BY candidate.workspace_id, candidate.session_code, candidate.sequence
+                FOR UPDATE SKIP LOCKED LIMIT $1)
+            UPDATE nuotti_outbox target
+            SET claim_owner=$2, claim_until=now()+$3
+            FROM candidates
+            WHERE target.workspace_id=candidates.workspace_id
+              AND target.session_code=candidates.session_code
+              AND target.sequence=candidates.sequence
+            RETURNING target.workspace_id, target.session_code, target.sequence,
+                      target.message_type, target.payload::text
+            """);
+        command.Parameters.AddWithValue(limit);
+        command.Parameters.AddWithValue(owner);
+        command.Parameters.AddWithValue(lease);
+        return await ReadMessagesAsync(command, cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<DurableOutboxMessage>> ReadAfterAsync(
+        string workspaceId, string sessionCode, SessionSequence cursor, CancellationToken cancellationToken = default)
+    {
+        await EnsureSchemaAsync(cancellationToken);
+        await using var command = dataSource.CreateCommand("""
+            SELECT workspace_id, session_code, sequence, message_type, payload::text FROM nuotti_session_event
+            WHERE workspace_id=$1 AND session_code=$2 AND sequence>$3 ORDER BY sequence
+            """);
+        command.Parameters.AddWithValue(workspaceId);
+        command.Parameters.AddWithValue(sessionCode);
+        command.Parameters.AddWithValue(cursor.Value);
+        return await ReadMessagesAsync(command, cancellationToken);
+    }
+
+    public async Task MarkDeliveredAsync(DurableOutboxMessage message, Guid owner, CancellationToken cancellationToken = default)
+    {
+        await EnsureSchemaAsync(cancellationToken);
+        await using var command = dataSource.CreateCommand("""
+            UPDATE nuotti_outbox SET delivered_at=COALESCE(delivered_at, now()), claim_until=NULL
+            WHERE workspace_id=$1 AND session_code=$2 AND sequence=$3 AND claim_owner=$4
+            """);
+        command.Parameters.AddWithValue(message.WorkspaceId);
+        command.Parameters.AddWithValue(message.SessionCode);
+        command.Parameters.AddWithValue(message.Sequence.Value);
+        command.Parameters.AddWithValue(owner);
+        await command.ExecuteNonQueryAsync(cancellationToken);
+    }
+
+    static CommandResult ReadResult(NpgsqlDataReader reader)
+    {
+        var outcome = System.Enum.Parse<Outcome>(reader.GetString(0));
+        var state = reader.IsDBNull(1) ? null : JsonSerializer.Deserialize<GameStateSnapshot>(reader.GetString(1), ContractsJson.RestOptions);
+        var problem = reader.IsDBNull(2) ? null : JsonSerializer.Deserialize<NuottiProblem>(reader.GetString(2), ContractsJson.RestOptions);
+        return new CommandResult(outcome, state, problem);
+    }
+
+    static async Task<IReadOnlyList<DurableOutboxMessage>> ReadMessagesAsync(NpgsqlCommand command, CancellationToken ct)
+    {
+        var messages = new List<DurableOutboxMessage>();
+        await using var reader = await command.ExecuteReaderAsync(ct);
+        while (await reader.ReadAsync(ct))
+            messages.Add(new DurableOutboxMessage(reader.GetString(0), reader.GetString(1),
+                new SessionSequence(reader.GetInt64(2)), reader.GetString(3), reader.GetString(4)));
+        return messages;
+    }
+}

--- a/Nuotti.Backend/Persistence/SessionMessagePublisher.cs
+++ b/Nuotti.Backend/Persistence/SessionMessagePublisher.cs
@@ -1,0 +1,46 @@
+using System.Text.Json;
+using Nuotti.Contracts.V1;
+using Nuotti.Contracts.V1.Event;
+using Nuotti.Contracts.V1.Eventing;
+using Nuotti.Contracts.V1.Message;
+
+namespace Nuotti.Backend.Persistence;
+
+/// <summary>Single registry for Session message serialization and runtime-type publication.</summary>
+public static class SessionMessagePublisher
+{
+    sealed record Entry(Type Type, bool Durable, Func<IEventBus, object, CancellationToken, Task> Publish);
+
+    static Entry Of<T>(bool durable = true) => new(typeof(T), durable,
+        (bus, message, ct) => bus.PublishAsync((T)message, ct));
+
+    static readonly Entry[] Entries =
+    [
+        Of<GamePhaseChanged>(), Of<CorrectAnswerRevealed>(), Of<HintGiven>(),
+        Of<CatalogUpdated>(), Of<QuestionOffered>(), Of<AnswerSubmitted>(), Of<GameStateChanged>(),
+        Of<QuestionPushed>(false), Of<PlayTrack>(false), Of<StopTrack>(false)
+    ];
+
+    static readonly IReadOnlyDictionary<Type, Entry> ByType = Entries.ToDictionary(entry => entry.Type);
+    static readonly IReadOnlyDictionary<string, Entry> ByName = Entries.ToDictionary(entry => entry.Type.Name, StringComparer.Ordinal);
+
+    public static Task PublishAsync(IEventBus bus, object message, CancellationToken cancellationToken = default)
+        => ByType.TryGetValue(message.GetType(), out var entry)
+            ? entry.Publish(bus, message, cancellationToken)
+            : throw new NotSupportedException($"Message type '{message.GetType().Name}' is not publishable.");
+
+    public static (string Type, string Payload) SerializeDurable(object message)
+    {
+        if (!ByType.TryGetValue(message.GetType(), out var entry) || !entry.Durable)
+            throw new NotSupportedException($"Message type '{message.GetType().Name}' is not durable.");
+        return (entry.Type.Name, JsonSerializer.Serialize(message, entry.Type, ContractsJson.RestOptions));
+    }
+
+    public static object DeserializeDurable(string messageType, string payload)
+    {
+        if (!ByName.TryGetValue(messageType, out var entry) || !entry.Durable)
+            throw new NotSupportedException($"Message type '{messageType}' is not durable.");
+        return JsonSerializer.Deserialize(payload, entry.Type, ContractsJson.RestOptions)
+            ?? throw new JsonException($"Durable message '{messageType}' deserialized to null.");
+    }
+}

--- a/Nuotti.Backend/Program.cs
+++ b/Nuotti.Backend/Program.cs
@@ -8,6 +8,7 @@ using Nuotti.Backend.Idempotency;
 using Nuotti.Backend.InfrastructureProof;
 using Nuotti.Backend.Metrics;
 using Nuotti.Backend.Models;
+using Nuotti.Backend.Persistence;
 using Nuotti.Backend.Sessions;
 using Nuotti.Contracts.V1.Eventing;
 using Microsoft.Extensions.Options;
@@ -99,6 +100,12 @@ builder.Services.AddSingleton<ILogStreamer, LogStreamer>();
 builder.Services.AddSingleton<ISessionStore, InMemorySessionStore>();
 builder.Services.AddSingleton<IGameStateStore, InMemoryGameStateStore>();
 builder.Services.AddSingleton<IIdempotencyStore, InMemoryIdempotencyStore>();
+if (!string.IsNullOrWhiteSpace(databaseConnection))
+{
+    builder.Services.AddSingleton<IDurableSessionCommitStore, PostgresDurableSessionCommitStore>();
+    builder.Services.AddSingleton<DurableOutboxDispatcher>();
+    builder.Services.AddHostedService<DurableOutboxWorker>();
+}
 
 // Metrics
 builder.Services.AddSingleton<BackendMetrics>();
@@ -162,6 +169,7 @@ app.MapTimeEndpoints();
 app.MapDiagnosticsEndpoints();
 app.MapDevEndpoints();
 app.MapInfrastructureProofEndpoints();
+if (!string.IsNullOrWhiteSpace(databaseConnection)) app.MapRecoveryEndpoints();
 app.MapNuottiEndpoints("Nuotti.Backend");
 
 // Force creation of subscribers so they can attach to the bus


### PR DESCRIPTION
Closes #249. Adds a Workspace-scoped PostgreSQL transaction for snapshot, prior outcome, ordered event log, and outbox; expected-sequence fencing and atomic create preconditions; leased earliest-per-Session delivery across replicas; a retry worker; and compatible snapshot recovery. Verification: focused 8/8, Backend 132/132, standards/spec reviews clean.