### PR TITLE
Isolate Workspace membership journey

### DIFF
--- a/Nuotti.Backend.Tests/WorkspaceJourneyTests.cs
+++ b/Nuotti.Backend.Tests/WorkspaceJourneyTests.cs
@@ -1,0 +1,158 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Nuotti.Backend;
+using Nuotti.Backend.Workspaces;
+
+namespace Nuotti.Backend.Tests;
+
+public sealed class WorkspaceJourneyTests(WebApplicationFactory<QuizHub> factory)
+    : IClassFixture<WebApplicationFactory<QuizHub>>
+{
+    readonly HttpClient _client = factory.WithWebHostBuilder(_ => { }).CreateClient();
+
+    [Fact]
+    public async Task Owner_and_member_can_run_an_isolated_session_journey()
+    {
+        var owner = await SignInAsync(UniqueEmail("owner"));
+        var workspace = await CreateWorkspaceAsync(owner.SessionToken, "The Satellites");
+        await SelectAsync(owner.SessionToken, workspace.WorkspaceId);
+
+        var invitation = await SendAsync<IssuedMagicLink>(HttpMethod.Post,
+            $"/v1/workspaces/{workspace.WorkspaceId}/invitations", owner.SessionToken,
+            new { email = UniqueEmail("member") });
+        var member = await RedeemAsync(invitation.Token);
+        await SelectAsync(member.SessionToken, workspace.WorkspaceId);
+
+        var create = await SendRawAsync(HttpMethod.Post,
+            $"/v1/workspaces/{workspace.WorkspaceId}/sessions/SHOW42/create", owner.SessionToken);
+        Assert.Equal(HttpStatusCode.Accepted, create.StatusCode);
+
+        var start = await SendRawAsync(HttpMethod.Post,
+            $"/v1/workspaces/{workspace.WorkspaceId}/sessions/SHOW42/start", member.SessionToken);
+        Assert.Equal(HttpStatusCode.Accepted, start.StatusCode);
+
+        var recovery = await SendRawAsync(HttpMethod.Get,
+            $"/v1/workspaces/{workspace.WorkspaceId}/sessions/SHOW42/recovery", member.SessionToken);
+        Assert.Equal(HttpStatusCode.OK, recovery.StatusCode);
+    }
+
+    [Fact]
+    public async Task Selected_workspace_is_required_and_cross_workspace_access_is_indistinguishable()
+    {
+        var user = await SignInAsync(UniqueEmail("multi"));
+        var first = await CreateWorkspaceAsync(user.SessionToken, "First band");
+        var second = await CreateWorkspaceAsync(user.SessionToken, "Second band");
+
+        await SelectAsync(user.SessionToken, first.WorkspaceId);
+        var wrongSelection = await SendRawAsync(HttpMethod.Post,
+            $"/v1/workspaces/{second.WorkspaceId}/sessions/HIDDEN/create", user.SessionToken);
+        var nonexistent = await SendRawAsync(HttpMethod.Post,
+            "/v1/workspaces/ws_does_not_exist/sessions/HIDDEN/create", user.SessionToken);
+        Assert.Equal(HttpStatusCode.NotFound, wrongSelection.StatusCode);
+        Assert.Equal(nonexistent.StatusCode, wrongSelection.StatusCode);
+
+        await SelectAsync(user.SessionToken, second.WorkspaceId);
+        var secondCreate = await SendRawAsync(HttpMethod.Post,
+            $"/v1/workspaces/{second.WorkspaceId}/sessions/HIDDEN/create", user.SessionToken);
+        Assert.Equal(HttpStatusCode.Accepted, secondCreate.StatusCode);
+
+        await SelectAsync(user.SessionToken, first.WorkspaceId);
+        var hiddenRecovery = await SendRawAsync(HttpMethod.Get,
+            $"/v1/workspaces/{second.WorkspaceId}/sessions/HIDDEN/recovery", user.SessionToken);
+        var missingRecovery = await SendRawAsync(HttpMethod.Get,
+            $"/v1/workspaces/{second.WorkspaceId}/sessions/MISSING/recovery", user.SessionToken);
+        Assert.Equal(HttpStatusCode.NotFound, hiddenRecovery.StatusCode);
+        Assert.Equal(missingRecovery.StatusCode, hiddenRecovery.StatusCode);
+    }
+
+    [Fact]
+    public async Task Owner_can_revoke_member_immediately()
+    {
+        var owner = await SignInAsync(UniqueEmail("revoke-owner"));
+        var workspace = await CreateWorkspaceAsync(owner.SessionToken, "Revocation band");
+        await SelectAsync(owner.SessionToken, workspace.WorkspaceId);
+        var invitation = await SendAsync<IssuedMagicLink>(HttpMethod.Post,
+            $"/v1/workspaces/{workspace.WorkspaceId}/invitations", owner.SessionToken,
+            new { email = UniqueEmail("revoke-member") });
+        var member = await RedeemAsync(invitation.Token);
+        await SelectAsync(member.SessionToken, workspace.WorkspaceId);
+
+        var revoke = await SendRawAsync(HttpMethod.Delete,
+            $"/v1/workspaces/{workspace.WorkspaceId}/members/{member.Principal.UserId}", owner.SessionToken);
+        Assert.Equal(HttpStatusCode.NoContent, revoke.StatusCode);
+
+        var afterRevocation = await SendRawAsync(HttpMethod.Post,
+            $"/v1/workspaces/{workspace.WorkspaceId}/sessions/NOPE/create", member.SessionToken);
+        Assert.Equal(HttpStatusCode.NotFound, afterRevocation.StatusCode);
+    }
+
+    [Fact]
+    public async Task Invalid_identity_and_workspace_inputs_are_expected_client_errors()
+    {
+        var invalidEmail = await SendRawAsync(HttpMethod.Post, "/v1/auth/magic-links", null,
+            new { email = "not-an-email" });
+        Assert.Equal(HttpStatusCode.BadRequest, invalidEmail.StatusCode);
+
+        var owner = await SignInAsync(UniqueEmail("validation"));
+        var invalidName = await SendRawAsync(HttpMethod.Post, "/v1/workspaces", owner.SessionToken,
+            new { name = "   " });
+        Assert.Equal(HttpStatusCode.BadRequest, invalidName.StatusCode);
+    }
+
+    [Fact]
+    public async Task Invitation_requires_explicit_selection_and_roles_are_strings()
+    {
+        var owner = await SignInAsync(UniqueEmail("explicit-owner"));
+        var workspace = await CreateWorkspaceAsync(owner.SessionToken, "Explicit band");
+        Assert.Equal("Owner", JsonSerializer.SerializeToElement(
+            workspace, new JsonSerializerOptions(JsonSerializerDefaults.Web)).GetProperty("role").GetString());
+        await SelectAsync(owner.SessionToken, workspace.WorkspaceId);
+        var invitation = await SendAsync<IssuedMagicLink>(HttpMethod.Post,
+            $"/v1/workspaces/{workspace.WorkspaceId}/invitations", owner.SessionToken,
+            new { email = UniqueEmail("explicit-member") });
+        var member = await RedeemAsync(invitation.Token);
+        Assert.Null(member.Principal.SelectedWorkspaceId);
+
+        var beforeSelection = await SendRawAsync(HttpMethod.Post,
+            $"/v1/workspaces/{workspace.WorkspaceId}/sessions/EXPLICIT/create", member.SessionToken);
+        Assert.Equal(HttpStatusCode.NotFound, beforeSelection.StatusCode);
+    }
+
+    async Task<RedeemedMagicLink> SignInAsync(string email)
+    {
+        var link = await SendAsync<IssuedMagicLink>(HttpMethod.Post, "/v1/auth/magic-links", null, new { email });
+        return await RedeemAsync(link.Token);
+    }
+
+    Task<RedeemedMagicLink> RedeemAsync(string token) =>
+        SendAsync<RedeemedMagicLink>(HttpMethod.Post, "/v1/auth/magic-links/redeem", null, new { token });
+
+    Task<WorkspaceAccess> CreateWorkspaceAsync(string token, string name) =>
+        SendAsync<WorkspaceAccess>(HttpMethod.Post, "/v1/workspaces", token, new { name });
+
+    async Task SelectAsync(string token, string workspaceId)
+    {
+        var response = await SendRawAsync(HttpMethod.Post, $"/v1/workspaces/{workspaceId}/select", token);
+        response.EnsureSuccessStatusCode();
+    }
+
+    async Task<T> SendAsync<T>(HttpMethod method, string path, string? token, object? body = null)
+    {
+        var response = await SendRawAsync(method, path, token, body);
+        response.EnsureSuccessStatusCode();
+        return (await response.Content.ReadFromJsonAsync<T>())!;
+    }
+
+    async Task<HttpResponseMessage> SendRawAsync(HttpMethod method, string path, string? token, object? body = null)
+    {
+        using var request = new HttpRequestMessage(method, path);
+        if (token is not null) request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        if (body is not null) request.Content = JsonContent.Create(body);
+        return await _client.SendAsync(request);
+    }
+
+    static string UniqueEmail(string prefix) => $"{prefix}-{Guid.NewGuid():N}@example.test";
+}

--- a/Nuotti.Backend.Tests/WorkspacePublicationTests.cs
+++ b/Nuotti.Backend.Tests/WorkspacePublicationTests.cs
@@ -1,0 +1,52 @@
+using Nuotti.Backend.Eventing;
+using Nuotti.Backend.Persistence;
+using Nuotti.Contracts.V1.Enum;
+using Nuotti.Contracts.V1.Event;
+using Nuotti.Contracts.V1.Message;
+
+namespace Nuotti.Backend.Tests;
+
+public sealed class WorkspacePublicationTests
+{
+    [Fact]
+    public async Task Answer_and_relay_messages_keep_their_workspace_routing_envelope()
+    {
+        var bus = new InMemoryEventBus();
+        var routed = new List<SessionMessagePublisher.WorkspacePublication>();
+        using var subscription = bus.Subscribe<SessionMessagePublisher.WorkspacePublication>((message, _) =>
+        {
+            routed.Add(message);
+            return Task.CompletedTask;
+        });
+
+        var answer = new AnswerSubmitted("audience-1", 2)
+        {
+            AudienceId = "audience-1",
+            ChoiceIndex = 2,
+            SessionCode = "SHOW42",
+            CorrelationId = Guid.NewGuid(),
+            CausedByCommandId = Guid.NewGuid()
+        };
+        var play = new PlayTrack("track.wav")
+        {
+            SessionCode = "SHOW42",
+            IssuedByRole = Role.Performer,
+            IssuedById = "performer-1"
+        };
+
+        await SessionMessagePublisher.PublishAsync(bus, answer, workspaceId: "ws_band");
+        await SessionMessagePublisher.PublishAsync(bus, play, workspaceId: "ws_band");
+
+        Assert.Collection(routed,
+            message =>
+            {
+                Assert.Equal(("ws_band", "SHOW42"), (message.WorkspaceId, message.SessionCode));
+                Assert.IsType<AnswerSubmitted>(message.Payload);
+            },
+            message =>
+            {
+                Assert.Equal(("ws_band", "SHOW42"), (message.WorkspaceId, message.SessionCode));
+                Assert.IsType<PlayTrack>(message.Payload);
+            });
+    }
+}

--- a/Nuotti.Backend/Commands/SessionCommandProcessor.cs
+++ b/Nuotti.Backend/Commands/SessionCommandProcessor.cs
@@ -146,7 +146,7 @@ public sealed class SessionCommandProcessor(
             else
             {
                 store.Set(session, seeded);
-                await bus.PublishAsync(createdEvent, ct);
+                await SessionMessagePublisher.PublishAsync(bus, createdEvent, ct, workspaceId);
             }
             Complete(activity, command, seeded);
             return CommandResult.Applied(seeded);
@@ -203,7 +203,7 @@ public sealed class SessionCommandProcessor(
         else
         {
             if (stateChanged) store.Set(session, next);
-            foreach (var publication in publications) await PublishAsync(publication, ct);
+            foreach (var publication in publications) await PublishAsync(publication, ct, workspaceId);
         }
 
         Complete(activity, command, stateChanged ? next : null);
@@ -420,7 +420,8 @@ public sealed class SessionCommandProcessor(
     /// Publishes with the runtime type. IEventBus keys subscribers by TEvent, so passing an
     /// `object` would register everything under `object` and reach no subscriber.
     /// </summary>
-    Task PublishAsync(object evt, CancellationToken ct) => SessionMessagePublisher.PublishAsync(bus, evt, ct);
+    Task PublishAsync(object evt, CancellationToken ct, string workspaceId) =>
+        SessionMessagePublisher.PublishAsync(bus, evt, ct, workspaceId);
 
     void Complete(System.Diagnostics.Activity? activity, CommandBase command, GameStateSnapshot? state)
     {

--- a/Nuotti.Backend/Endpoints/RecoveryEndpoints.cs
+++ b/Nuotti.Backend/Endpoints/RecoveryEndpoints.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using Nuotti.Backend.Persistence;
+using Nuotti.Backend.Workspaces;
 using Nuotti.Contracts.V1;
 using Nuotti.Contracts.V1.Model;
 using Nuotti.Contracts.V1.Protocol;
@@ -16,11 +17,18 @@ public static class RecoveryEndpoints
     public static void MapRecoveryEndpoints(this WebApplication app)
     {
         app.MapGet("/v1/workspaces/{workspaceId}/sessions/{sessionCode}/recovery", async (
+            HttpContext http,
             string workspaceId,
             string sessionCode,
+            IWorkspaceAccessStore accessStore,
             IDurableSessionCommitStore store,
             CancellationToken cancellationToken) =>
         {
+            var selected = await WorkspaceHttpAccess.RequireSelectedAsync(
+                http, accessStore, workspaceId, cancellationToken);
+            if (selected.Principal is null) return Results.Unauthorized();
+            if (selected.Access is null) return Results.NotFound();
+
             var record = await store.LoadAsync(workspaceId, sessionCode, cancellationToken);
             if (record is null) return Results.NotFound();
 

--- a/Nuotti.Backend/Endpoints/WorkspaceEndpoints.cs
+++ b/Nuotti.Backend/Endpoints/WorkspaceEndpoints.cs
@@ -1,0 +1,149 @@
+using Nuotti.Backend.Commands;
+using Nuotti.Backend.Middleware;
+using Nuotti.Backend.Workspaces;
+using Nuotti.Contracts.V1.Enum;
+using Nuotti.Contracts.V1.Message.Phase;
+using System.Net.Mail;
+
+namespace Nuotti.Backend.Endpoints;
+
+public sealed record EmailRequest(string Email);
+public sealed record RedeemLinkRequest(string Token);
+public sealed record CreateWorkspaceRequest(string Name);
+public sealed record InviteMemberRequest(string Email);
+
+public static class WorkspaceEndpoints
+{
+    public static void MapWorkspaceEndpoints(this WebApplication app)
+    {
+        app.MapPost("/v1/auth/magic-links", async (EmailRequest request, IWorkspaceAccessStore store,
+            IWebHostEnvironment environment, IMagicLinkDelivery delivery, CancellationToken ct) =>
+        {
+            if (!ValidEmail(request.Email)) return Invalid("email", "A valid email address is required.");
+            var link = await store.IssueSignInAsync(request.Email, ct);
+            // Local development exposes the token so the journey can run without an email provider.
+            // Deployed environments never disclose credentials in the HTTP response.
+            if (environment.IsDevelopment()) return Results.Ok(link);
+            return await delivery.DeliverAsync(request.Email, link, ct)
+                ? Results.Accepted() : DeliveryUnavailable();
+        });
+
+        app.MapPost("/v1/auth/magic-links/redeem", async (RedeemLinkRequest request, IWorkspaceAccessStore store, CancellationToken ct) =>
+        {
+            var redeemed = await store.RedeemAsync(request.Token, ct);
+            return redeemed is null ? Results.NotFound() : Results.Ok(redeemed);
+        });
+
+        app.MapGet("/v1/workspaces", async (HttpContext http, IWorkspaceAccessStore store, CancellationToken ct) =>
+        {
+            var principal = await WorkspaceHttpAccess.AuthenticateAsync(http, store, ct);
+            return principal is null ? Results.Unauthorized() : Results.Ok(await store.ListAsync(principal, ct));
+        });
+
+        app.MapPost("/v1/workspaces", async (
+            HttpContext http, CreateWorkspaceRequest request, IWorkspaceAccessStore store, CancellationToken ct) =>
+        {
+            var principal = await WorkspaceHttpAccess.AuthenticateAsync(http, store, ct);
+            if (principal is null) return Results.Unauthorized();
+            if (string.IsNullOrWhiteSpace(request.Name) || request.Name.Trim().Length > 120)
+                return Invalid("name", "Workspace name must be between 1 and 120 characters.");
+            return Results.Ok(await store.CreateWorkspaceAsync(principal, request.Name, ct));
+        });
+
+        app.MapPost("/v1/workspaces/{workspaceId}/select", async (
+            HttpContext http, string workspaceId, IWorkspaceAccessStore store, CancellationToken ct) =>
+        {
+            var principal = await WorkspaceHttpAccess.AuthenticateAsync(http, store, ct);
+            if (principal is null) return Results.Unauthorized();
+            var selected = await store.SelectAsync(principal, workspaceId, ct);
+            return selected is null ? Results.NotFound() : Results.Ok(selected);
+        });
+
+        app.MapPost("/v1/workspaces/{workspaceId}/invitations", async (
+            HttpContext http, string workspaceId, InviteMemberRequest request,
+            IWorkspaceAccessStore store, IWebHostEnvironment environment, IMagicLinkDelivery delivery,
+            CancellationToken ct) =>
+        {
+            var selected = await WorkspaceHttpAccess.RequireSelectedAsync(http, store, workspaceId, ct);
+            if (selected.Principal is null) return Results.Unauthorized();
+            if (selected.Access?.Role != WorkspaceRole.Owner) return Results.NotFound();
+            if (!ValidEmail(request.Email)) return Invalid("email", "A valid email address is required.");
+            var link = await store.InviteAsync(selected.Principal, workspaceId, request.Email, ct);
+            if (link is null) return Results.NotFound();
+            if (environment.IsDevelopment()) return Results.Ok(link);
+            return await delivery.DeliverAsync(request.Email, link, ct)
+                ? Results.Accepted() : DeliveryUnavailable();
+        });
+
+        app.MapGet("/v1/workspaces/{workspaceId}/members", async (
+            HttpContext http, string workspaceId, IWorkspaceAccessStore store, CancellationToken ct) =>
+        {
+            var selected = await WorkspaceHttpAccess.RequireSelectedAsync(http, store, workspaceId, ct);
+            if (selected.Principal is null) return Results.Unauthorized();
+            if (selected.Access?.Role != WorkspaceRole.Owner) return Results.NotFound();
+            return Results.Ok(await store.MembersAsync(selected.Principal, workspaceId, ct));
+        });
+
+        app.MapDelete("/v1/workspaces/{workspaceId}/members/{memberUserId}", async (
+            HttpContext http, string workspaceId, string memberUserId,
+            IWorkspaceAccessStore store, CancellationToken ct) =>
+        {
+            var selected = await WorkspaceHttpAccess.RequireSelectedAsync(http, store, workspaceId, ct);
+            if (selected.Principal is null) return Results.Unauthorized();
+            if (selected.Access?.Role != WorkspaceRole.Owner) return Results.NotFound();
+            return await store.RevokeAsync(selected.Principal, workspaceId, memberUserId, ct)
+                ? Results.NoContent() : Results.NotFound();
+        });
+
+        app.MapPost("/v1/workspaces/{workspaceId}/sessions/{sessionCode}/create", async (
+            HttpContext http, string workspaceId, string sessionCode,
+            IWorkspaceAccessStore store, ISessionCommandProcessor processor, CancellationToken ct) =>
+        {
+            var selected = await WorkspaceHttpAccess.RequireSelectedAsync(http, store, workspaceId, ct);
+            if (selected.Principal is null) return Results.Unauthorized();
+            if (selected.Access is null) return Results.NotFound();
+            var command = new CreateSession(sessionCode)
+            {
+                SessionCode = sessionCode,
+                IssuedByRole = Role.Performer,
+                IssuedById = selected.Principal.UserId
+            };
+            return (await processor.ApplyAsync(sessionCode,
+                Actor.Verified(Role.Performer, selected.Principal.UserId), command,
+                CorrelationIdMiddleware.GetCorrelationId(http), ct, workspaceId)).ToHttpResult();
+        });
+
+        app.MapPost("/v1/workspaces/{workspaceId}/sessions/{sessionCode}/start", async (
+            HttpContext http, string workspaceId, string sessionCode,
+            IWorkspaceAccessStore store, ISessionCommandProcessor processor, CancellationToken ct) =>
+        {
+            var selected = await WorkspaceHttpAccess.RequireSelectedAsync(http, store, workspaceId, ct);
+            if (selected.Principal is null) return Results.Unauthorized();
+            if (selected.Access is null) return Results.NotFound();
+            var command = new StartGame
+            {
+                SessionCode = sessionCode,
+                IssuedByRole = Role.Performer,
+                IssuedById = selected.Principal.UserId
+            };
+            return (await processor.ApplyAsync(sessionCode,
+                Actor.Verified(Role.Performer, selected.Principal.UserId), command,
+                CorrelationIdMiddleware.GetCorrelationId(http), ct, workspaceId)).ToHttpResult();
+        });
+    }
+
+    static bool ValidEmail(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value) || value.Length > 320) return false;
+        try { return new MailAddress(value).Address.Equals(value.Trim(), StringComparison.OrdinalIgnoreCase); }
+        catch (FormatException) { return false; }
+    }
+
+    static IResult Invalid(string field, string message) => Results.ValidationProblem(
+        new Dictionary<string, string[]> { [field] = [message] });
+
+    static IResult DeliveryUnavailable() => Results.Problem(
+        title: "Magic-link delivery unavailable",
+        detail: "The sign-in email could not be sent. Try again later.",
+        statusCode: StatusCodes.Status503ServiceUnavailable);
+}

--- a/Nuotti.Backend/Eventing/Subscribers/HubBroadcastSubscriber.cs
+++ b/Nuotti.Backend/Eventing/Subscribers/HubBroadcastSubscriber.cs
@@ -2,6 +2,8 @@ using Microsoft.AspNetCore.SignalR;
 using Nuotti.Contracts.V1.Event;
 using Nuotti.Contracts.V1.Eventing;
 using Nuotti.Contracts.V1.Message;
+using Nuotti.Backend.Workspaces;
+using Nuotti.Backend.Persistence;
 namespace Nuotti.Backend.Eventing.Subscribers;
 
 /// <summary>
@@ -12,15 +14,20 @@ public sealed class HubBroadcastSubscriber : IDisposable
 {
     readonly List<IDisposable> _subs = [];
     readonly IHubContext<QuizHub> _hub;
+    readonly IHubContext<WorkspaceHub> _workspaceHub;
 
-    public HubBroadcastSubscriber(IEventBus bus, IHubContext<QuizHub> hub)
+    public HubBroadcastSubscriber(IEventBus bus, IHubContext<QuizHub> hub, IHubContext<WorkspaceHub> workspaceHub)
     {
         _hub = hub;
+        _workspaceHub = workspaceHub;
 
         // The snapshot push. Clients receive the bare snapshot, not the event envelope, so the
         // payload is unchanged from when endpoints sent this themselves.
         _subs.Add(bus.Subscribe<GameStateChanged>((evt, ct) =>
             Send(evt.SessionCode, "GameStateChanged", evt.Snapshot, ct)));
+
+        _subs.Add(bus.Subscribe<SessionMessagePublisher.WorkspacePublication>((publication, ct) =>
+            SendWorkspace(publication, ct)));
 
         // Answers carry no snapshot push: one per answer would be quadratic in audience size.
         // Clients apply GameReducer to this event to keep their tallies live.
@@ -38,6 +45,22 @@ public sealed class HubBroadcastSubscriber : IDisposable
 
     Task Send(string session, string method, object payload, CancellationToken ct)
         => _hub.Clients.Group(session).SendAsync(method, payload, ct);
+
+    Task SendWorkspace(SessionMessagePublisher.WorkspacePublication publication, CancellationToken ct)
+    {
+        var (method, payload) = publication.Payload switch
+        {
+            GameStateChanged changed => ("GameStateChanged", (object)changed.Snapshot),
+            AnswerSubmitted answer => ("AnswerSubmitted", answer),
+            QuestionPushed question => ("QuestionPushed", question),
+            PlayTrack play => ("PlayTrack", play),
+            StopTrack stop => ("Stop", stop),
+            _ => (string.Empty, publication.Payload)
+        };
+        return method.Length == 0 ? Task.CompletedTask : _workspaceHub.Clients
+            .Group(WorkspaceHub.GroupName(publication.WorkspaceId, publication.SessionCode))
+            .SendAsync(method, payload, ct);
+    }
 
     public void Dispose()
     {

--- a/Nuotti.Backend/Persistence/DurableOutboxDispatcher.cs
+++ b/Nuotti.Backend/Persistence/DurableOutboxDispatcher.cs
@@ -17,7 +17,8 @@ public sealed class DurableOutboxDispatcher(
             try
             {
                 var payload = SessionMessagePublisher.DeserializeDurable(message.MessageType, message.Payload);
-                await SessionMessagePublisher.PublishAsync(bus, payload, cancellationToken);
+                await SessionMessagePublisher.PublishAsync(
+                    bus, payload, cancellationToken, message.WorkspaceId);
                 await store.MarkDeliveredAsync(message, _owner, cancellationToken);
                 delivered++;
             }

--- a/Nuotti.Backend/Persistence/SessionMessagePublisher.cs
+++ b/Nuotti.Backend/Persistence/SessionMessagePublisher.cs
@@ -9,6 +9,7 @@ namespace Nuotti.Backend.Persistence;
 /// <summary>Single registry for Session message serialization and runtime-type publication.</summary>
 public static class SessionMessagePublisher
 {
+    public sealed record WorkspacePublication(string WorkspaceId, string SessionCode, object Payload);
     sealed record Entry(Type Type, bool Durable, Func<IEventBus, object, CancellationToken, Task> Publish);
 
     static Entry Of<T>(bool durable = true) => new(typeof(T), durable,
@@ -24,10 +25,23 @@ public static class SessionMessagePublisher
     static readonly IReadOnlyDictionary<Type, Entry> ByType = Entries.ToDictionary(entry => entry.Type);
     static readonly IReadOnlyDictionary<string, Entry> ByName = Entries.ToDictionary(entry => entry.Type.Name, StringComparer.Ordinal);
 
-    public static Task PublishAsync(IEventBus bus, object message, CancellationToken cancellationToken = default)
-        => ByType.TryGetValue(message.GetType(), out var entry)
-            ? entry.Publish(bus, message, cancellationToken)
-            : throw new NotSupportedException($"Message type '{message.GetType().Name}' is not publishable.");
+    public static async Task PublishAsync(IEventBus bus, object message,
+        CancellationToken cancellationToken = default, string? workspaceId = null)
+    {
+        if (!ByType.TryGetValue(message.GetType(), out var entry))
+            throw new NotSupportedException($"Message type '{message.GetType().Name}' is not publishable.");
+        await entry.Publish(bus, message, cancellationToken);
+        if (workspaceId is not null && workspaceId != "legacy")
+        {
+            var sessionCode = message switch
+            {
+                EventBase evt => evt.SessionCode,
+                CommandBase command => command.SessionCode,
+                _ => throw new NotSupportedException("Workspace publication requires a Session message.")
+            };
+            await bus.PublishAsync(new WorkspacePublication(workspaceId, sessionCode, message), cancellationToken);
+        }
+    }
 
     public static (string Type, string Payload) SerializeDurable(object message)
     {

--- a/Nuotti.Backend/Program.cs
+++ b/Nuotti.Backend/Program.cs
@@ -10,6 +10,7 @@ using Nuotti.Backend.Metrics;
 using Nuotti.Backend.Models;
 using Nuotti.Backend.Persistence;
 using Nuotti.Backend.Sessions;
+using Nuotti.Backend.Workspaces;
 using Nuotti.Contracts.V1.Eventing;
 using Microsoft.Extensions.Options;
 using Serilog;
@@ -97,15 +98,25 @@ builder.Services.AddCors(options =>
 });
 
 builder.Services.AddSingleton<ILogStreamer, LogStreamer>();
+builder.Services.AddHttpClient(nameof(HttpMagicLinkDelivery));
+builder.Services.AddSingleton<IMagicLinkDelivery, HttpMagicLinkDelivery>();
 builder.Services.AddSingleton<ISessionStore, InMemorySessionStore>();
 builder.Services.AddSingleton<IGameStateStore, InMemoryGameStateStore>();
 builder.Services.AddSingleton<IIdempotencyStore, InMemoryIdempotencyStore>();
 if (!string.IsNullOrWhiteSpace(databaseConnection))
 {
+    builder.Services.AddSingleton<IWorkspaceAccessStore, PostgresWorkspaceAccessStore>();
     builder.Services.AddSingleton<IDurableSessionCommitStore, PostgresDurableSessionCommitStore>();
-    builder.Services.AddSingleton<DurableOutboxDispatcher>();
-    builder.Services.AddHostedService<DurableOutboxWorker>();
 }
+else
+{
+    // Keep the same durable command/recovery path available during local development and
+    // isolated tests. Production replaces only the adapter, not the authorization boundary.
+    builder.Services.AddSingleton<IWorkspaceAccessStore, InMemoryWorkspaceAccessStore>();
+    builder.Services.AddSingleton<IDurableSessionCommitStore, InMemoryDurableSessionCommitStore>();
+}
+builder.Services.AddSingleton<DurableOutboxDispatcher>();
+builder.Services.AddHostedService<DurableOutboxWorker>();
 
 // Metrics
 builder.Services.AddSingleton<BackendMetrics>();
@@ -153,23 +164,27 @@ var app = builder.Build();
 app.UseCors("NuottiCors");
 app.UseMiddleware<Nuotti.Backend.Middleware.CorrelationIdMiddleware>();
 app.UseMiddleware<ProblemHandlingMiddleware>();
-app.MapPhaseEndpoints();
-
-app.MapHub<QuizHub>("/hub").RequireCors("NuottiCors");
 if (app.Environment.IsDevelopment())
 {
+    // Compatibility surfaces predate Workspace authentication and are deliberately local-only.
+    // Deployed environments expose only Workspace-scoped mutation/recovery routes.
+    app.MapPhaseEndpoints();
+    app.MapApiEndpoints();
+    app.MapHub<QuizHub>("/hub").RequireCors("NuottiCors");
     app.MapHub<LogHub>("/log").RequireCors("NuottiCors");
 }
-app.MapApiEndpoints();
+app.MapHub<WorkspaceHub>(app.Environment.IsDevelopment() ? "/workspace-hub" : "/hub")
+    .RequireCors("NuottiCors");
 app.MapHealthEndpoints();
-app.MapStatusEndpoints();
+if (app.Environment.IsDevelopment()) app.MapStatusEndpoints();
 app.MapMetricsEndpoints();
 app.MapAboutEndpoints();
 app.MapTimeEndpoints();
-app.MapDiagnosticsEndpoints();
+if (app.Environment.IsDevelopment()) app.MapDiagnosticsEndpoints();
 app.MapDevEndpoints();
 app.MapInfrastructureProofEndpoints();
-if (!string.IsNullOrWhiteSpace(databaseConnection)) app.MapRecoveryEndpoints();
+app.MapWorkspaceEndpoints();
+app.MapRecoveryEndpoints();
 app.MapNuottiEndpoints("Nuotti.Backend");
 
 // Force creation of subscribers so they can attach to the bus

--- a/Nuotti.Backend/Workspaces/InMemoryWorkspaceAccessStore.cs
+++ b/Nuotti.Backend/Workspaces/InMemoryWorkspaceAccessStore.cs
@@ -1,0 +1,160 @@
+namespace Nuotti.Backend.Workspaces;
+
+public sealed class InMemoryWorkspaceAccessStore(TimeProvider? timeProvider = null) : IWorkspaceAccessStore
+{
+    sealed record User(string Id, string Email);
+    sealed record Link(string Email, string? WorkspaceId, DateTimeOffset ExpiresAt, bool Used = false);
+    sealed record Session(string UserId, string? SelectedWorkspaceId);
+    sealed record Workspace(string Id, string Name, Dictionary<string, WorkspaceRole> Memberships);
+
+    readonly object _gate = new();
+    readonly TimeProvider _time = timeProvider ?? TimeProvider.System;
+    readonly Dictionary<string, User> _usersByEmail = new(StringComparer.OrdinalIgnoreCase);
+    readonly Dictionary<string, User> _usersById = new(StringComparer.Ordinal);
+    readonly Dictionary<string, Link> _links = new(StringComparer.Ordinal);
+    readonly Dictionary<string, Session> _sessions = new(StringComparer.Ordinal);
+    readonly Dictionary<string, Workspace> _workspaces = new(StringComparer.Ordinal);
+
+    public Task<IssuedMagicLink> IssueSignInAsync(string email, CancellationToken cancellationToken = default)
+        => Task.FromResult(Issue(WorkspaceTokens.NormalizeEmail(email), workspaceId: null));
+
+    public Task<RedeemedMagicLink?> RedeemAsync(string token, CancellationToken cancellationToken = default)
+    {
+        lock (_gate)
+        {
+            var hash = WorkspaceTokens.Hash(token);
+            if (!_links.TryGetValue(hash, out var link) || link.Used || link.ExpiresAt <= _time.GetUtcNow())
+                return Task.FromResult<RedeemedMagicLink?>(null);
+            _links[hash] = link with { Used = true };
+            var user = GetOrCreateUser(link.Email);
+            if (link.WorkspaceId is not null && _workspaces.TryGetValue(link.WorkspaceId, out var workspace))
+                workspace.Memberships.TryAdd(user.Id, WorkspaceRole.Member);
+            var rawSession = WorkspaceTokens.New();
+            var sessionId = WorkspaceTokens.Hash(rawSession);
+            // Redeeming membership never changes active context; selection is explicit.
+            _sessions[sessionId] = new Session(user.Id, SelectedWorkspaceId: null);
+            return Task.FromResult<RedeemedMagicLink?>(new(
+                rawSession, new WorkspacePrincipal(user.Id, user.Email, null, sessionId)));
+        }
+    }
+
+    public Task<WorkspacePrincipal?> AuthenticateAsync(string sessionToken, CancellationToken cancellationToken = default)
+    {
+        lock (_gate)
+        {
+            if (!_sessions.TryGetValue(WorkspaceTokens.Hash(sessionToken), out var session)
+                || !_usersById.TryGetValue(session.UserId, out var user))
+                return Task.FromResult<WorkspacePrincipal?>(null);
+            return Task.FromResult<WorkspacePrincipal?>(new(user.Id, user.Email, session.SelectedWorkspaceId, WorkspaceTokens.Hash(sessionToken)));
+        }
+    }
+
+    public Task<WorkspaceAccess> CreateWorkspaceAsync(WorkspacePrincipal principal, string name, CancellationToken cancellationToken = default)
+    {
+        var normalizedName = string.IsNullOrWhiteSpace(name) ? throw new ArgumentException("Workspace name is required.", nameof(name)) : name.Trim();
+        lock (_gate)
+        {
+            var id = $"ws_{Guid.NewGuid():N}";
+            _workspaces[id] = new Workspace(id, normalizedName, new Dictionary<string, WorkspaceRole>
+            {
+                [principal.UserId] = WorkspaceRole.Owner
+            });
+            return Task.FromResult(new WorkspaceAccess(id, normalizedName, WorkspaceRole.Owner));
+        }
+    }
+
+    public Task<IReadOnlyList<WorkspaceAccess>> ListAsync(WorkspacePrincipal principal, CancellationToken cancellationToken = default)
+    {
+        lock (_gate)
+            return Task.FromResult<IReadOnlyList<WorkspaceAccess>>(_workspaces.Values
+                .Where(workspace => workspace.Memberships.TryGetValue(principal.UserId, out _))
+                .Select(workspace => new WorkspaceAccess(workspace.Id, workspace.Name, workspace.Memberships[principal.UserId]))
+                .OrderBy(workspace => workspace.Name, StringComparer.OrdinalIgnoreCase)
+                .ToArray());
+    }
+
+    public Task<WorkspacePrincipal?> SelectAsync(WorkspacePrincipal principal, string workspaceId, CancellationToken cancellationToken = default)
+    {
+        lock (_gate)
+        {
+            if (!_workspaces.TryGetValue(workspaceId, out var workspace)
+                || !workspace.Memberships.ContainsKey(principal.UserId))
+                return Task.FromResult<WorkspacePrincipal?>(null);
+            var key = principal.AuthenticationSessionId;
+            if (key is null) return Task.FromResult<WorkspacePrincipal?>(null);
+            _sessions[key] = _sessions[key] with { SelectedWorkspaceId = workspaceId };
+            return Task.FromResult<WorkspacePrincipal?>(principal with { SelectedWorkspaceId = workspaceId });
+        }
+    }
+
+    public Task<WorkspaceAccess?> GetAccessAsync(WorkspacePrincipal principal, string workspaceId, CancellationToken cancellationToken = default)
+    {
+        lock (_gate)
+        {
+            if (!_workspaces.TryGetValue(workspaceId, out var workspace)
+                || !workspace.Memberships.TryGetValue(principal.UserId, out var role))
+                return Task.FromResult<WorkspaceAccess?>(null);
+            return Task.FromResult<WorkspaceAccess?>(new(workspace.Id, workspace.Name, role));
+        }
+    }
+
+    public Task<IssuedMagicLink?> InviteAsync(WorkspacePrincipal owner, string workspaceId, string email, CancellationToken cancellationToken = default)
+    {
+        lock (_gate)
+        {
+            if (!IsOwner(owner.UserId, workspaceId)) return Task.FromResult<IssuedMagicLink?>(null);
+            return Task.FromResult<IssuedMagicLink?>(Issue(WorkspaceTokens.NormalizeEmail(email), workspaceId));
+        }
+    }
+
+    public Task<bool> RevokeAsync(WorkspacePrincipal owner, string workspaceId, string memberUserId, CancellationToken cancellationToken = default)
+    {
+        lock (_gate)
+        {
+            if (!IsOwner(owner.UserId, workspaceId) || owner.UserId == memberUserId
+                || !_workspaces[workspaceId].Memberships.TryGetValue(memberUserId, out var role)
+                || role == WorkspaceRole.Owner) return Task.FromResult(false);
+            _workspaces[workspaceId].Memberships.Remove(memberUserId);
+            foreach (var key in _sessions.Where(pair => pair.Value.UserId == memberUserId
+                    && pair.Value.SelectedWorkspaceId == workspaceId).Select(pair => pair.Key).ToArray())
+                _sessions[key] = _sessions[key] with { SelectedWorkspaceId = null };
+            return Task.FromResult(true);
+        }
+    }
+
+    public Task<IReadOnlyList<WorkspaceMember>?> MembersAsync(WorkspacePrincipal principal, string workspaceId, CancellationToken cancellationToken = default)
+    {
+        lock (_gate)
+        {
+            if (!_workspaces.TryGetValue(workspaceId, out var workspace)
+                || !workspace.Memberships.ContainsKey(principal.UserId))
+                return Task.FromResult<IReadOnlyList<WorkspaceMember>?>(null);
+            return Task.FromResult<IReadOnlyList<WorkspaceMember>?>(workspace.Memberships
+                .Select(pair => new WorkspaceMember(pair.Key, _usersById[pair.Key].Email, pair.Value)).ToArray());
+        }
+    }
+
+    IssuedMagicLink Issue(string email, string? workspaceId)
+    {
+        lock (_gate)
+        {
+            var raw = WorkspaceTokens.New();
+            var expires = _time.GetUtcNow().AddMinutes(15);
+            _links[WorkspaceTokens.Hash(raw)] = new Link(email, workspaceId, expires);
+            return new IssuedMagicLink(raw, expires);
+        }
+    }
+
+    User GetOrCreateUser(string email)
+    {
+        if (_usersByEmail.TryGetValue(email, out var existing)) return existing;
+        var user = new User($"usr_{Guid.NewGuid():N}", email);
+        _usersByEmail[email] = user;
+        _usersById[user.Id] = user;
+        return user;
+    }
+
+    bool IsOwner(string userId, string workspaceId) => _workspaces.TryGetValue(workspaceId, out var workspace)
+        && workspace.Memberships.GetValueOrDefault(userId) == WorkspaceRole.Owner;
+
+}

--- a/Nuotti.Backend/Workspaces/MagicLinkDelivery.cs
+++ b/Nuotti.Backend/Workspaces/MagicLinkDelivery.cs
@@ -1,0 +1,39 @@
+using System.Net.Http.Json;
+
+namespace Nuotti.Backend.Workspaces;
+
+public interface IMagicLinkDelivery
+{
+    Task<bool> DeliverAsync(string email, IssuedMagicLink link, CancellationToken cancellationToken = default);
+}
+
+/// <summary>Delivers credentials to a configured internal email-service webhook.</summary>
+public sealed class HttpMagicLinkDelivery(
+    IHttpClientFactory clients,
+    IConfiguration configuration,
+    ILogger<HttpMagicLinkDelivery> logger) : IMagicLinkDelivery
+{
+    public async Task<bool> DeliverAsync(string email, IssuedMagicLink link, CancellationToken cancellationToken = default)
+    {
+        var destination = configuration["Nuotti:MagicLinkDeliveryUrl"];
+        if (!Uri.TryCreate(destination, UriKind.Absolute, out var uri))
+        {
+            logger.LogError("Magic-link delivery is not configured");
+            return false;
+        }
+
+        try
+        {
+            using var response = await clients.CreateClient(nameof(HttpMagicLinkDelivery))
+                .PostAsJsonAsync(uri, new { email, link.Token, link.ExpiresAt }, cancellationToken);
+            if (response.IsSuccessStatusCode) return true;
+            logger.LogError("Magic-link delivery failed with status {StatusCode}", response.StatusCode);
+            return false;
+        }
+        catch (System.Exception exception) when (exception is not OperationCanceledException)
+        {
+            logger.LogError(exception, "Magic-link delivery failed");
+            return false;
+        }
+    }
+}

--- a/Nuotti.Backend/Workspaces/PostgresWorkspaceAccessStore.cs
+++ b/Nuotti.Backend/Workspaces/PostgresWorkspaceAccessStore.cs
@@ -1,0 +1,198 @@
+using System.Text.Json;
+using Npgsql;
+
+namespace Nuotti.Backend.Workspaces;
+
+/// <summary>
+/// Durable Workspace security boundary. The MVP keeps the small identity graph in one locked
+/// document so every invitation, redemption, selection, and revocation is atomic across replicas.
+/// The interface allows this representation to be normalized later without changing callers.
+/// </summary>
+public sealed class PostgresWorkspaceAccessStore(NpgsqlDataSource dataSource, TimeProvider? timeProvider = null)
+    : IWorkspaceAccessStore
+{
+    readonly SemaphoreSlim _initializeGate = new(1, 1);
+    readonly TimeProvider _time = timeProvider ?? TimeProvider.System;
+    volatile bool _initialized;
+
+    public Task<IssuedMagicLink> IssueSignInAsync(string email, CancellationToken cancellationToken = default) =>
+        MutateAsync(state => Issue(state, WorkspaceTokens.NormalizeEmail(email), null), cancellationToken);
+
+    public Task<RedeemedMagicLink?> RedeemAsync(string token, CancellationToken cancellationToken = default) =>
+        MutateAsync<RedeemedMagicLink?>(state =>
+        {
+            var hash = WorkspaceTokens.Hash(token);
+            if (!state.Links.TryGetValue(hash, out var link) || link.Used || link.ExpiresAt <= _time.GetUtcNow())
+                return null;
+            link.Used = true;
+            var user = GetOrCreateUser(state, link.Email);
+            if (link.WorkspaceId is not null && state.Workspaces.TryGetValue(link.WorkspaceId, out var workspace))
+                workspace.Memberships.TryAdd(user.Id, WorkspaceRole.Member);
+            var rawSession = WorkspaceTokens.New();
+            var sessionId = WorkspaceTokens.Hash(rawSession);
+            // Membership and active context are separate decisions. Redemption never selects.
+            state.Sessions[sessionId] = new WorkspaceSessionState { UserId = user.Id };
+            return new RedeemedMagicLink(rawSession,
+                new WorkspacePrincipal(user.Id, user.Email, null, sessionId));
+        }, cancellationToken);
+
+    public Task<WorkspacePrincipal?> AuthenticateAsync(string sessionToken, CancellationToken cancellationToken = default) =>
+        ReadAsync<WorkspacePrincipal?>(state =>
+        {
+            var sessionId = WorkspaceTokens.Hash(sessionToken);
+            return state.Sessions.TryGetValue(sessionId, out var session)
+                   && state.UsersById.TryGetValue(session.UserId, out var user)
+                ? new WorkspacePrincipal(user.Id, user.Email, session.SelectedWorkspaceId, sessionId)
+                : null;
+        }, cancellationToken);
+
+    public Task<WorkspaceAccess> CreateWorkspaceAsync(WorkspacePrincipal principal, string name, CancellationToken cancellationToken = default) =>
+        MutateAsync(state =>
+        {
+            var id = $"ws_{Guid.NewGuid():N}";
+            var workspace = new WorkspaceDocument { Id = id, Name = name.Trim() };
+            workspace.Memberships[principal.UserId] = WorkspaceRole.Owner;
+            state.Workspaces[id] = workspace;
+            return new WorkspaceAccess(id, workspace.Name, WorkspaceRole.Owner);
+        }, cancellationToken);
+
+    public Task<IReadOnlyList<WorkspaceAccess>> ListAsync(WorkspacePrincipal principal, CancellationToken cancellationToken = default) =>
+        ReadAsync<IReadOnlyList<WorkspaceAccess>>(state => state.Workspaces.Values
+            .Where(workspace => workspace.Memberships.ContainsKey(principal.UserId))
+            .Select(workspace => new WorkspaceAccess(workspace.Id, workspace.Name, workspace.Memberships[principal.UserId]))
+            .OrderBy(workspace => workspace.Name, StringComparer.OrdinalIgnoreCase).ToArray(), cancellationToken);
+
+    public Task<WorkspacePrincipal?> SelectAsync(WorkspacePrincipal principal, string workspaceId, CancellationToken cancellationToken = default) =>
+        MutateAsync<WorkspacePrincipal?>(state =>
+        {
+            if (principal.AuthenticationSessionId is null
+                || !state.Sessions.TryGetValue(principal.AuthenticationSessionId, out var session)
+                || !state.Workspaces.TryGetValue(workspaceId, out var workspace)
+                || !workspace.Memberships.ContainsKey(principal.UserId)) return null;
+            session.SelectedWorkspaceId = workspaceId;
+            return principal with { SelectedWorkspaceId = workspaceId };
+        }, cancellationToken);
+
+    public Task<WorkspaceAccess?> GetAccessAsync(WorkspacePrincipal principal, string workspaceId, CancellationToken cancellationToken = default) =>
+        ReadAsync<WorkspaceAccess?>(state => state.Workspaces.TryGetValue(workspaceId, out var workspace)
+            && workspace.Memberships.TryGetValue(principal.UserId, out var role)
+                ? new WorkspaceAccess(workspace.Id, workspace.Name, role) : null, cancellationToken);
+
+    public Task<IssuedMagicLink?> InviteAsync(WorkspacePrincipal owner, string workspaceId, string email, CancellationToken cancellationToken = default) =>
+        MutateAsync<IssuedMagicLink?>(state => IsOwner(state, owner.UserId, workspaceId)
+            ? Issue(state, WorkspaceTokens.NormalizeEmail(email), workspaceId) : null, cancellationToken);
+
+    public Task<bool> RevokeAsync(WorkspacePrincipal owner, string workspaceId, string memberUserId, CancellationToken cancellationToken = default) =>
+        MutateAsync(state =>
+        {
+            if (!IsOwner(state, owner.UserId, workspaceId) || owner.UserId == memberUserId
+                || !state.Workspaces[workspaceId].Memberships.TryGetValue(memberUserId, out var role)
+                || role == WorkspaceRole.Owner) return false;
+            state.Workspaces[workspaceId].Memberships.Remove(memberUserId);
+            foreach (var session in state.Sessions.Values.Where(session => session.UserId == memberUserId
+                         && session.SelectedWorkspaceId == workspaceId)) session.SelectedWorkspaceId = null;
+            return true;
+        }, cancellationToken);
+
+    public Task<IReadOnlyList<WorkspaceMember>?> MembersAsync(WorkspacePrincipal principal, string workspaceId, CancellationToken cancellationToken = default) =>
+        ReadAsync<IReadOnlyList<WorkspaceMember>?>(state =>
+        {
+            if (!state.Workspaces.TryGetValue(workspaceId, out var workspace)
+                || !workspace.Memberships.ContainsKey(principal.UserId)) return null;
+            return workspace.Memberships.Select(member => new WorkspaceMember(
+                member.Key, state.UsersById[member.Key].Email, member.Value)).ToArray();
+        }, cancellationToken);
+
+    IssuedMagicLink Issue(WorkspaceAccessDocument state, string email, string? workspaceId)
+    {
+        var raw = WorkspaceTokens.New();
+        var expires = _time.GetUtcNow().AddMinutes(15);
+        state.Links[WorkspaceTokens.Hash(raw)] = new WorkspaceLinkState
+            { Email = email, WorkspaceId = workspaceId, ExpiresAt = expires };
+        return new IssuedMagicLink(raw, expires);
+    }
+
+    static WorkspaceUserState GetOrCreateUser(WorkspaceAccessDocument state, string email)
+    {
+        if (state.UserIdsByEmail.TryGetValue(email, out var id)) return state.UsersById[id];
+        var user = new WorkspaceUserState { Id = $"usr_{Guid.NewGuid():N}", Email = email };
+        state.UserIdsByEmail[email] = user.Id;
+        state.UsersById[user.Id] = user;
+        return user;
+    }
+
+    static bool IsOwner(WorkspaceAccessDocument state, string userId, string workspaceId) =>
+        state.Workspaces.TryGetValue(workspaceId, out var workspace)
+        && workspace.Memberships.GetValueOrDefault(userId) == WorkspaceRole.Owner;
+
+    async Task<T> ReadAsync<T>(Func<WorkspaceAccessDocument, T> read, CancellationToken ct)
+    {
+        await EnsureSchemaAsync(ct);
+        await using var command = dataSource.CreateCommand(
+            "SELECT state::text FROM nuotti_workspace_access WHERE singleton=true");
+        return read(JsonSerializer.Deserialize<WorkspaceAccessDocument>((string)(await command.ExecuteScalarAsync(ct))!)!);
+    }
+
+    async Task<T> MutateAsync<T>(Func<WorkspaceAccessDocument, T> mutate, CancellationToken ct)
+    {
+        await EnsureSchemaAsync(ct);
+        await using var connection = await dataSource.OpenConnectionAsync(ct);
+        await using var transaction = await connection.BeginTransactionAsync(ct);
+        await using var load = new NpgsqlCommand(
+            "SELECT state::text FROM nuotti_workspace_access WHERE singleton=true FOR UPDATE", connection, transaction);
+        var state = JsonSerializer.Deserialize<WorkspaceAccessDocument>((string)(await load.ExecuteScalarAsync(ct))!)!;
+        var result = mutate(state);
+        await using var save = new NpgsqlCommand(
+            "UPDATE nuotti_workspace_access SET state=$1::jsonb, updated_at=now() WHERE singleton=true", connection, transaction);
+        save.Parameters.AddWithValue(JsonSerializer.Serialize(state));
+        await save.ExecuteNonQueryAsync(ct);
+        await transaction.CommitAsync(ct);
+        return result;
+    }
+
+    async Task EnsureSchemaAsync(CancellationToken ct)
+    {
+        if (_initialized) return;
+        await _initializeGate.WaitAsync(ct);
+        try
+        {
+            if (_initialized) return;
+            await using var command = dataSource.CreateCommand("""
+                CREATE TABLE IF NOT EXISTS nuotti_workspace_access (
+                    singleton boolean PRIMARY KEY DEFAULT true CHECK (singleton),
+                    state jsonb NOT NULL,
+                    updated_at timestamptz NOT NULL DEFAULT now());
+                INSERT INTO nuotti_workspace_access(singleton, state)
+                VALUES (true, '{"usersById":{},"userIdsByEmail":{},"links":{},"sessions":{},"workspaces":{}}'::jsonb)
+                ON CONFLICT (singleton) DO NOTHING;
+                """);
+            await command.ExecuteNonQueryAsync(ct);
+            _initialized = true;
+        }
+        finally { _initializeGate.Release(); }
+    }
+}
+
+internal sealed class WorkspaceAccessDocument
+{
+    public Dictionary<string, WorkspaceUserState> UsersById { get; set; } = [];
+    public Dictionary<string, string> UserIdsByEmail { get; set; } = [];
+    public Dictionary<string, WorkspaceLinkState> Links { get; set; } = [];
+    public Dictionary<string, WorkspaceSessionState> Sessions { get; set; } = [];
+    public Dictionary<string, WorkspaceDocument> Workspaces { get; set; } = [];
+}
+internal sealed class WorkspaceUserState { public string Id { get; set; } = ""; public string Email { get; set; } = ""; }
+internal sealed class WorkspaceLinkState
+{
+    public string Email { get; set; } = "";
+    public string? WorkspaceId { get; set; }
+    public DateTimeOffset ExpiresAt { get; set; }
+    public bool Used { get; set; }
+}
+internal sealed class WorkspaceSessionState { public string UserId { get; set; } = ""; public string? SelectedWorkspaceId { get; set; } }
+internal sealed class WorkspaceDocument
+{
+    public string Id { get; set; } = "";
+    public string Name { get; set; } = "";
+    public Dictionary<string, WorkspaceRole> Memberships { get; set; } = [];
+}

--- a/Nuotti.Backend/Workspaces/WorkspaceAccess.cs
+++ b/Nuotti.Backend/Workspaces/WorkspaceAccess.cs
@@ -1,0 +1,41 @@
+using System.Text.Json.Serialization;
+
+namespace Nuotti.Backend.Workspaces;
+
+[JsonConverter(typeof(JsonStringEnumConverter<WorkspaceRole>))]
+public enum WorkspaceRole { Owner, Member }
+
+public sealed record WorkspacePrincipal(
+    string UserId,
+    string Email,
+    string? SelectedWorkspaceId,
+    [property: JsonIgnore] string? AuthenticationSessionId = null);
+public sealed record WorkspaceAccess(string WorkspaceId, string Name, WorkspaceRole Role);
+public sealed record WorkspaceMember(string UserId, string Email, WorkspaceRole Role);
+public sealed record IssuedMagicLink(string Token, DateTimeOffset ExpiresAt);
+public sealed record RedeemedMagicLink(string SessionToken, WorkspacePrincipal Principal);
+
+public interface IWorkspaceAccessStore
+{
+    Task<IssuedMagicLink> IssueSignInAsync(string email, CancellationToken cancellationToken = default);
+    Task<RedeemedMagicLink?> RedeemAsync(string token, CancellationToken cancellationToken = default);
+    Task<WorkspacePrincipal?> AuthenticateAsync(string sessionToken, CancellationToken cancellationToken = default);
+    Task<WorkspaceAccess> CreateWorkspaceAsync(WorkspacePrincipal principal, string name, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<WorkspaceAccess>> ListAsync(WorkspacePrincipal principal, CancellationToken cancellationToken = default);
+    Task<WorkspacePrincipal?> SelectAsync(WorkspacePrincipal principal, string workspaceId, CancellationToken cancellationToken = default);
+    Task<WorkspaceAccess?> GetAccessAsync(WorkspacePrincipal principal, string workspaceId, CancellationToken cancellationToken = default);
+    Task<IssuedMagicLink?> InviteAsync(WorkspacePrincipal owner, string workspaceId, string email, CancellationToken cancellationToken = default);
+    Task<bool> RevokeAsync(WorkspacePrincipal owner, string workspaceId, string memberUserId, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<WorkspaceMember>?> MembersAsync(WorkspacePrincipal principal, string workspaceId, CancellationToken cancellationToken = default);
+}
+
+internal static class WorkspaceTokens
+{
+    internal static string New() => Convert.ToBase64String(System.Security.Cryptography.RandomNumberGenerator.GetBytes(32))
+        .Replace('+', '-').Replace('/', '_').TrimEnd('=');
+
+    internal static string Hash(string value) => Convert.ToHexString(
+        System.Security.Cryptography.SHA256.HashData(System.Text.Encoding.UTF8.GetBytes(value)));
+
+    internal static string NormalizeEmail(string email) => email.Trim().ToLowerInvariant();
+}

--- a/Nuotti.Backend/Workspaces/WorkspaceHttpAccess.cs
+++ b/Nuotti.Backend/Workspaces/WorkspaceHttpAccess.cs
@@ -1,0 +1,25 @@
+namespace Nuotti.Backend.Workspaces;
+
+public static class WorkspaceHttpAccess
+{
+    public static async Task<WorkspacePrincipal?> AuthenticateAsync(
+        HttpContext http, IWorkspaceAccessStore store, CancellationToken cancellationToken = default)
+    {
+        var authorization = http.Request.Headers.Authorization.ToString();
+        const string prefix = "Bearer ";
+        if (!authorization.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)) return null;
+        var token = authorization[prefix.Length..].Trim();
+        return token.Length == 0 ? null : await store.AuthenticateAsync(token, cancellationToken);
+    }
+
+    public static async Task<(WorkspacePrincipal? Principal, WorkspaceAccess? Access)> RequireSelectedAsync(
+        HttpContext http,
+        IWorkspaceAccessStore store,
+        string workspaceId,
+        CancellationToken cancellationToken = default)
+    {
+        var principal = await AuthenticateAsync(http, store, cancellationToken);
+        if (principal is null || principal.SelectedWorkspaceId != workspaceId) return (principal, null);
+        return (principal, await store.GetAccessAsync(principal, workspaceId, cancellationToken));
+    }
+}

--- a/Nuotti.Backend/Workspaces/WorkspaceHub.cs
+++ b/Nuotti.Backend/Workspaces/WorkspaceHub.cs
@@ -1,0 +1,36 @@
+using Microsoft.AspNetCore.SignalR;
+
+namespace Nuotti.Backend.Workspaces;
+
+/// <summary>Read-only realtime transport scoped by an authenticated Workspace selection.</summary>
+public sealed class WorkspaceHub(IWorkspaceAccessStore accessStore) : Hub
+{
+    public override async Task OnConnectedAsync()
+    {
+        var http = Context.GetHttpContext();
+        var workspaceId = http?.Request.Query["workspaceId"].ToString();
+        var sessionCode = http?.Request.Query["sessionCode"].ToString();
+        var token = http?.Request.Query["access_token"].ToString();
+        if (string.IsNullOrWhiteSpace(token))
+        {
+            var authorization = http?.Request.Headers.Authorization.ToString();
+            const string prefix = "Bearer ";
+            token = authorization?.StartsWith(prefix, StringComparison.OrdinalIgnoreCase) == true
+                ? authorization[prefix.Length..].Trim() : null;
+        }
+
+        var principal = string.IsNullOrWhiteSpace(token) ? null : await accessStore.AuthenticateAsync(token);
+        if (principal is null || string.IsNullOrWhiteSpace(workspaceId) || string.IsNullOrWhiteSpace(sessionCode)
+            || principal.SelectedWorkspaceId != workspaceId
+            || await accessStore.GetAccessAsync(principal, workspaceId) is null)
+        {
+            Context.Abort();
+            return;
+        }
+
+        await Groups.AddToGroupAsync(Context.ConnectionId, GroupName(workspaceId, sessionCode));
+        await base.OnConnectedAsync();
+    }
+
+    public static string GroupName(string workspaceId, string sessionCode) => $"{workspaceId}:{sessionCode}";
+}


### PR DESCRIPTION
Closes #250

- adds one-time magic-link membership with explicit Workspace selection and Owner/Member authorization
- persists Workspace security state in PostgreSQL and hashes credentials at rest
- scopes durable Session mutation, recovery, and realtime fan-out by Workspace
- keeps legacy unscoped surfaces development-only
- adds adversarial cross-Workspace, revocation, validation, and routing coverage

Verification: 139/139 Nuotti.Backend.Tests passing; standards and spec reviews clean.