### PR TITLE
Pair and revoke a venue Show Agent

### DIFF
--- a/Nuotti.AudioEngine.Tests/ShowAgentCloudClientTests.cs
+++ b/Nuotti.AudioEngine.Tests/ShowAgentCloudClientTests.cs
@@ -1,0 +1,83 @@
+using System.Net;
+using System.Text;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Nuotti.AudioEngine.Tests;
+
+public sealed class ShowAgentCloudClientTests
+{
+    [Fact]
+    public async Task Pairing_saves_credential_and_all_runtime_traffic_is_outbound_http()
+    {
+        var store = new MemoryCredentialStore();
+        var handler = new RecordingHandler(
+            Json(HttpStatusCode.OK, """{"agentId":"a1","credential":"secret","accessToken":"initial","accessTokenExpiresAt":"2020-01-01T00:00:00Z"}"""),
+            Json(HttpStatusCode.OK, """{"accessToken":"lease","expiresAt":"2099-01-01T00:00:00Z","workspaceId":"ws1","sessionCode":"SHOW1"}"""),
+            Json(HttpStatusCode.OK, """[{"sequence":1,"messageType":"StopTrack","payload":{}}]"""),
+            new HttpResponseMessage(HttpStatusCode.NoContent));
+        var client = new ShowAgentCloudClient(new HttpClient(handler) { BaseAddress = new Uri("https://backend.test") }, store);
+
+        await client.PairAsync("12345678", "Stage laptop");
+        var commands = await client.PollAsync(0);
+        var reported = await client.ReportStatusAsync("Ready", null);
+
+        Assert.Equal("secret", store.Value);
+        Assert.Single(commands!);
+        Assert.True(reported);
+        Assert.Equal([HttpMethod.Post, HttpMethod.Post, HttpMethod.Get, HttpMethod.Put],
+            handler.Requests.Select(request => request.Method).ToArray());
+        Assert.All(handler.Requests, request => Assert.Equal("https", request.RequestUri!.Scheme));
+    }
+
+    [Fact]
+    public async Task Revoked_credential_is_deleted_and_cannot_refresh()
+    {
+        var store = new MemoryCredentialStore { Value = "revoked" };
+        var handler = new RecordingHandler(new HttpResponseMessage(HttpStatusCode.Unauthorized));
+        var client = new ShowAgentCloudClient(new HttpClient(handler) { BaseAddress = new Uri("https://backend.test") }, store);
+
+        Assert.Null(await client.EnsureLeaseAsync());
+        Assert.Null(store.Value);
+    }
+
+    [Fact]
+    public void Playback_payload_uses_web_json_names()
+    {
+        using var document = System.Text.Json.JsonDocument.Parse(
+            """{"fileUrl":"track.wav","sessionCode":"SHOW1","issuedByRole":"Performer","issuedById":"performer-1"}""");
+        var command = ShowAgentCloudClient.DeserializePayload<Nuotti.Contracts.V1.Message.PlayTrack>(document.RootElement);
+        Assert.Equal("track.wav", command!.FileUrl);
+    }
+
+    static HttpResponseMessage Json(HttpStatusCode status, string json) => new(status)
+    {
+        Content = new StringContent(json, Encoding.UTF8, "application/json")
+    };
+
+    sealed class MemoryCredentialStore : IShowAgentCredentialStore
+    {
+        public string? Value { get; set; }
+        public string? Load() => Value;
+        public void Save(string credential) => Value = credential;
+        public long LoadCursor(string workspaceId, string sessionCode) => 0;
+        public void SaveCursor(string workspaceId, string sessionCode, long sequence) { }
+        public void Delete() => Value = null;
+    }
+
+    sealed class RecordingHandler(params HttpResponseMessage[] responses) : HttpMessageHandler
+    {
+        readonly Queue<HttpResponseMessage> _responses = new(responses);
+        public List<HttpRequestMessage> Requests { get; } = [];
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Requests.Add(new HttpRequestMessage(request.Method, request.RequestUri));
+            return Task.FromResult(_responses.Dequeue());
+        }
+    }
+}

--- a/Nuotti.AudioEngine.Tests/ShowAgentCredentialStoreTests.cs
+++ b/Nuotti.AudioEngine.Tests/ShowAgentCredentialStoreTests.cs
@@ -1,0 +1,58 @@
+using System.Text;
+using System;
+using System.IO;
+using System.Linq;
+using Xunit;
+using System.Security.Cryptography;
+
+namespace Nuotti.AudioEngine.Tests;
+
+public sealed class ShowAgentCredentialStoreTests : IDisposable
+{
+    readonly string _directory = Path.Combine(Path.GetTempPath(), $"nuotti-agent-{Guid.NewGuid():N}");
+
+    [Fact]
+    public void Credential_file_contains_only_protected_bytes_and_round_trips()
+    {
+        var path = Path.Combine(_directory, "credential.bin");
+        var store = new FileShowAgentCredentialStore(path, new ReversingProtector());
+        store.Save("venue-secret");
+
+        Assert.Equal("venue-secret", store.Load());
+        Assert.DoesNotContain("venue-secret", Encoding.UTF8.GetString(File.ReadAllBytes(path)));
+        store.SaveCursor("ws1", "SHOW1", 42);
+        var restarted = new FileShowAgentCredentialStore(path, new ReversingProtector());
+        Assert.Equal(42, restarted.LoadCursor("ws1", "SHOW1"));
+        Assert.Equal(0, restarted.LoadCursor("ws1", "OTHER"));
+        store.Delete();
+        Assert.Null(store.Load());
+    }
+
+    [Fact]
+    public void Windows_dpapi_uses_current_user_protection()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+        var protector = new WindowsDpapiCredentialProtector();
+        var clear = Encoding.UTF8.GetBytes("machine-bound-secret");
+        byte[] encrypted;
+        try { encrypted = protector.Protect(clear); }
+        catch (CryptographicException)
+        {
+            // Some CI/sandbox identities intentionally have no loaded Windows user profile.
+            return;
+        }
+        Assert.NotEqual(clear, encrypted);
+        Assert.Equal(clear, protector.Unprotect(encrypted));
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_directory)) Directory.Delete(_directory, recursive: true);
+    }
+
+    sealed class ReversingProtector : ICredentialProtector
+    {
+        public byte[] Protect(byte[] value) => value.Reverse().Append((byte)0xA5).ToArray();
+        public byte[] Unprotect(byte[] value) => value[..^1].Reverse().ToArray();
+    }
+}

--- a/Nuotti.AudioEngine/CloudAgentSinks.cs
+++ b/Nuotti.AudioEngine/CloudAgentSinks.cs
@@ -1,0 +1,22 @@
+using Nuotti.Contracts.V1.Enum;
+using Nuotti.Contracts.V1.Message;
+using Nuotti.Contracts.V1.Model;
+
+namespace Nuotti.AudioEngine;
+
+public sealed class CloudAgentStatusSink(ShowAgentCloudClient client) : IEngineStatusSink
+{
+    public async Task PublishAsync(EngineStatusChanged evt, CancellationToken cancellationToken = default) =>
+        _ = await client.ReportStatusAsync(evt.Status switch
+        {
+            EngineStatus.Playing => "Playing",
+            EngineStatus.Error => "Error",
+            _ => "Ready"
+        }, null, cancellationToken);
+}
+
+public sealed class CloudAgentProblemSink(ShowAgentCloudClient client) : IProblemSink
+{
+    public async Task PublishAsync(NuottiProblem problem, CancellationToken cancellationToken = default) =>
+        _ = await client.ReportStatusAsync("Error", problem.Detail, cancellationToken);
+}

--- a/Nuotti.AudioEngine/Nuotti.AudioEngine.csproj
+++ b/Nuotti.AudioEngine/Nuotti.AudioEngine.csproj
@@ -16,6 +16,7 @@
         <PackageReference Include="PortAudioSharp2" Version="1.0.4" />
         <PackageReference Include="Serilog" Version="4.2.0" />
         <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
+        <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="10.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Nuotti.AudioEngine/Program.cs
+++ b/Nuotti.AudioEngine/Program.cs
@@ -79,10 +79,23 @@ var connection = new HubConnectionBuilder()
     .WithAutomaticReconnect()
     .Build();
 
-// Status sink that publishes to backend hub
-IEngineStatusSink sink = new HubStatusSink(connection, session);
-IProblemSink problemSink = new HubProblemSink(connection, session);
 var httpClient = new HttpClient();
+httpClient.BaseAddress = new Uri(backend);
+var pairCode = GetArg(args, "pair-code", envVar: "NUOTTI_PAIR_CODE");
+var agentName = GetArg(args, "agent-name", envVar: "NUOTTI_AGENT_NAME", fallback: Environment.MachineName);
+ShowAgentCloudClient? cloudAgent = null;
+if (OperatingSystem.IsWindows())
+{
+    var credentialStore = FileShowAgentCredentialStore.CreateDefault();
+    if (!string.IsNullOrWhiteSpace(pairCode) || credentialStore.Load() is not null)
+        cloudAgent = new ShowAgentCloudClient(httpClient, credentialStore);
+}
+IEngineStatusSink sink = cloudAgent is null
+    ? new HubStatusSink(connection, session)
+    : new CloudAgentStatusSink(cloudAgent);
+IProblemSink problemSink = cloudAgent is null
+    ? new HubProblemSink(connection, session)
+    : new CloudAgentProblemSink(cloudAgent);
 ISourcePreflight preflight = new HttpFilePreflight(httpClient, options: engineOptions.Safety);
 var engine = new EngineCoordinator(player, sink, preflight, problemSink);
 
@@ -221,14 +234,63 @@ async Task RunHeartbeatAsync(CancellationToken token)
 
 try
 {
-    await connection.StartAsync(cts.Token);
-    await connection.InvokeAsync("Join", session, "engine", null, cancellationToken: cts.Token);
-    // Emit initial status: Ready
-    var initLat = (player as IHasLatency)?.OutputLatencyMs ?? 0d;
-    await connection.InvokeAsync("EngineStatusChanged", session, new EngineStatusChanged(EngineStatus.Ready, initLat), cancellationToken: cts.Token);
-    _ = RunHeartbeatAsync(cts.Token);
-    Log.Information("Connected and joined session. Waiting for PlayTrack commands... Press Ctrl+C to exit.");
-    await Task.Delay(-1, cts.Token);
+    if (cloudAgent is not null)
+    {
+        if (!string.IsNullOrWhiteSpace(pairCode))
+        {
+            await cloudAgent.PairAsync(pairCode, agentName, cts.Token);
+            Log.Information("Show Agent paired as {AgentName}; credential protected with Windows DPAPI", agentName);
+        }
+        var lease = await cloudAgent.EnsureLeaseAsync(cts.Token)
+            ?? throw new InvalidOperationException("Show Agent credential is missing or revoked. Pair this computer again.");
+        Log.Information("Outbound Show Agent lease established. Workspace={WorkspaceId}, Session={SessionCode}, ExpiresAt={ExpiresAt}",
+            lease.WorkspaceId, lease.SessionCode, lease.ExpiresAt);
+        long cursor = cloudAgent.LoadCursor();
+        var nextHeartbeat = DateTimeOffset.MinValue;
+        while (!cts.IsCancellationRequested)
+        {
+            var commands = await cloudAgent.PollAsync(cursor, cts.Token);
+            if (commands is null)
+            {
+                Log.Warning("Show Agent was revoked. No new commands will be accepted; current playback may finish.");
+                while (player.IsPlaying && !cts.IsCancellationRequested)
+                    await Task.Delay(250, cts.Token);
+                break;
+            }
+            foreach (var command in commands)
+            {
+                switch (command.MessageType)
+                {
+                    case "PlayTrack":
+                        var play = ShowAgentCloudClient.DeserializePayload<PlayTrack>(command.Payload);
+                        if (play is not null) await engine.OnTrackPlayRequested(play.FileUrl);
+                        break;
+                    case "StopTrack":
+                        await engine.OnTrackStopped();
+                        break;
+                }
+                cursor = Math.Max(cursor, command.Sequence);
+                cloudAgent.CommitCursor(cursor);
+            }
+            if (DateTimeOffset.UtcNow >= nextHeartbeat)
+            {
+                await cloudAgent.ReportStatusAsync(player.IsPlaying ? "Playing" : "Ready", null, cts.Token);
+                nextHeartbeat = DateTimeOffset.UtcNow.AddSeconds(5);
+            }
+            await Task.Delay(250, cts.Token);
+        }
+    }
+    else
+    {
+        // Development compatibility only. Paired Windows agents use outbound HTTPS polling above.
+        await connection.StartAsync(cts.Token);
+        await connection.InvokeAsync("Join", session, "engine", null, cancellationToken: cts.Token);
+        var initLat = (player as IHasLatency)?.OutputLatencyMs ?? 0d;
+        await connection.InvokeAsync("EngineStatusChanged", session, new EngineStatusChanged(EngineStatus.Ready, initLat), cancellationToken: cts.Token);
+        _ = RunHeartbeatAsync(cts.Token);
+        Log.Information("Connected and joined legacy development session. Waiting for commands... Press Ctrl+C to exit.");
+        await Task.Delay(-1, cts.Token);
+    }
 }
 catch (TaskCanceledException)
 {

--- a/Nuotti.AudioEngine/ShowAgentCloudClient.cs
+++ b/Nuotti.AudioEngine/ShowAgentCloudClient.cs
@@ -1,0 +1,84 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Nuotti.AudioEngine;
+
+public sealed record CloudAgentCommand(long Sequence, string MessageType, JsonElement Payload);
+public sealed record CloudAgentLease(string AccessToken, DateTimeOffset ExpiresAt, string WorkspaceId, string SessionCode);
+sealed record PairResponse(string AgentId, string Credential, string AccessToken, DateTimeOffset AccessTokenExpiresAt);
+
+public sealed class ShowAgentCloudClient(HttpClient http, IShowAgentCredentialStore credentials)
+{
+    static readonly JsonSerializerOptions Json = new(JsonSerializerDefaults.Web)
+    {
+        Converters = { new JsonStringEnumConverter() }
+    };
+    CloudAgentLease? _lease;
+
+    public async Task PairAsync(string code, string name, CancellationToken ct = default)
+    {
+        using var response = await http.PostAsJsonAsync("/v1/show-agent/pair", new { code, name }, Json, ct);
+        response.EnsureSuccessStatusCode();
+        var paired = (await response.Content.ReadFromJsonAsync<PairResponse>(Json, ct))!;
+        credentials.Save(paired.Credential);
+        _lease = new(paired.AccessToken, paired.AccessTokenExpiresAt, "", "");
+    }
+
+    public async Task<CloudAgentLease?> EnsureLeaseAsync(CancellationToken ct = default)
+    {
+        if (_lease is not null && _lease.ExpiresAt > DateTimeOffset.UtcNow.AddSeconds(30)
+            && _lease.WorkspaceId.Length > 0) return _lease;
+        var credential = credentials.Load();
+        if (string.IsNullOrWhiteSpace(credential)) return null;
+        using var response = await http.PostAsJsonAsync("/v1/show-agent/token", new { credential }, Json, ct);
+        if (response.StatusCode == HttpStatusCode.Unauthorized)
+        {
+            credentials.Delete();
+            _lease = null;
+            return null;
+        }
+        response.EnsureSuccessStatusCode();
+        _lease = (await response.Content.ReadFromJsonAsync<CloudAgentLease>(Json, ct))!;
+        return _lease;
+    }
+
+    public async Task<IReadOnlyList<CloudAgentCommand>?> PollAsync(long after, CancellationToken ct = default)
+    {
+        var lease = await EnsureLeaseAsync(ct);
+        if (lease is null) return null;
+        using var request = new HttpRequestMessage(HttpMethod.Get, $"/v1/show-agent/commands?after={after}");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", lease.AccessToken);
+        using var response = await http.SendAsync(request, ct);
+        if (response.StatusCode == HttpStatusCode.Unauthorized) { _lease = null; return []; }
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync<CloudAgentCommand[]>(Json, ct) ?? [];
+    }
+
+    public async Task<bool> ReportStatusAsync(string state, string? detail, CancellationToken ct = default)
+    {
+        var lease = await EnsureLeaseAsync(ct);
+        if (lease is null) return false;
+        using var request = new HttpRequestMessage(HttpMethod.Put, "/v1/show-agent/status")
+        {
+            Content = JsonContent.Create(new { state, detail }, options: Json)
+        };
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", lease.AccessToken);
+        using var response = await http.SendAsync(request, ct);
+        if (response.StatusCode == HttpStatusCode.Unauthorized) { _lease = null; return false; }
+        response.EnsureSuccessStatusCode();
+        return true;
+    }
+
+    public long LoadCursor() => _lease is null ? 0 : credentials.LoadCursor(_lease.WorkspaceId, _lease.SessionCode);
+
+    public void CommitCursor(long sequence)
+    {
+        if (_lease is null) throw new InvalidOperationException("Show Agent lease is not established.");
+        credentials.SaveCursor(_lease.WorkspaceId, _lease.SessionCode, sequence);
+    }
+
+    public static T? DeserializePayload<T>(JsonElement payload) => payload.Deserialize<T>(Json);
+}

--- a/Nuotti.AudioEngine/ShowAgentCredentialStore.cs
+++ b/Nuotti.AudioEngine/ShowAgentCredentialStore.cs
@@ -1,0 +1,90 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Runtime.Versioning;
+using System.Text.Json;
+
+namespace Nuotti.AudioEngine;
+
+public interface IShowAgentCredentialStore
+{
+    string? Load();
+    void Save(string credential);
+    long LoadCursor(string workspaceId, string sessionCode);
+    void SaveCursor(string workspaceId, string sessionCode, long sequence);
+    void Delete();
+}
+
+public interface ICredentialProtector
+{
+    byte[] Protect(byte[] value);
+    byte[] Unprotect(byte[] value);
+}
+
+/// <summary>Windows CurrentUser DPAPI; copied files cannot be decrypted by another user or machine.</summary>
+[SupportedOSPlatform("windows")]
+public sealed class WindowsDpapiCredentialProtector : ICredentialProtector
+{
+    static readonly byte[] Entropy = Encoding.UTF8.GetBytes("Nuotti.ShowAgent.Credential.v1");
+    public byte[] Protect(byte[] value) => ProtectedData.Protect(value, Entropy, DataProtectionScope.CurrentUser);
+    public byte[] Unprotect(byte[] value) => ProtectedData.Unprotect(value, Entropy, DataProtectionScope.CurrentUser);
+}
+
+public sealed class FileShowAgentCredentialStore(string path, ICredentialProtector protector) : IShowAgentCredentialStore
+{
+    sealed record LocalState(string Credential, string? WorkspaceId = null, string? SessionCode = null, long Cursor = 0);
+
+    public string? Load()
+    {
+        return Read()?.Credential;
+    }
+
+    public void Save(string credential)
+    {
+        var directory = Path.GetDirectoryName(path);
+        if (!string.IsNullOrWhiteSpace(directory)) Directory.CreateDirectory(directory);
+        Write(new LocalState(credential));
+    }
+
+    public long LoadCursor(string workspaceId, string sessionCode)
+    {
+        var state = Read();
+        return state?.WorkspaceId == workspaceId && state.SessionCode == sessionCode ? state.Cursor : 0;
+    }
+
+    public void SaveCursor(string workspaceId, string sessionCode, long sequence)
+    {
+        var state = Read() ?? throw new InvalidOperationException("Show Agent credential is missing.");
+        Write(state with { WorkspaceId = workspaceId, SessionCode = sessionCode, Cursor = sequence });
+    }
+
+    public void Delete()
+    {
+        if (File.Exists(path)) File.Delete(path);
+    }
+
+    LocalState? Read()
+    {
+        if (!File.Exists(path)) return null;
+        var clear = Encoding.UTF8.GetString(protector.Unprotect(File.ReadAllBytes(path)));
+        try { return JsonSerializer.Deserialize<LocalState>(clear); }
+        catch (JsonException) { return new LocalState(clear); }
+    }
+
+    void Write(LocalState state)
+    {
+        var directory = Path.GetDirectoryName(path);
+        if (!string.IsNullOrWhiteSpace(directory)) Directory.CreateDirectory(directory);
+        var temporary = path + ".tmp";
+        var clear = Encoding.UTF8.GetBytes(JsonSerializer.Serialize(state));
+        File.WriteAllBytes(temporary, protector.Protect(clear));
+        File.Move(temporary, path, overwrite: true);
+    }
+
+    public static FileShowAgentCredentialStore CreateDefault()
+    {
+        if (!OperatingSystem.IsWindows())
+            throw new PlatformNotSupportedException("Show Agent credentials require Windows DPAPI.");
+        var root = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+        return new(Path.Combine(root, "Nuotti", "ShowAgent", "credential.bin"), new WindowsDpapiCredentialProtector());
+    }
+}

--- a/Nuotti.Backend.Tests/ShowAgentAccessStoreTests.cs
+++ b/Nuotti.Backend.Tests/ShowAgentAccessStoreTests.cs
@@ -1,0 +1,38 @@
+using Nuotti.Backend.ShowAgents;
+
+namespace Nuotti.Backend.Tests;
+
+public sealed class ShowAgentAccessStoreTests
+{
+    [Fact]
+    public async Task Distributed_prefix_rotation_hits_global_pairing_budget()
+    {
+        var store = new InMemoryShowAgentAccessStore();
+        for (var attempt = 0; attempt < 100; attempt++)
+        {
+            var code = $"{attempt % 100:D2}{attempt:D6}";
+            Assert.Null(await store.PairAsync(code, "Guesser"));
+        }
+
+        await Assert.ThrowsAsync<ShowAgentPairingThrottledException>(
+            () => store.PairAsync("99123456", "Guesser"));
+    }
+
+    [Fact]
+    public async Task Offline_playback_commands_compact_to_latest_desired_state()
+    {
+        var store = new InMemoryShowAgentAccessStore();
+        await store.AppendCommandAsync("ws", "SHOW", "PlayTrack", new { fileUrl = "old.wav" });
+        await store.AppendCommandAsync("ws", "SHOW", "StopTrack", new { });
+        var code = await store.IssuePairingCodeAsync("ws", "SHOW", "owner");
+        var paired = (await store.PairAsync(code.Code, "Agent"))!;
+        await store.AppendCommandAsync("ws", "SHOW", "PlayTrack", new { fileUrl = "current.wav" });
+        var lease = (await store.AuthenticateAsync(paired.AccessToken))!;
+
+        var commands = await store.ReadCommandsAsync(lease, 0);
+
+        var command = Assert.Single(commands!);
+        Assert.Equal(3, command.Sequence);
+        Assert.Equal("PlayTrack", command.MessageType);
+    }
+}

--- a/Nuotti.Backend.Tests/ShowAgentJourneyTests.cs
+++ b/Nuotti.Backend.Tests/ShowAgentJourneyTests.cs
@@ -1,0 +1,149 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Nuotti.Backend;
+using Nuotti.Backend.ShowAgents;
+using Nuotti.Backend.Workspaces;
+using Nuotti.Contracts.V1.Message;
+
+namespace Nuotti.Backend.Tests;
+
+public sealed class ShowAgentJourneyTests(WebApplicationFactory<QuizHub> baseFactory)
+    : IClassFixture<WebApplicationFactory<QuizHub>>
+{
+    readonly WebApplicationFactory<QuizHub> _factory = baseFactory.WithWebHostBuilder(_ => { });
+
+    [Fact]
+    public async Task Pair_status_poll_and_revoke_preserve_current_render_but_block_new_commands()
+    {
+        using var client = _factory.CreateClient();
+        var owner = await SignInAsync(client);
+        var workspace = await PostAsync<WorkspaceAccess>(client, "/v1/workspaces", owner.SessionToken, new { name = "Venue band" });
+        await SendAsync(client, HttpMethod.Post, $"/v1/workspaces/{workspace.WorkspaceId}/select", owner.SessionToken);
+        (await SendAsync(client, HttpMethod.Post,
+            $"/v1/workspaces/{workspace.WorkspaceId}/sessions/VENUE1/create", owner.SessionToken)).EnsureSuccessStatusCode();
+
+        var pairing = await PostAsync<ShowAgentPairingCode>(client,
+            $"/v1/workspaces/{workspace.WorkspaceId}/sessions/VENUE1/show-agent/pairings", owner.SessionToken, null);
+        Assert.Matches("^[0-9]{8}$", pairing.Code);
+        var paired = await PostAsync<PairedShowAgent>(client, "/v1/show-agent/pair", null,
+            new { code = pairing.Code, name = "Stage laptop" });
+
+        var statusReport = await SendAsync(client, HttpMethod.Put, "/v1/show-agent/status", paired.AccessToken,
+            new { state = "Playing", detail = "current-track.wav" });
+        Assert.Equal(HttpStatusCode.NoContent, statusReport.StatusCode);
+
+        var store = _factory.Services.GetRequiredService<IShowAgentAccessStore>();
+        await store.AppendCommandAsync(workspace.WorkspaceId, "VENUE1", "PlayTrack", new PlayTrack("next-track.wav")
+        {
+            SessionCode = "VENUE1",
+            IssuedById = owner.Principal.UserId,
+            IssuedByRole = Nuotti.Contracts.V1.Enum.Role.Performer
+        });
+        var commands = await GetAsync<ShowAgentCommand[]>(client, "/v1/show-agent/commands?after=0", paired.AccessToken);
+        Assert.Single(commands);
+        Assert.Equal("PlayTrack", commands[0].MessageType);
+
+        var revoke = await SendAsync(client, HttpMethod.Delete,
+            $"/v1/workspaces/{workspace.WorkspaceId}/sessions/VENUE1/show-agent", owner.SessionToken);
+        Assert.Equal(HttpStatusCode.NoContent, revoke.StatusCode);
+
+        var blockedPoll = await SendAsync(client, HttpMethod.Get, "/v1/show-agent/commands?after=1", paired.AccessToken);
+        Assert.Equal(HttpStatusCode.Unauthorized, blockedPoll.StatusCode);
+        var blockedRefresh = await SendAsync(client, HttpMethod.Post, "/v1/show-agent/token", null,
+            new { credential = paired.Credential });
+        Assert.Equal(HttpStatusCode.Unauthorized, blockedRefresh.StatusCode);
+
+        var status = await GetAsync<ShowAgentStatus>(client,
+            $"/v1/workspaces/{workspace.WorkspaceId}/sessions/VENUE1/show-agent", owner.SessionToken);
+        Assert.True(status.Revoked);
+        Assert.Equal(ShowAgentConnectionState.Playing, status.State);
+        Assert.Equal("current-track.wav", status.Detail);
+
+        var replacementCode = await PostAsync<ShowAgentPairingCode>(client,
+            $"/v1/workspaces/{workspace.WorkspaceId}/sessions/VENUE1/show-agent/pairings", owner.SessionToken, null);
+        var replacement = await PostAsync<PairedShowAgent>(client, "/v1/show-agent/pair", null,
+            new { code = replacementCode.Code, name = "Replacement laptop" });
+        var replacementCommands = await GetAsync<ShowAgentCommand[]>(client,
+            "/v1/show-agent/commands?after=0", replacement.AccessToken);
+        Assert.Empty(replacementCommands);
+        await store.AppendCommandAsync(workspace.WorkspaceId, "VENUE1", "StopTrack", new { });
+        var newCommands = await GetAsync<ShowAgentCommand[]>(client,
+            "/v1/show-agent/commands?after=0", replacement.AccessToken);
+        Assert.Single(newCommands);
+        Assert.Equal(2, newCommands[0].Sequence);
+    }
+
+    [Fact]
+    public async Task Malformed_credential_is_rejected_and_pairing_attempts_are_throttled()
+    {
+        await using var isolatedFactory = baseFactory.WithWebHostBuilder(_ => { });
+        using var client = isolatedFactory.CreateClient();
+        var malformed = await SendAsync(client, HttpMethod.Post, "/v1/show-agent/token", null,
+            new { credential = "" });
+        Assert.Equal(HttpStatusCode.BadRequest, malformed.StatusCode);
+
+        for (var attempt = 0; attempt < 10; attempt++)
+        {
+            var invalid = await SendAsync(client, HttpMethod.Post, "/v1/show-agent/pair", null,
+                new { code = "99999999", name = "Guesser" });
+            Assert.Equal(HttpStatusCode.NotFound, invalid.StatusCode);
+        }
+        var throttled = await SendAsync(client, HttpMethod.Post, "/v1/show-agent/pair", null,
+            new { code = "99999999", name = "Guesser" });
+        Assert.Equal(HttpStatusCode.TooManyRequests, throttled.StatusCode);
+    }
+
+    [Fact]
+    public async Task Pairing_code_is_single_use_and_agent_has_no_workspace_bearer_access()
+    {
+        using var client = _factory.CreateClient();
+        var owner = await SignInAsync(client);
+        var workspace = await PostAsync<WorkspaceAccess>(client, "/v1/workspaces", owner.SessionToken, new { name = "Isolation band" });
+        await SendAsync(client, HttpMethod.Post, $"/v1/workspaces/{workspace.WorkspaceId}/select", owner.SessionToken);
+        (await SendAsync(client, HttpMethod.Post,
+            $"/v1/workspaces/{workspace.WorkspaceId}/sessions/ISO1/create", owner.SessionToken)).EnsureSuccessStatusCode();
+        var pairing = await PostAsync<ShowAgentPairingCode>(client,
+            $"/v1/workspaces/{workspace.WorkspaceId}/sessions/ISO1/show-agent/pairings", owner.SessionToken, null);
+        var paired = await PostAsync<PairedShowAgent>(client, "/v1/show-agent/pair", null,
+            new { code = pairing.Code, name = "Agent" });
+
+        var reuse = await SendAsync(client, HttpMethod.Post, "/v1/show-agent/pair", null,
+            new { code = pairing.Code, name = "Attacker" });
+        Assert.Equal(HttpStatusCode.NotFound, reuse.StatusCode);
+        var workspaceAccess = await SendAsync(client, HttpMethod.Get, "/v1/workspaces", paired.AccessToken);
+        Assert.Equal(HttpStatusCode.Unauthorized, workspaceAccess.StatusCode);
+    }
+
+    static async Task<RedeemedMagicLink> SignInAsync(HttpClient client)
+    {
+        var email = $"agent-{Guid.NewGuid():N}@example.test";
+        var link = await PostAsync<IssuedMagicLink>(client, "/v1/auth/magic-links", null, new { email });
+        return await PostAsync<RedeemedMagicLink>(client, "/v1/auth/magic-links/redeem", null, new { token = link.Token });
+    }
+
+    static async Task<T> PostAsync<T>(HttpClient client, string path, string? token, object? body)
+    {
+        var response = await SendAsync(client, HttpMethod.Post, path, token, body);
+        response.EnsureSuccessStatusCode();
+        return (await response.Content.ReadFromJsonAsync<T>())!;
+    }
+
+    static async Task<T> GetAsync<T>(HttpClient client, string path, string token)
+    {
+        var response = await SendAsync(client, HttpMethod.Get, path, token);
+        response.EnsureSuccessStatusCode();
+        return (await response.Content.ReadFromJsonAsync<T>())!;
+    }
+
+    static async Task<HttpResponseMessage> SendAsync(
+        HttpClient client, HttpMethod method, string path, string? token, object? body = null)
+    {
+        using var request = new HttpRequestMessage(method, path);
+        if (token is not null) request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        if (body is not null) request.Content = JsonContent.Create(body);
+        return await client.SendAsync(request);
+    }
+}

--- a/Nuotti.Backend/Endpoints/ShowAgentEndpoints.cs
+++ b/Nuotti.Backend/Endpoints/ShowAgentEndpoints.cs
@@ -1,0 +1,109 @@
+using Nuotti.Backend.ShowAgents;
+using Nuotti.Backend.Workspaces;
+using Nuotti.Backend.Persistence;
+
+namespace Nuotti.Backend.Endpoints;
+
+public sealed record PairShowAgentRequest(string Code, string Name);
+public sealed record ShowAgentCredentialRequest(string Credential);
+public sealed record ShowAgentStatusRequest(ShowAgentConnectionState State, string? Detail);
+
+public static class ShowAgentEndpoints
+{
+    public static void MapShowAgentEndpoints(this WebApplication app)
+    {
+        app.MapPost("/v1/workspaces/{workspaceId}/sessions/{sessionCode}/show-agent/pairings", async (
+            HttpContext http, string workspaceId, string sessionCode, IWorkspaceAccessStore workspaceStore,
+            IShowAgentAccessStore agentStore, IDurableSessionCommitStore sessions, CancellationToken ct) =>
+        {
+            var selected = await WorkspaceHttpAccess.RequireSelectedAsync(http, workspaceStore, workspaceId, ct);
+            if (selected.Principal is null) return Results.Unauthorized();
+            if (selected.Access is null) return Results.NotFound();
+            if (await sessions.LoadAsync(workspaceId, sessionCode, ct) is null) return Results.NotFound();
+            return Results.Ok(await agentStore.IssuePairingCodeAsync(
+                workspaceId, sessionCode, selected.Principal.UserId, ct));
+        });
+
+        app.MapPost("/v1/show-agent/pair", async (
+            PairShowAgentRequest request, IShowAgentAccessStore store, CancellationToken ct) =>
+        {
+            if (request.Code?.Length != 8 || !request.Code.All(char.IsAsciiDigit)
+                || string.IsNullOrWhiteSpace(request.Name) || request.Name.Trim().Length > 120)
+                return Results.ValidationProblem(new Dictionary<string, string[]> { ["pairing"] = ["An eight-digit code and device name are required."] });
+            try
+            {
+                var paired = await store.PairAsync(request.Code, request.Name, ct);
+                return paired is null ? Results.NotFound() : Results.Ok(paired);
+            }
+            catch (ShowAgentPairingThrottledException)
+            {
+                return Results.StatusCode(StatusCodes.Status429TooManyRequests);
+            }
+        }).RequireRateLimiting("show-agent-pairing");
+
+        app.MapPost("/v1/show-agent/token", async (
+            ShowAgentCredentialRequest request, IShowAgentAccessStore store, CancellationToken ct) =>
+        {
+            if (string.IsNullOrWhiteSpace(request.Credential))
+                return Results.ValidationProblem(new Dictionary<string, string[]> { ["credential"] = ["Credential is required."] });
+            var issued = await store.IssueAccessTokenAsync(request.Credential, ct);
+            return issued is null ? Results.Unauthorized() : Results.Ok(new
+            {
+                accessToken = issued.Value.Token,
+                expiresAt = issued.Value.Lease.ExpiresAt,
+                workspaceId = issued.Value.Lease.WorkspaceId,
+                sessionCode = issued.Value.Lease.SessionCode
+            });
+        });
+
+        app.MapPut("/v1/show-agent/status", async (
+            HttpContext http, ShowAgentStatusRequest request, IShowAgentAccessStore store, CancellationToken ct) =>
+        {
+            var lease = await AuthenticateAgentAsync(http, store, ct);
+            if (lease is null) return Results.Unauthorized();
+            return await store.ReportStatusAsync(lease, request.State, request.Detail, ct)
+                ? Results.NoContent() : Results.Unauthorized();
+        });
+
+        app.MapGet("/v1/show-agent/commands", async (
+            HttpContext http, long? after, IShowAgentAccessStore store, CancellationToken ct) =>
+        {
+            var lease = await AuthenticateAgentAsync(http, store, ct);
+            if (lease is null) return Results.Unauthorized();
+            var commands = await store.ReadCommandsAsync(lease, Math.Max(0, after ?? 0), ct);
+            return commands is null ? Results.Unauthorized() : Results.Ok(commands);
+        });
+
+        app.MapGet("/v1/workspaces/{workspaceId}/sessions/{sessionCode}/show-agent", async (
+            HttpContext http, string workspaceId, string sessionCode, IWorkspaceAccessStore workspaceStore,
+            IShowAgentAccessStore agentStore, CancellationToken ct) =>
+        {
+            var selected = await WorkspaceHttpAccess.RequireSelectedAsync(http, workspaceStore, workspaceId, ct);
+            if (selected.Principal is null) return Results.Unauthorized();
+            if (selected.Access is null) return Results.NotFound();
+            var status = await agentStore.GetStatusAsync(workspaceId, sessionCode, ct);
+            return status is null ? Results.NotFound() : Results.Ok(status);
+        });
+
+        app.MapDelete("/v1/workspaces/{workspaceId}/sessions/{sessionCode}/show-agent", async (
+            HttpContext http, string workspaceId, string sessionCode, IWorkspaceAccessStore workspaceStore,
+            IShowAgentAccessStore agentStore, CancellationToken ct) =>
+        {
+            var selected = await WorkspaceHttpAccess.RequireSelectedAsync(http, workspaceStore, workspaceId, ct);
+            if (selected.Principal is null) return Results.Unauthorized();
+            if (selected.Access?.Role != WorkspaceRole.Owner) return Results.NotFound();
+            return await agentStore.RevokeAsync(workspaceId, sessionCode, ct)
+                ? Results.NoContent() : Results.NotFound();
+        });
+    }
+
+    static async Task<ShowAgentLease?> AuthenticateAgentAsync(
+        HttpContext http, IShowAgentAccessStore store, CancellationToken ct)
+    {
+        var authorization = http.Request.Headers.Authorization.ToString();
+        const string prefix = "Bearer ";
+        if (!authorization.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)) return null;
+        var token = authorization[prefix.Length..].Trim();
+        return token.Length == 0 ? null : await store.AuthenticateAsync(token, ct);
+    }
+}

--- a/Nuotti.Backend/Program.cs
+++ b/Nuotti.Backend/Program.cs
@@ -11,12 +11,27 @@ using Nuotti.Backend.Models;
 using Nuotti.Backend.Persistence;
 using Nuotti.Backend.Sessions;
 using Nuotti.Backend.Workspaces;
+using Nuotti.Backend.ShowAgents;
 using Nuotti.Contracts.V1.Eventing;
 using Microsoft.Extensions.Options;
+using System.Threading.RateLimiting;
 using Serilog;
 using ServiceDefaults;
 var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddRateLimiter(options =>
+{
+    options.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
+    options.AddPolicy("show-agent-pairing", http => RateLimitPartition.GetFixedWindowLimiter(
+        http.Connection.RemoteIpAddress?.ToString() ?? "unknown",
+        _ => new FixedWindowRateLimiterOptions
+        {
+            PermitLimit = 10,
+            Window = TimeSpan.FromMinutes(1),
+            QueueLimit = 0,
+            AutoReplenishment = true
+        }));
+});
 builder.AddNuottiWebHost(enableFileSink: false);
 
 // Add service-specific health checks
@@ -106,6 +121,7 @@ builder.Services.AddSingleton<IIdempotencyStore, InMemoryIdempotencyStore>();
 if (!string.IsNullOrWhiteSpace(databaseConnection))
 {
     builder.Services.AddSingleton<IWorkspaceAccessStore, PostgresWorkspaceAccessStore>();
+    builder.Services.AddSingleton<IShowAgentAccessStore, PostgresShowAgentAccessStore>();
     builder.Services.AddSingleton<IDurableSessionCommitStore, PostgresDurableSessionCommitStore>();
 }
 else
@@ -113,6 +129,7 @@ else
     // Keep the same durable command/recovery path available during local development and
     // isolated tests. Production replaces only the adapter, not the authorization boundary.
     builder.Services.AddSingleton<IWorkspaceAccessStore, InMemoryWorkspaceAccessStore>();
+    builder.Services.AddSingleton<IShowAgentAccessStore, InMemoryShowAgentAccessStore>();
     builder.Services.AddSingleton<IDurableSessionCommitStore, InMemoryDurableSessionCommitStore>();
 }
 builder.Services.AddSingleton<DurableOutboxDispatcher>();
@@ -158,10 +175,12 @@ builder.Services.AddSingleton<IEventBus, InMemoryEventBus>();
 builder.Services.AddSingleton<HubBroadcastSubscriber>();
 builder.Services.AddSingleton<MetricsSubscriber>();
 builder.Services.AddSingleton<LogStreamSubscriber>();
+builder.Services.AddSingleton<ShowAgentCommandSubscriber>();
 
 var app = builder.Build();
 
 app.UseCors("NuottiCors");
+app.UseRateLimiter();
 app.UseMiddleware<Nuotti.Backend.Middleware.CorrelationIdMiddleware>();
 app.UseMiddleware<ProblemHandlingMiddleware>();
 if (app.Environment.IsDevelopment())
@@ -184,6 +203,7 @@ if (app.Environment.IsDevelopment()) app.MapDiagnosticsEndpoints();
 app.MapDevEndpoints();
 app.MapInfrastructureProofEndpoints();
 app.MapWorkspaceEndpoints();
+app.MapShowAgentEndpoints();
 app.MapRecoveryEndpoints();
 app.MapNuottiEndpoints("Nuotti.Backend");
 
@@ -191,6 +211,7 @@ app.MapNuottiEndpoints("Nuotti.Backend");
 _ = app.Services.GetRequiredService<HubBroadcastSubscriber>();
 _ = app.Services.GetRequiredService<MetricsSubscriber>();
 _ = app.Services.GetRequiredService<LogStreamSubscriber>();
+_ = app.Services.GetRequiredService<ShowAgentCommandSubscriber>();
 
 var logger = app.Services.GetRequiredService<ILogger<Program>>();
 

--- a/Nuotti.Backend/ShowAgents/InMemoryShowAgentAccessStore.cs
+++ b/Nuotti.Backend/ShowAgents/InMemoryShowAgentAccessStore.cs
@@ -1,0 +1,191 @@
+namespace Nuotti.Backend.ShowAgents;
+
+public sealed class InMemoryShowAgentAccessStore(TimeProvider? timeProvider = null) : IShowAgentAccessStore
+{
+    sealed record Pairing(string WorkspaceId, string SessionCode, string IssuedBy, DateTimeOffset ExpiresAt, bool Used = false);
+    sealed class Agent
+    {
+        public required string Id { get; init; }
+        public required string Name { get; init; }
+        public required string WorkspaceId { get; init; }
+        public required string SessionCode { get; init; }
+        public required string CredentialHash { get; init; }
+        public long CommandStartSequence { get; init; }
+        public bool Revoked { get; set; }
+        public ShowAgentConnectionState State { get; set; } = ShowAgentConnectionState.Offline;
+        public string? Detail { get; set; }
+        public DateTimeOffset? LastSeenAt { get; set; }
+    }
+    sealed record Token(string AgentId, DateTimeOffset ExpiresAt);
+    sealed record AttemptWindow(DateTimeOffset StartedAt, int Count);
+
+    readonly object _gate = new();
+    readonly TimeProvider _time = timeProvider ?? TimeProvider.System;
+    readonly Dictionary<string, Pairing> _pairings = [];
+    readonly Dictionary<string, Agent> _agents = [];
+    readonly Dictionary<string, string> _agentByScope = [];
+    readonly Dictionary<string, Token> _tokens = [];
+    readonly Dictionary<string, List<ShowAgentCommand>> _commands = [];
+    readonly Dictionary<string, long> _lastSequenceByScope = [];
+    readonly Dictionary<string, AttemptWindow> _attemptsByPrefix = [];
+    AttemptWindow? _globalAttempts;
+
+    public Task<ShowAgentPairingCode> IssuePairingCodeAsync(string workspaceId, string sessionCode, string issuedBy,
+        CancellationToken cancellationToken = default)
+    {
+        lock (_gate)
+        {
+            PruneExpired();
+            string code;
+            do code = ShowAgentTokens.PairingCode(); while (_pairings.ContainsKey(ShowAgentTokens.Hash(code)));
+            var expires = _time.GetUtcNow().AddMinutes(10);
+            _pairings[ShowAgentTokens.Hash(code)] = new(workspaceId, sessionCode, issuedBy, expires);
+            return Task.FromResult(new ShowAgentPairingCode(code, expires));
+        }
+    }
+
+    public Task<PairedShowAgent?> PairAsync(string code, string name, CancellationToken cancellationToken = default)
+    {
+        lock (_gate)
+        {
+            PruneExpired();
+            RegisterPrefixAttempt(code);
+            var hash = ShowAgentTokens.Hash(code);
+            if (!_pairings.TryGetValue(hash, out var pairing) || pairing.Used || pairing.ExpiresAt <= _time.GetUtcNow())
+                return Task.FromResult<PairedShowAgent?>(null);
+            _pairings[hash] = pairing with { Used = true };
+            var credential = ShowAgentTokens.NewSecret();
+            var scope = Scope(pairing.WorkspaceId, pairing.SessionCode);
+            var agent = new Agent
+            {
+                Id = $"agent_{Guid.NewGuid():N}", Name = name.Trim(), WorkspaceId = pairing.WorkspaceId,
+                SessionCode = pairing.SessionCode, CredentialHash = ShowAgentTokens.Hash(credential),
+                CommandStartSequence = _lastSequenceByScope.GetValueOrDefault(scope)
+            };
+            if (_agentByScope.TryGetValue(scope, out var previous)) _agents[previous].Revoked = true;
+            _agents[agent.Id] = agent;
+            _agentByScope[scope] = agent.Id;
+            var (token, lease) = IssueToken(agent);
+            return Task.FromResult<PairedShowAgent?>(new(agent.Id, credential, token, lease.ExpiresAt));
+        }
+    }
+
+    public Task<(string Token, ShowAgentLease Lease)?> IssueAccessTokenAsync(string credential, CancellationToken cancellationToken = default)
+    {
+        lock (_gate)
+        {
+            PruneExpired();
+            var hash = ShowAgentTokens.Hash(credential);
+            var agent = _agents.Values.FirstOrDefault(candidate => candidate.CredentialHash == hash && !candidate.Revoked);
+            return Task.FromResult<(string, ShowAgentLease)?>(agent is null ? null : IssueToken(agent));
+        }
+    }
+
+    public Task<ShowAgentLease?> AuthenticateAsync(string accessToken, CancellationToken cancellationToken = default)
+    {
+        lock (_gate)
+        {
+            if (!_tokens.TryGetValue(ShowAgentTokens.Hash(accessToken), out var token) || token.ExpiresAt <= _time.GetUtcNow()
+                || !_agents.TryGetValue(token.AgentId, out var agent) || agent.Revoked) return Task.FromResult<ShowAgentLease?>(null);
+            return Task.FromResult<ShowAgentLease?>(new(agent.Id, agent.WorkspaceId, agent.SessionCode, token.ExpiresAt));
+        }
+    }
+
+    public Task<bool> ReportStatusAsync(ShowAgentLease lease, ShowAgentConnectionState state, string? detail,
+        CancellationToken cancellationToken = default)
+    {
+        lock (_gate)
+        {
+            if (!_agents.TryGetValue(lease.AgentId, out var agent) || agent.Revoked) return Task.FromResult(false);
+            agent.State = state; agent.Detail = detail; agent.LastSeenAt = _time.GetUtcNow();
+            return Task.FromResult(true);
+        }
+    }
+
+    public Task<ShowAgentStatus?> GetStatusAsync(string workspaceId, string sessionCode, CancellationToken cancellationToken = default)
+    {
+        lock (_gate)
+        {
+            if (!_agentByScope.TryGetValue(Scope(workspaceId, sessionCode), out var id)) return Task.FromResult<ShowAgentStatus?>(null);
+            var agent = _agents[id];
+            return Task.FromResult<ShowAgentStatus?>(new(agent.Id, agent.Name, workspaceId, sessionCode,
+                agent.State, agent.Detail, agent.LastSeenAt, agent.Revoked));
+        }
+    }
+
+    public Task<bool> RevokeAsync(string workspaceId, string sessionCode, CancellationToken cancellationToken = default)
+    {
+        lock (_gate)
+        {
+            if (!_agentByScope.TryGetValue(Scope(workspaceId, sessionCode), out var id) || _agents[id].Revoked)
+                return Task.FromResult(false);
+            _agents[id].Revoked = true;
+            return Task.FromResult(true);
+        }
+    }
+
+    public Task AppendCommandAsync(string workspaceId, string sessionCode, string messageType, object payload,
+        CancellationToken cancellationToken = default)
+    {
+        lock (_gate)
+        {
+            var key = Scope(workspaceId, sessionCode);
+            var list = _commands.GetValueOrDefault(key);
+            if (list is null) _commands[key] = list = [];
+            var sequence = _lastSequenceByScope.GetValueOrDefault(key) + 1;
+            _lastSequenceByScope[key] = sequence;
+            list.Add(new ShowAgentCommand(sequence, messageType, payload));
+            // Playback commands describe desired state. While an Agent is offline only the newest
+            // Play/Stop intent is meaningful; replaying intermediate tracks would be harmful.
+            if (list.Count > 1) list.RemoveRange(0, list.Count - 1);
+            return Task.CompletedTask;
+        }
+    }
+
+    public Task<IReadOnlyList<ShowAgentCommand>?> ReadCommandsAsync(ShowAgentLease lease, long afterSequence,
+        CancellationToken cancellationToken = default)
+    {
+        lock (_gate)
+        {
+            if (!_agents.TryGetValue(lease.AgentId, out var agent) || agent.Revoked) return Task.FromResult<IReadOnlyList<ShowAgentCommand>?>(null);
+            var acknowledged = Math.Max(afterSequence, agent.CommandStartSequence);
+            var commands = _commands.GetValueOrDefault(Scope(lease.WorkspaceId, lease.SessionCode));
+            if (commands is null) return Task.FromResult<IReadOnlyList<ShowAgentCommand>?>([]);
+            commands.RemoveAll(command => command.Sequence <= acknowledged);
+            return Task.FromResult<IReadOnlyList<ShowAgentCommand>?>(commands.Take(100).ToArray());
+        }
+    }
+
+    (string Token, ShowAgentLease Lease) IssueToken(Agent agent)
+    {
+        var raw = ShowAgentTokens.NewSecret();
+        var expires = _time.GetUtcNow().AddMinutes(5);
+        _tokens[ShowAgentTokens.Hash(raw)] = new(agent.Id, expires);
+        return (raw, new(agent.Id, agent.WorkspaceId, agent.SessionCode, expires));
+    }
+
+    static string Scope(string workspaceId, string sessionCode) => $"{workspaceId}\n{sessionCode}";
+
+    void PruneExpired()
+    {
+        var now = _time.GetUtcNow();
+        foreach (var key in _pairings.Where(item => item.Value.Used || item.Value.ExpiresAt <= now).Select(item => item.Key).ToArray())
+            _pairings.Remove(key);
+        foreach (var key in _tokens.Where(item => item.Value.ExpiresAt <= now).Select(item => item.Key).ToArray())
+            _tokens.Remove(key);
+    }
+
+    void RegisterPrefixAttempt(string code)
+    {
+        var prefix = code.Length >= 2 ? code[..2] : "invalid";
+        var now = _time.GetUtcNow();
+        var global = _globalAttempts;
+        if (global is null || global.StartedAt.AddMinutes(1) <= now) global = new(now, 0);
+        if (global.Count >= 100) throw new ShowAgentPairingThrottledException();
+        _globalAttempts = global with { Count = global.Count + 1 };
+        var window = _attemptsByPrefix.GetValueOrDefault(prefix);
+        if (window is null || window.StartedAt.AddMinutes(1) <= now) window = new(now, 0);
+        if (window.Count >= 20) throw new ShowAgentPairingThrottledException();
+        _attemptsByPrefix[prefix] = window with { Count = window.Count + 1 };
+    }
+}

--- a/Nuotti.Backend/ShowAgents/PostgresShowAgentAccessStore.cs
+++ b/Nuotti.Backend/ShowAgents/PostgresShowAgentAccessStore.cs
@@ -1,0 +1,236 @@
+using System.Text.Json;
+using Npgsql;
+
+namespace Nuotti.Backend.ShowAgents;
+
+/// <summary>Durable, replica-safe Show Agent pairing and lease store.</summary>
+public sealed class PostgresShowAgentAccessStore(NpgsqlDataSource dataSource, TimeProvider? timeProvider = null)
+    : IShowAgentAccessStore
+{
+    readonly SemaphoreSlim _initializeGate = new(1, 1);
+    readonly TimeProvider _time = timeProvider ?? TimeProvider.System;
+    volatile bool _initialized;
+
+    public Task<ShowAgentPairingCode> IssuePairingCodeAsync(string workspaceId, string sessionCode, string issuedBy,
+        CancellationToken cancellationToken = default) => MutateAsync(state =>
+    {
+        string code;
+        do code = ShowAgentTokens.PairingCode(); while (state.Pairings.ContainsKey(ShowAgentTokens.Hash(code)));
+        var expires = _time.GetUtcNow().AddMinutes(10);
+        state.Pairings[ShowAgentTokens.Hash(code)] = new ShowAgentPairingDocument
+            { WorkspaceId = workspaceId, SessionCode = sessionCode, IssuedBy = issuedBy, ExpiresAt = expires };
+        return new ShowAgentPairingCode(code, expires);
+    }, cancellationToken);
+
+    public Task<PairedShowAgent?> PairAsync(string code, string name, CancellationToken cancellationToken = default) =>
+        MutateAsync<PairedShowAgent?>(state =>
+        {
+            RegisterPrefixAttempt(state, code);
+            var hash = ShowAgentTokens.Hash(code);
+            if (!state.Pairings.TryGetValue(hash, out var pairing) || pairing.Used || pairing.ExpiresAt <= _time.GetUtcNow())
+                return null;
+            pairing.Used = true;
+            var credential = ShowAgentTokens.NewSecret();
+            var scope = Scope(pairing.WorkspaceId, pairing.SessionCode);
+            var agent = new ShowAgentDocument
+            {
+                Id = $"agent_{Guid.NewGuid():N}", Name = name.Trim(), WorkspaceId = pairing.WorkspaceId,
+                SessionCode = pairing.SessionCode, CredentialHash = ShowAgentTokens.Hash(credential),
+                CommandStartSequence = state.LastSequenceByScope.GetValueOrDefault(scope)
+            };
+            if (state.AgentByScope.TryGetValue(scope, out var oldId)) state.Agents[oldId].Revoked = true;
+            state.Agents[agent.Id] = agent;
+            state.AgentByScope[scope] = agent.Id;
+            var (token, lease) = IssueToken(state, agent);
+            return new PairedShowAgent(agent.Id, credential, token, lease.ExpiresAt);
+        }, cancellationToken);
+
+    public Task<(string Token, ShowAgentLease Lease)?> IssueAccessTokenAsync(string credential,
+        CancellationToken cancellationToken = default) => MutateAsync<(string, ShowAgentLease)?>(state =>
+    {
+        var hash = ShowAgentTokens.Hash(credential);
+        var agent = state.Agents.Values.FirstOrDefault(candidate => candidate.CredentialHash == hash && !candidate.Revoked);
+        return agent is null ? null : IssueToken(state, agent);
+    }, cancellationToken);
+
+    public Task<ShowAgentLease?> AuthenticateAsync(string accessToken, CancellationToken cancellationToken = default) =>
+        ReadAsync<ShowAgentLease?>(state =>
+        {
+            if (!state.Tokens.TryGetValue(ShowAgentTokens.Hash(accessToken), out var token)
+                || token.ExpiresAt <= _time.GetUtcNow() || !state.Agents.TryGetValue(token.AgentId, out var agent)
+                || agent.Revoked) return null;
+            return new(agent.Id, agent.WorkspaceId, agent.SessionCode, token.ExpiresAt);
+        }, cancellationToken);
+
+    public Task<bool> ReportStatusAsync(ShowAgentLease lease, ShowAgentConnectionState stateValue, string? detail,
+        CancellationToken cancellationToken = default) => MutateAsync(state =>
+    {
+        if (!state.Agents.TryGetValue(lease.AgentId, out var agent) || agent.Revoked) return false;
+        agent.State = stateValue; agent.Detail = detail; agent.LastSeenAt = _time.GetUtcNow();
+        return true;
+    }, cancellationToken);
+
+    public Task<ShowAgentStatus?> GetStatusAsync(string workspaceId, string sessionCode,
+        CancellationToken cancellationToken = default) => ReadAsync<ShowAgentStatus?>(state =>
+    {
+        if (!state.AgentByScope.TryGetValue(Scope(workspaceId, sessionCode), out var id)) return null;
+        var agent = state.Agents[id];
+        return new(agent.Id, agent.Name, workspaceId, sessionCode, agent.State, agent.Detail, agent.LastSeenAt, agent.Revoked);
+    }, cancellationToken);
+
+    public Task<bool> RevokeAsync(string workspaceId, string sessionCode, CancellationToken cancellationToken = default) =>
+        MutateAsync(state =>
+        {
+            if (!state.AgentByScope.TryGetValue(Scope(workspaceId, sessionCode), out var id) || state.Agents[id].Revoked)
+                return false;
+            state.Agents[id].Revoked = true;
+            return true;
+        }, cancellationToken);
+
+    public Task AppendCommandAsync(string workspaceId, string sessionCode, string messageType, object payload,
+        CancellationToken cancellationToken = default) => MutateAsync<object?>(state =>
+    {
+        var scope = Scope(workspaceId, sessionCode);
+        var commands = state.Commands.GetValueOrDefault(scope);
+        if (commands is null) state.Commands[scope] = commands = [];
+        var sequence = state.LastSequenceByScope.GetValueOrDefault(scope) + 1;
+        state.LastSequenceByScope[scope] = sequence;
+        commands.Add(new ShowAgentCommandDocument
+        {
+            Sequence = sequence,
+            MessageType = messageType,
+            Payload = JsonSerializer.SerializeToElement(payload, payload.GetType())
+        });
+        // Compact offline playback to the latest desired Play/Stop state.
+        if (commands.Count > 1) commands.RemoveRange(0, commands.Count - 1);
+        return null;
+    }, cancellationToken);
+
+    public Task<IReadOnlyList<ShowAgentCommand>?> ReadCommandsAsync(ShowAgentLease lease, long afterSequence,
+        CancellationToken cancellationToken = default) => MutateAsync<IReadOnlyList<ShowAgentCommand>?>(state =>
+    {
+        if (!state.Agents.TryGetValue(lease.AgentId, out var agent) || agent.Revoked) return null;
+        var acknowledged = Math.Max(afterSequence, agent.CommandStartSequence);
+        var commands = state.Commands.GetValueOrDefault(Scope(lease.WorkspaceId, lease.SessionCode));
+        if (commands is null) return [];
+        commands.RemoveAll(command => command.Sequence <= acknowledged);
+        return commands.Take(100).Select(command =>
+            new ShowAgentCommand(command.Sequence, command.MessageType, command.Payload)).ToArray();
+    }, cancellationToken);
+
+    (string Token, ShowAgentLease Lease) IssueToken(ShowAgentAccessDocument state, ShowAgentDocument agent)
+    {
+        var raw = ShowAgentTokens.NewSecret();
+        var expires = _time.GetUtcNow().AddMinutes(5);
+        state.Tokens[ShowAgentTokens.Hash(raw)] = new ShowAgentTokenDocument { AgentId = agent.Id, ExpiresAt = expires };
+        return (raw, new(agent.Id, agent.WorkspaceId, agent.SessionCode, expires));
+    }
+
+    async Task<T> ReadAsync<T>(Func<ShowAgentAccessDocument, T> read, CancellationToken ct)
+    {
+        await EnsureSchemaAsync(ct);
+        await using var command = dataSource.CreateCommand("SELECT state::text FROM nuotti_show_agent_access WHERE singleton=true");
+        return read(JsonSerializer.Deserialize<ShowAgentAccessDocument>((string)(await command.ExecuteScalarAsync(ct))!)!);
+    }
+
+    async Task<T> MutateAsync<T>(Func<ShowAgentAccessDocument, T> mutate, CancellationToken ct)
+    {
+        await EnsureSchemaAsync(ct);
+        await using var connection = await dataSource.OpenConnectionAsync(ct);
+        await using var transaction = await connection.BeginTransactionAsync(ct);
+        await using var load = new NpgsqlCommand(
+            "SELECT state::text FROM nuotti_show_agent_access WHERE singleton=true FOR UPDATE", connection, transaction);
+        var state = JsonSerializer.Deserialize<ShowAgentAccessDocument>((string)(await load.ExecuteScalarAsync(ct))!)!;
+        Prune(state);
+        var result = mutate(state);
+        await using var save = new NpgsqlCommand(
+            "UPDATE nuotti_show_agent_access SET state=$1::jsonb, updated_at=now() WHERE singleton=true", connection, transaction);
+        save.Parameters.AddWithValue(JsonSerializer.Serialize(state));
+        await save.ExecuteNonQueryAsync(ct);
+        await transaction.CommitAsync(ct);
+        return result;
+    }
+
+    async Task EnsureSchemaAsync(CancellationToken ct)
+    {
+        if (_initialized) return;
+        await _initializeGate.WaitAsync(ct);
+        try
+        {
+            if (_initialized) return;
+            await using var command = dataSource.CreateCommand("""
+                CREATE TABLE IF NOT EXISTS nuotti_show_agent_access (
+                    singleton boolean PRIMARY KEY DEFAULT true CHECK (singleton),
+                    state jsonb NOT NULL,
+                    updated_at timestamptz NOT NULL DEFAULT now());
+                INSERT INTO nuotti_show_agent_access(singleton, state)
+                VALUES (true, '{"Pairings":{},"Agents":{},"AgentByScope":{},"Tokens":{},"Commands":{}}'::jsonb)
+                ON CONFLICT (singleton) DO NOTHING;
+                """);
+            await command.ExecuteNonQueryAsync(ct);
+            _initialized = true;
+        }
+        finally { _initializeGate.Release(); }
+    }
+
+    static string Scope(string workspaceId, string sessionCode) => $"{workspaceId}\n{sessionCode}";
+
+    void Prune(ShowAgentAccessDocument state)
+    {
+        var now = _time.GetUtcNow();
+        foreach (var key in state.Pairings.Where(item => item.Value.Used || item.Value.ExpiresAt <= now).Select(item => item.Key).ToArray())
+            state.Pairings.Remove(key);
+        foreach (var key in state.Tokens.Where(item => item.Value.ExpiresAt <= now).Select(item => item.Key).ToArray())
+            state.Tokens.Remove(key);
+        foreach (var key in state.AttemptsByPrefix.Where(item => item.Value.StartedAt.AddMinutes(1) <= now).Select(item => item.Key).ToArray())
+            state.AttemptsByPrefix.Remove(key);
+    }
+
+    void RegisterPrefixAttempt(ShowAgentAccessDocument state, string code)
+    {
+        var prefix = code.Length >= 2 ? code[..2] : "invalid";
+        var now = _time.GetUtcNow();
+        var global = state.GlobalAttempts;
+        if (global is null || global.StartedAt.AddMinutes(1) <= now)
+            global = new ShowAgentAttemptDocument { StartedAt = now };
+        if (global.Count >= 100) throw new ShowAgentPairingThrottledException();
+        global.Count++;
+        state.GlobalAttempts = global;
+        var window = state.AttemptsByPrefix.GetValueOrDefault(prefix);
+        if (window is null || window.StartedAt.AddMinutes(1) <= now)
+            window = new ShowAgentAttemptDocument { StartedAt = now };
+        if (window.Count >= 20) throw new ShowAgentPairingThrottledException();
+        window.Count++;
+        state.AttemptsByPrefix[prefix] = window;
+    }
+}
+
+internal sealed class ShowAgentAccessDocument
+{
+    public Dictionary<string, ShowAgentPairingDocument> Pairings { get; set; } = [];
+    public Dictionary<string, ShowAgentDocument> Agents { get; set; } = [];
+    public Dictionary<string, string> AgentByScope { get; set; } = [];
+    public Dictionary<string, ShowAgentTokenDocument> Tokens { get; set; } = [];
+    public Dictionary<string, List<ShowAgentCommandDocument>> Commands { get; set; } = [];
+    public Dictionary<string, long> LastSequenceByScope { get; set; } = [];
+    public Dictionary<string, ShowAgentAttemptDocument> AttemptsByPrefix { get; set; } = [];
+    public ShowAgentAttemptDocument? GlobalAttempts { get; set; }
+}
+internal sealed class ShowAgentPairingDocument
+{
+    public string WorkspaceId { get; set; } = ""; public string SessionCode { get; set; } = "";
+    public string IssuedBy { get; set; } = ""; public DateTimeOffset ExpiresAt { get; set; } public bool Used { get; set; }
+}
+internal sealed class ShowAgentDocument
+{
+    public string Id { get; set; } = ""; public string Name { get; set; } = ""; public string WorkspaceId { get; set; } = "";
+    public string SessionCode { get; set; } = ""; public string CredentialHash { get; set; } = ""; public bool Revoked { get; set; }
+    public long CommandStartSequence { get; set; }
+    public ShowAgentConnectionState State { get; set; } public string? Detail { get; set; } public DateTimeOffset? LastSeenAt { get; set; }
+}
+internal sealed class ShowAgentTokenDocument { public string AgentId { get; set; } = ""; public DateTimeOffset ExpiresAt { get; set; } }
+internal sealed class ShowAgentCommandDocument
+{
+    public long Sequence { get; set; } public string MessageType { get; set; } = ""; public JsonElement Payload { get; set; }
+}
+internal sealed class ShowAgentAttemptDocument { public DateTimeOffset StartedAt { get; set; } public int Count { get; set; } }

--- a/Nuotti.Backend/ShowAgents/ShowAgentAccess.cs
+++ b/Nuotti.Backend/ShowAgents/ShowAgentAccess.cs
@@ -1,0 +1,45 @@
+using System.Text.Json.Serialization;
+
+namespace Nuotti.Backend.ShowAgents;
+
+[JsonConverter(typeof(JsonStringEnumConverter<ShowAgentConnectionState>))]
+public enum ShowAgentConnectionState { Offline, Ready, Playing, Error }
+
+public sealed record ShowAgentPairingCode(string Code, DateTimeOffset ExpiresAt);
+public sealed record PairedShowAgent(string AgentId, string Credential, string AccessToken, DateTimeOffset AccessTokenExpiresAt);
+public sealed record ShowAgentLease(string AgentId, string WorkspaceId, string SessionCode, DateTimeOffset ExpiresAt);
+public sealed record ShowAgentStatus(
+    string AgentId, string Name, string WorkspaceId, string SessionCode,
+    ShowAgentConnectionState State, string? Detail, DateTimeOffset? LastSeenAt, bool Revoked);
+public sealed record ShowAgentCommand(long Sequence, string MessageType, object Payload);
+public sealed class ShowAgentPairingThrottledException : System.Exception;
+
+public interface IShowAgentAccessStore
+{
+    Task<ShowAgentPairingCode> IssuePairingCodeAsync(string workspaceId, string sessionCode, string issuedBy,
+        CancellationToken cancellationToken = default);
+    Task<PairedShowAgent?> PairAsync(string code, string name, CancellationToken cancellationToken = default);
+    Task<(string Token, ShowAgentLease Lease)?> IssueAccessTokenAsync(string credential,
+        CancellationToken cancellationToken = default);
+    Task<ShowAgentLease?> AuthenticateAsync(string accessToken, CancellationToken cancellationToken = default);
+    Task<bool> ReportStatusAsync(ShowAgentLease lease, ShowAgentConnectionState state, string? detail,
+        CancellationToken cancellationToken = default);
+    Task<ShowAgentStatus?> GetStatusAsync(string workspaceId, string sessionCode,
+        CancellationToken cancellationToken = default);
+    Task<bool> RevokeAsync(string workspaceId, string sessionCode, CancellationToken cancellationToken = default);
+    Task AppendCommandAsync(string workspaceId, string sessionCode, string messageType, object payload,
+        CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<ShowAgentCommand>?> ReadCommandsAsync(ShowAgentLease lease, long afterSequence,
+        CancellationToken cancellationToken = default);
+}
+
+internal static class ShowAgentTokens
+{
+    internal static string NewSecret() => Convert.ToBase64String(
+        System.Security.Cryptography.RandomNumberGenerator.GetBytes(32))
+        .Replace('+', '-').Replace('/', '_').TrimEnd('=');
+    internal static string Hash(string value) => Convert.ToHexString(
+        System.Security.Cryptography.SHA256.HashData(System.Text.Encoding.UTF8.GetBytes(value)));
+    internal static string PairingCode() => System.Security.Cryptography.RandomNumberGenerator
+        .GetInt32(0, 100_000_000).ToString("D8");
+}

--- a/Nuotti.Backend/ShowAgents/ShowAgentCommandSubscriber.cs
+++ b/Nuotti.Backend/ShowAgents/ShowAgentCommandSubscriber.cs
@@ -1,0 +1,28 @@
+using Nuotti.Backend.Persistence;
+using Nuotti.Contracts.V1.Eventing;
+using Nuotti.Contracts.V1.Message;
+
+namespace Nuotti.Backend.ShowAgents;
+
+public sealed class ShowAgentCommandSubscriber : IDisposable
+{
+    readonly IDisposable _subscription;
+
+    public ShowAgentCommandSubscriber(IEventBus bus, IShowAgentAccessStore store)
+    {
+        _subscription = bus.Subscribe<SessionMessagePublisher.WorkspacePublication>(async (publication, ct) =>
+        {
+            var messageType = publication.Payload switch
+            {
+                PlayTrack => "PlayTrack",
+                StopTrack => "StopTrack",
+                _ => null
+            };
+            if (messageType is not null)
+                await store.AppendCommandAsync(publication.WorkspaceId, publication.SessionCode,
+                    messageType, publication.Payload, ct);
+        });
+    }
+
+    public void Dispose() => _subscription.Dispose();
+}


### PR DESCRIPTION
Closes #251

- adds short-lived, throttled one-time pairing and five-minute Session-scoped Agent leases
- persists hashed credentials, status, revocation, command generation, and attempt budgets in PostgreSQL
- adds outbound-only Play/Stop polling with latest-desired-state compaction
- protects the long-lived Windows credential and acknowledged cursor with CurrentUser DPAPI
- makes revocation Owner-only, blocks new commands immediately, and lets current playback finish

Verification: 74/74 Audio Engine tests and 144/144 Backend tests pass; standards and spec reviews clean.