### PR TITLE
Implement private asset revision lifecycle

### DIFF
--- a/Nuotti.Backend.Tests/PrivateAssetJourneyTests.cs
+++ b/Nuotti.Backend.Tests/PrivateAssetJourneyTests.cs
@@ -39,11 +39,19 @@ public sealed class PrivateAssetJourneyTests(WebApplicationFactory<QuizHub> base
         var entry = await store.CreateEntryAsync("workspace", "Song", "Artist", "owner");
         var draft = await store.CreateDraftAsync("workspace", entry.CatalogEntryId, "backing-track", "audio/wav", 4,
             new("owned", "original", "NO", ["backing-track"], null, "rights-case"), "owner");
-        Assert.NotNull(await store.TryBeginFinalizationAsync("workspace", draft!.Value.Revision.RevisionId));
+        var oldClaim = await store.TryBeginFinalizationAsync("workspace", draft!.Value.Revision.RevisionId);
+        Assert.NotNull(oldClaim);
         Assert.Null(await store.TryBeginFinalizationAsync("workspace", draft.Value.Revision.RevisionId));
 
         time.Advance(TimeSpan.FromMinutes(11));
 
+        var newClaim = await store.TryBeginFinalizationAsync("workspace", draft.Value.Revision.RevisionId);
+        Assert.NotNull(newClaim);
+        await store.CancelFinalizationAsync("workspace", draft.Value.Revision.RevisionId, oldClaim.Token);
+        Assert.Null(await store.TryBeginFinalizationAsync("workspace", draft.Value.Revision.RevisionId));
+        Assert.Null(await store.PublishAsync("workspace", draft.Value.Revision.RevisionId, "sealed",
+            oldClaim.Token, 4, new string('a', 64)));
+        await store.CancelFinalizationAsync("workspace", draft.Value.Revision.RevisionId, newClaim.Token);
         Assert.NotNull(await store.TryBeginFinalizationAsync("workspace", draft.Value.Revision.RevisionId));
     }
 

--- a/Nuotti.Backend.Tests/PrivateAssetJourneyTests.cs
+++ b/Nuotti.Backend.Tests/PrivateAssetJourneyTests.cs
@@ -1,0 +1,191 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Security.Cryptography;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Nuotti.Backend;
+using Nuotti.Backend.Assets;
+using Nuotti.Backend.Workspaces;
+
+namespace Nuotti.Backend.Tests;
+
+public sealed class PrivateAssetJourneyTests(WebApplicationFactory<QuizHub> baseFactory)
+    : IClassFixture<WebApplicationFactory<QuizHub>>
+{
+    readonly WebApplicationFactory<QuizHub> _factory = baseFactory.WithWebHostBuilder(_ => { });
+
+    [Fact]
+    public async Task Concurrent_publication_claims_allow_only_one_finalizer()
+    {
+        var store = new InMemoryPrivateAssetMetadataStore();
+        var entry = await store.CreateEntryAsync("workspace", "Song", "Artist", "owner");
+        var provenance = new AssetProvenance("owned", "original recording", "NO",
+            ["backing-track"], null, "rights-case");
+        var draft = await store.CreateDraftAsync("workspace", entry.CatalogEntryId, "backing-track",
+            "audio/wav", 4, provenance, "owner");
+
+        var claims = await Task.WhenAll(Enumerable.Range(0, 8)
+            .Select(_ => store.TryBeginFinalizationAsync("workspace", draft!.Value.Revision.RevisionId)));
+
+        Assert.Single(claims, claim => claim is not null);
+    }
+
+    [Fact]
+    public async Task Stale_publication_claim_can_be_recovered()
+    {
+        var time = new MutableTimeProvider(DateTimeOffset.Parse("2026-07-31T12:00:00Z"));
+        var store = new InMemoryPrivateAssetMetadataStore(time);
+        var entry = await store.CreateEntryAsync("workspace", "Song", "Artist", "owner");
+        var draft = await store.CreateDraftAsync("workspace", entry.CatalogEntryId, "backing-track", "audio/wav", 4,
+            new("owned", "original", "NO", ["backing-track"], null, "rights-case"), "owner");
+        Assert.NotNull(await store.TryBeginFinalizationAsync("workspace", draft!.Value.Revision.RevisionId));
+        Assert.Null(await store.TryBeginFinalizationAsync("workspace", draft.Value.Revision.RevisionId));
+
+        time.Advance(TimeSpan.FromMinutes(11));
+
+        Assert.NotNull(await store.TryBeginFinalizationAsync("workspace", draft.Value.Revision.RevisionId));
+    }
+
+    [Fact]
+    public async Task Member_uploads_directly_publishes_immutable_revision_and_owner_archives_it()
+    {
+        using var client = _factory.CreateClient();
+        var owner = await SignInAsync(client, "asset-owner");
+        var workspace = await PostAsync<WorkspaceAccess>(client, "/v1/workspaces", owner.SessionToken, new { name = "Asset band" });
+        await SelectAsync(client, owner.SessionToken, workspace.WorkspaceId);
+        var invitation = await PostAsync<IssuedMagicLink>(client,
+            $"/v1/workspaces/{workspace.WorkspaceId}/invitations", owner.SessionToken,
+            new { email = $"asset-member-{Guid.NewGuid():N}@example.test" });
+        var member = await PostAsync<RedeemedMagicLink>(client, "/v1/auth/magic-links/redeem", null, new { token = invitation.Token });
+        await SelectAsync(client, member.SessionToken, workspace.WorkspaceId);
+
+        var entry = await PostAsync<PrivateCatalogEntry>(client,
+            $"/v1/workspaces/{workspace.WorkspaceId}/catalog", member.SessionToken,
+            new { title = "Midnight Train", artist = "The Examples" });
+        var expiredUpload = await SendAsync(client, HttpMethod.Post,
+            $"/v1/workspaces/{workspace.WorkspaceId}/catalog/{entry.CatalogEntryId}/asset-uploads", member.SessionToken,
+            new
+            {
+                assetType = "backing-track", contentType = "audio/wav", size = 10,
+                provenance = new { source = "licensed", rightsBasis = "venue licence", territory = "NO", permittedUses = new[] { "backing-track" }, rightsExpiresAt = DateTimeOffset.UtcNow.AddMinutes(-1), supportingDocumentReference = "expired-case" }
+            });
+        Assert.Equal(HttpStatusCode.BadRequest, expiredUpload.StatusCode);
+        var arbitraryUse = await SendAsync(client, HttpMethod.Post,
+            $"/v1/workspaces/{workspace.WorkspaceId}/catalog/{entry.CatalogEntryId}/asset-uploads", member.SessionToken,
+            new
+            {
+                assetType = "backing-track", contentType = "audio/wav", size = 10,
+                provenance = new { source = "licensed", rightsBasis = "venue licence", territory = "NO", permittedUses = new[] { "anything-goes" }, rightsExpiresAt = (DateTimeOffset?)null, supportingDocumentReference = "bad-use" }
+            });
+        Assert.Equal(HttpStatusCode.BadRequest, arbitraryUse.StatusCode);
+        var provenance = new AssetProvenance("licensed master", "venue playback licence", "NO",
+            ["backing-track", "live-performance"], DateTimeOffset.UtcNow.AddYears(1), "rights-case-42");
+        var bytes = "private-audio-bytes"u8.ToArray();
+        var upload = await PostAsync<PrivateAssetUploadGrant>(client,
+            $"/v1/workspaces/{workspace.WorkspaceId}/catalog/{entry.CatalogEntryId}/asset-uploads", member.SessionToken,
+            new { assetType = "backing-track", contentType = "audio/wav", size = bytes.LongLength, provenance });
+        Assert.Equal("objects.invalid", upload.UploadUri.Host);
+        Assert.DoesNotContain(workspace.WorkspaceId, upload.UploadUri.AbsoluteUri, StringComparison.Ordinal);
+
+        var metadata = _factory.Services.GetRequiredService<IPrivateAssetMetadataStore>();
+        var objects = Assert.IsType<InMemoryPrivateAssetObjectStore>(_factory.Services.GetRequiredService<IPrivateAssetObjectStore>());
+        var objectKey = await metadata.GetObjectKeyAsync(workspace.WorkspaceId, upload.Revision.RevisionId);
+        objects.PutDirect(objectKey!, bytes, "audio/wav"); // Models the client PUT to object storage; no Backend byte endpoint exists.
+        var sha256 = Convert.ToHexString(SHA256.HashData(bytes)).ToLowerInvariant();
+
+        var published = await PostAsync<PrivateAssetRevision>(client,
+            $"/v1/workspaces/{workspace.WorkspaceId}/revisions/{upload.Revision.RevisionId}/publish", member.SessionToken,
+            new { sha256 });
+        Assert.Equal(AssetRevisionStatus.Published, published.Status);
+        Assert.Equal(sha256, published.Sha256);
+        Assert.Equal(provenance.Source, published.Provenance.Source);
+        Assert.Equal(provenance.RightsBasis, published.Provenance.RightsBasis);
+        Assert.Equal(provenance.Territory, published.Provenance.Territory);
+        Assert.Equal(provenance.PermittedUses, published.Provenance.PermittedUses);
+        Assert.Equal(provenance.RightsExpiresAt, published.Provenance.RightsExpiresAt);
+        Assert.Equal(provenance.SupportingDocumentReference, published.Provenance.SupportingDocumentReference);
+        var sealedKey = await metadata.GetObjectKeyAsync(workspace.WorkspaceId, published.RevisionId);
+        Assert.NotEqual(objectKey, sealedKey);
+        objects.PutDirect(objectKey!, "mutated-after-publish"u8.ToArray(), "audio/wav");
+        Assert.Equal(bytes, objects.GetDirect(sealedKey!));
+
+        var republish = await SendAsync(client, HttpMethod.Post,
+            $"/v1/workspaces/{workspace.WorkspaceId}/revisions/{published.RevisionId}/publish", member.SessionToken,
+            new { sha256 });
+        Assert.Equal(HttpStatusCode.Conflict, republish.StatusCode);
+        var download = await PostAsync<PrivateAssetDownloadGrant>(client,
+            $"/v1/workspaces/{workspace.WorkspaceId}/revisions/{published.RevisionId}/download", member.SessionToken, null);
+        Assert.Equal("objects.invalid", download.DownloadUri.Host);
+
+        var archived = await DeleteAsync<PrivateAssetRevision>(client,
+            $"/v1/workspaces/{workspace.WorkspaceId}/revisions/{published.RevisionId}", owner.SessionToken);
+        Assert.Equal(AssetRevisionStatus.Archived, archived.Status);
+        var afterArchive = await SendAsync(client, HttpMethod.Post,
+            $"/v1/workspaces/{workspace.WorkspaceId}/revisions/{published.RevisionId}/download", member.SessionToken);
+        Assert.Equal(HttpStatusCode.NotFound, afterArchive.StatusCode);
+    }
+
+    [Fact]
+    public async Task Another_workspace_cannot_discover_revision_object_or_grants()
+    {
+        using var client = _factory.CreateClient();
+        var owner = await SignInAsync(client, "isolation-owner");
+        var workspace = await PostAsync<WorkspaceAccess>(client, "/v1/workspaces", owner.SessionToken, new { name = "Private band" });
+        await SelectAsync(client, owner.SessionToken, workspace.WorkspaceId);
+        var entry = await PostAsync<PrivateCatalogEntry>(client,
+            $"/v1/workspaces/{workspace.WorkspaceId}/catalog", owner.SessionToken, new { title = "Secret", artist = "Band" });
+        var upload = await PostAsync<PrivateAssetUploadGrant>(client,
+            $"/v1/workspaces/{workspace.WorkspaceId}/catalog/{entry.CatalogEntryId}/asset-uploads", owner.SessionToken,
+            new
+            {
+                assetType = "image", contentType = "image/png", size = 4,
+                provenance = new { source = "commissioned", rightsBasis = "owned", territory = "NO", permittedUses = new[] { "visual-hint" }, rightsExpiresAt = (DateTimeOffset?)null, supportingDocumentReference = "case-7" }
+            });
+
+        var attacker = await SignInAsync(client, "asset-attacker");
+        var other = await PostAsync<WorkspaceAccess>(client, "/v1/workspaces", attacker.SessionToken, new { name = "Other band" });
+        await SelectAsync(client, attacker.SessionToken, other.WorkspaceId);
+        var hidden = await SendAsync(client, HttpMethod.Get,
+            $"/v1/workspaces/{other.WorkspaceId}/revisions/{upload.Revision.RevisionId}", attacker.SessionToken);
+        var random = await SendAsync(client, HttpMethod.Get,
+            $"/v1/workspaces/{other.WorkspaceId}/revisions/rev_missing", attacker.SessionToken);
+        Assert.Equal(HttpStatusCode.NotFound, hidden.StatusCode);
+        Assert.Equal(random.StatusCode, hidden.StatusCode);
+        Assert.Null(await _factory.Services.GetRequiredService<IPrivateAssetMetadataStore>()
+            .GetObjectKeyAsync(other.WorkspaceId, upload.Revision.RevisionId));
+    }
+
+    static async Task<RedeemedMagicLink> SignInAsync(HttpClient client, string prefix)
+    {
+        var link = await PostAsync<IssuedMagicLink>(client, "/v1/auth/magic-links", null,
+            new { email = $"{prefix}-{Guid.NewGuid():N}@example.test" });
+        return await PostAsync<RedeemedMagicLink>(client, "/v1/auth/magic-links/redeem", null, new { token = link.Token });
+    }
+    static async Task SelectAsync(HttpClient client, string token, string workspaceId) =>
+        (await SendAsync(client, HttpMethod.Post, $"/v1/workspaces/{workspaceId}/select", token)).EnsureSuccessStatusCode();
+    static async Task<T> PostAsync<T>(HttpClient client, string path, string? token, object? body)
+    {
+        var response = await SendAsync(client, HttpMethod.Post, path, token, body); response.EnsureSuccessStatusCode();
+        return (await response.Content.ReadFromJsonAsync<T>())!;
+    }
+    static async Task<T> DeleteAsync<T>(HttpClient client, string path, string token)
+    {
+        var response = await SendAsync(client, HttpMethod.Delete, path, token); response.EnsureSuccessStatusCode();
+        return (await response.Content.ReadFromJsonAsync<T>())!;
+    }
+    static async Task<HttpResponseMessage> SendAsync(HttpClient client, HttpMethod method, string path, string? token, object? body = null)
+    {
+        using var request = new HttpRequestMessage(method, path);
+        if (token is not null) request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        if (body is not null) request.Content = JsonContent.Create(body);
+        return await client.SendAsync(request);
+    }
+
+    sealed class MutableTimeProvider(DateTimeOffset now) : TimeProvider
+    {
+        DateTimeOffset _now = now;
+        public override DateTimeOffset GetUtcNow() => _now;
+        public void Advance(TimeSpan duration) => _now += duration;
+    }
+}

--- a/Nuotti.Backend/Assets/AzurePrivateAssetObjectStore.cs
+++ b/Nuotti.Backend/Assets/AzurePrivateAssetObjectStore.cs
@@ -1,0 +1,71 @@
+using Azure.Storage.Blobs;
+using Azure.Storage.Sas;
+using System.Security.Cryptography;
+
+namespace Nuotti.Backend.Assets;
+
+public sealed class AzurePrivateAssetObjectStore(BlobServiceClient service, TimeProvider? timeProvider = null)
+    : IPrivateAssetObjectStore
+{
+    readonly TimeProvider _time = timeProvider ?? TimeProvider.System;
+
+    public async Task<(Uri Uri, DateTimeOffset ExpiresAt)> CreateUploadGrantAsync(
+        string objectKey, string contentType, CancellationToken cancellationToken = default)
+    {
+        var blob = await BlobAsync(objectKey, cancellationToken);
+        if (!blob.CanGenerateSasUri) throw new PrivateAssetGrantUnavailableException();
+        var expires = _time.GetUtcNow().AddMinutes(5);
+        return (blob.GenerateSasUri(BlobSasPermissions.Create | BlobSasPermissions.Write, expires), expires);
+    }
+
+    public async Task<(Uri Uri, DateTimeOffset ExpiresAt)> CreateDownloadGrantAsync(
+        string objectKey, CancellationToken cancellationToken = default)
+    {
+        var blob = await SealedBlobAsync(objectKey, cancellationToken);
+        if (!blob.CanGenerateSasUri) throw new PrivateAssetGrantUnavailableException();
+        var expires = _time.GetUtcNow().AddMinutes(2);
+        return (blob.GenerateSasUri(BlobSasPermissions.Read, expires), expires);
+    }
+
+    public async Task<SealedPrivateObject?> SealAsync(string objectKey, CancellationToken cancellationToken = default)
+    {
+        var blob = await BlobAsync(objectKey, cancellationToken);
+        if (!await blob.ExistsAsync(cancellationToken)) return null;
+        var snapshot = (await blob.CreateSnapshotAsync(cancellationToken: cancellationToken)).Value.Snapshot;
+        var sealedBlob = blob.WithSnapshot(snapshot);
+        var properties = (await sealedBlob.GetPropertiesAsync(cancellationToken: cancellationToken)).Value;
+        await using var content = await sealedBlob.OpenReadAsync(cancellationToken: cancellationToken);
+        var sha256 = Convert.ToHexString(await SHA256.HashDataAsync(content, cancellationToken)).ToLowerInvariant();
+        return new(new SealedReference(objectKey, snapshot).ToString(),
+            new(properties.ContentLength, properties.ContentType, sha256, properties.ETag.ToString()));
+    }
+
+    async Task<BlobClient> BlobAsync(string objectKey, CancellationToken ct)
+    {
+        var container = service.GetBlobContainerClient("private-song-assets");
+        await container.CreateIfNotExistsAsync(cancellationToken: ct);
+        return container.GetBlobClient(objectKey);
+    }
+
+    async Task<BlobClient> SealedBlobAsync(string reference, CancellationToken ct)
+    {
+        var parsed = SealedReference.Parse(reference);
+        return (await BlobAsync(parsed.ObjectKey, ct)).WithSnapshot(parsed.Snapshot);
+    }
+
+    public async Task DiscardSealedAsync(string objectKey, CancellationToken cancellationToken = default) =>
+        await (await SealedBlobAsync(objectKey, cancellationToken)).DeleteIfExistsAsync(cancellationToken: cancellationToken);
+
+    sealed record SealedReference(string ObjectKey, string Snapshot)
+    {
+        public override string ToString() => $"{ObjectKey}|{Snapshot}";
+        public static SealedReference Parse(string value)
+        {
+            var separator = value.LastIndexOf('|');
+            if (separator <= 0 || separator == value.Length - 1) throw new PrivateAssetGrantUnavailableException();
+            return new(value[..separator], value[(separator + 1)..]);
+        }
+    }
+}
+
+public sealed class PrivateAssetGrantUnavailableException : System.Exception;

--- a/Nuotti.Backend/Assets/InMemoryPrivateAssetStores.cs
+++ b/Nuotti.Backend/Assets/InMemoryPrivateAssetStores.cs
@@ -1,0 +1,144 @@
+namespace Nuotti.Backend.Assets;
+
+public sealed class InMemoryPrivateAssetMetadataStore(TimeProvider? timeProvider = null) : IPrivateAssetMetadataStore
+{
+    sealed record StoredRevision(PrivateAssetRevision Revision, string ObjectKey, DateTimeOffset? FinalizingAt = null);
+    readonly object _gate = new();
+    readonly TimeProvider _time = timeProvider ?? TimeProvider.System;
+    readonly Dictionary<string, PrivateCatalogEntry> _entries = [];
+    readonly Dictionary<string, StoredRevision> _revisions = [];
+
+    public Task<PrivateCatalogEntry> CreateEntryAsync(string workspaceId, string title, string artist, string userId,
+        CancellationToken cancellationToken = default)
+    {
+        lock (_gate)
+        {
+            var entry = new PrivateCatalogEntry($"entry_{Guid.NewGuid():N}", workspaceId, title.Trim(), artist.Trim(), userId, _time.GetUtcNow());
+            _entries[entry.CatalogEntryId] = entry;
+            return Task.FromResult(entry);
+        }
+    }
+
+    public Task<(PrivateAssetRevision Revision, string ObjectKey)?> CreateDraftAsync(
+        string workspaceId, string catalogEntryId, string assetType, string contentType, long declaredSize,
+        AssetProvenance provenance, string userId, CancellationToken cancellationToken = default)
+    {
+        lock (_gate)
+        {
+            if (!_entries.TryGetValue(catalogEntryId, out var entry) || entry.WorkspaceId != workspaceId)
+                return Task.FromResult<(PrivateAssetRevision, string)?>(null);
+            var revision = new PrivateAssetRevision($"rev_{Guid.NewGuid():N}", catalogEntryId, workspaceId,
+                AssetRevisionStatus.Draft, assetType, contentType, declaredSize, null, null, provenance,
+                userId, _time.GetUtcNow(), null, null);
+            var key = $"asset_{Guid.NewGuid():N}";
+            _revisions[revision.RevisionId] = new(revision, key);
+            return Task.FromResult<(PrivateAssetRevision, string)?>(new(revision, key));
+        }
+    }
+
+    public Task<PrivateAssetRevision?> PublishAsync(string workspaceId, string revisionId, string sealedObjectKey,
+        long storedSize, string sha256,
+        CancellationToken cancellationToken = default)
+    {
+        lock (_gate)
+        {
+            if (!_revisions.TryGetValue(revisionId, out var stored) || stored.Revision.WorkspaceId != workspaceId
+                || stored.Revision.Status != AssetRevisionStatus.Finalizing || stored.Revision.DeclaredSize != storedSize)
+                return Task.FromResult<PrivateAssetRevision?>(null);
+            var published = stored.Revision with
+            {
+                Status = AssetRevisionStatus.Published, StoredSize = storedSize,
+                Sha256 = sha256.ToLowerInvariant(), PublishedAt = _time.GetUtcNow()
+            };
+            _revisions[revisionId] = stored with { Revision = published, ObjectKey = sealedObjectKey, FinalizingAt = null };
+            return Task.FromResult<PrivateAssetRevision?>(published);
+        }
+    }
+
+    public Task<PrivateAssetRevision?> TryBeginFinalizationAsync(string workspaceId, string revisionId,
+        CancellationToken cancellationToken = default)
+    {
+        lock (_gate)
+        {
+            if (!_revisions.TryGetValue(revisionId, out var stored) || stored.Revision.WorkspaceId != workspaceId
+                || (stored.Revision.Status != AssetRevisionStatus.Draft
+                    && !(stored.Revision.Status == AssetRevisionStatus.Finalizing
+                        && stored.FinalizingAt <= _time.GetUtcNow().AddMinutes(-10))))
+                return Task.FromResult<PrivateAssetRevision?>(null);
+            var finalizing = stored.Revision with { Status = AssetRevisionStatus.Finalizing };
+            _revisions[revisionId] = stored with { Revision = finalizing, FinalizingAt = _time.GetUtcNow() };
+            return Task.FromResult<PrivateAssetRevision?>(finalizing);
+        }
+    }
+
+    public Task CancelFinalizationAsync(string workspaceId, string revisionId, CancellationToken cancellationToken = default)
+    {
+        lock (_gate)
+        {
+            if (_revisions.TryGetValue(revisionId, out var stored) && stored.Revision.WorkspaceId == workspaceId
+                && stored.Revision.Status == AssetRevisionStatus.Finalizing)
+                _revisions[revisionId] = stored with
+                {
+                    Revision = stored.Revision with { Status = AssetRevisionStatus.Draft }, FinalizingAt = null
+                };
+        }
+        return Task.CompletedTask;
+    }
+
+    public Task<PrivateAssetRevision?> GetAsync(string workspaceId, string revisionId, CancellationToken cancellationToken = default)
+    {
+        lock (_gate) return Task.FromResult<PrivateAssetRevision?>(_revisions.TryGetValue(revisionId, out var stored)
+            && stored.Revision.WorkspaceId == workspaceId ? stored.Revision : null);
+    }
+
+    public Task<string?> GetObjectKeyAsync(string workspaceId, string revisionId, CancellationToken cancellationToken = default)
+    {
+        lock (_gate) return Task.FromResult(_revisions.TryGetValue(revisionId, out var stored)
+            && stored.Revision.WorkspaceId == workspaceId ? stored.ObjectKey : null);
+    }
+
+    public Task<PrivateAssetRevision?> ArchiveAsync(string workspaceId, string revisionId, CancellationToken cancellationToken = default)
+    {
+        lock (_gate)
+        {
+            if (!_revisions.TryGetValue(revisionId, out var stored) || stored.Revision.WorkspaceId != workspaceId
+                || stored.Revision.Status != AssetRevisionStatus.Published) return Task.FromResult<PrivateAssetRevision?>(null);
+            var archived = stored.Revision with { Status = AssetRevisionStatus.Archived, ArchivedAt = _time.GetUtcNow() };
+            _revisions[revisionId] = stored with { Revision = archived };
+            return Task.FromResult<PrivateAssetRevision?>(archived);
+        }
+    }
+}
+
+public sealed class InMemoryPrivateAssetObjectStore(TimeProvider? timeProvider = null) : IPrivateAssetObjectStore
+{
+    readonly TimeProvider _time = timeProvider ?? TimeProvider.System;
+    readonly Dictionary<string, byte[]> _objects = [];
+    public Task<(Uri Uri, DateTimeOffset ExpiresAt)> CreateUploadGrantAsync(string objectKey, string contentType,
+        CancellationToken cancellationToken = default) => Task.FromResult((new Uri($"https://objects.invalid/upload/{objectKey}?grant={Guid.NewGuid():N}"), _time.GetUtcNow().AddMinutes(5)));
+    public Task<(Uri Uri, DateTimeOffset ExpiresAt)> CreateDownloadGrantAsync(string objectKey,
+        CancellationToken cancellationToken = default) => Task.FromResult((new Uri($"https://objects.invalid/download/{objectKey}?grant={Guid.NewGuid():N}"), _time.GetUtcNow().AddMinutes(5)));
+    readonly Dictionary<string, string> _contentTypes = [];
+    public Task<SealedPrivateObject?> SealAsync(string objectKey, CancellationToken cancellationToken = default)
+    {
+        if (!_objects.TryGetValue(objectKey, out var bytes)) return Task.FromResult<SealedPrivateObject?>(null);
+        var sealedKey = $"sealed_{Guid.NewGuid():N}";
+        _objects[sealedKey] = bytes.ToArray();
+        var contentType = _contentTypes.GetValueOrDefault(objectKey, "application/octet-stream");
+        _contentTypes[sealedKey] = contentType;
+        var evidence = new PrivateObjectEvidence(bytes.LongLength, contentType,
+            Convert.ToHexString(System.Security.Cryptography.SHA256.HashData(bytes)).ToLowerInvariant(),
+            $"memory-{Guid.NewGuid():N}");
+        return Task.FromResult<SealedPrivateObject?>(new(sealedKey, evidence));
+    }
+    public void PutDirect(string objectKey, byte[] bytes, string contentType = "application/octet-stream")
+    {
+        _objects[objectKey] = bytes;
+        _contentTypes[objectKey] = contentType;
+    }
+    public byte[]? GetDirect(string objectKey) => _objects.TryGetValue(objectKey, out var bytes) ? bytes.ToArray() : null;
+    public Task DiscardSealedAsync(string objectKey, CancellationToken cancellationToken = default)
+    {
+        _objects.Remove(objectKey); _contentTypes.Remove(objectKey); return Task.CompletedTask;
+    }
+}

--- a/Nuotti.Backend/Assets/InMemoryPrivateAssetStores.cs
+++ b/Nuotti.Backend/Assets/InMemoryPrivateAssetStores.cs
@@ -2,7 +2,8 @@ namespace Nuotti.Backend.Assets;
 
 public sealed class InMemoryPrivateAssetMetadataStore(TimeProvider? timeProvider = null) : IPrivateAssetMetadataStore
 {
-    sealed record StoredRevision(PrivateAssetRevision Revision, string ObjectKey, DateTimeOffset? FinalizingAt = null);
+    sealed record StoredRevision(PrivateAssetRevision Revision, string ObjectKey,
+        DateTimeOffset? FinalizingAt = null, string? FinalizationToken = null);
     readonly object _gate = new();
     readonly TimeProvider _time = timeProvider ?? TimeProvider.System;
     readonly Dictionary<string, PrivateCatalogEntry> _entries = [];
@@ -37,25 +38,29 @@ public sealed class InMemoryPrivateAssetMetadataStore(TimeProvider? timeProvider
     }
 
     public Task<PrivateAssetRevision?> PublishAsync(string workspaceId, string revisionId, string sealedObjectKey,
-        long storedSize, string sha256,
+        string claimToken, long storedSize, string sha256,
         CancellationToken cancellationToken = default)
     {
         lock (_gate)
         {
             if (!_revisions.TryGetValue(revisionId, out var stored) || stored.Revision.WorkspaceId != workspaceId
-                || stored.Revision.Status != AssetRevisionStatus.Finalizing || stored.Revision.DeclaredSize != storedSize)
+                || stored.Revision.Status != AssetRevisionStatus.Finalizing || stored.FinalizationToken != claimToken
+                || stored.Revision.DeclaredSize != storedSize)
                 return Task.FromResult<PrivateAssetRevision?>(null);
             var published = stored.Revision with
             {
                 Status = AssetRevisionStatus.Published, StoredSize = storedSize,
                 Sha256 = sha256.ToLowerInvariant(), PublishedAt = _time.GetUtcNow()
             };
-            _revisions[revisionId] = stored with { Revision = published, ObjectKey = sealedObjectKey, FinalizingAt = null };
+            _revisions[revisionId] = stored with
+            {
+                Revision = published, ObjectKey = sealedObjectKey, FinalizingAt = null, FinalizationToken = null
+            };
             return Task.FromResult<PrivateAssetRevision?>(published);
         }
     }
 
-    public Task<PrivateAssetRevision?> TryBeginFinalizationAsync(string workspaceId, string revisionId,
+    public Task<PrivateAssetFinalizationClaim?> TryBeginFinalizationAsync(string workspaceId, string revisionId,
         CancellationToken cancellationToken = default)
     {
         lock (_gate)
@@ -64,22 +69,29 @@ public sealed class InMemoryPrivateAssetMetadataStore(TimeProvider? timeProvider
                 || (stored.Revision.Status != AssetRevisionStatus.Draft
                     && !(stored.Revision.Status == AssetRevisionStatus.Finalizing
                         && stored.FinalizingAt <= _time.GetUtcNow().AddMinutes(-10))))
-                return Task.FromResult<PrivateAssetRevision?>(null);
+                return Task.FromResult<PrivateAssetFinalizationClaim?>(null);
             var finalizing = stored.Revision with { Status = AssetRevisionStatus.Finalizing };
-            _revisions[revisionId] = stored with { Revision = finalizing, FinalizingAt = _time.GetUtcNow() };
-            return Task.FromResult<PrivateAssetRevision?>(finalizing);
+            var token = Guid.NewGuid().ToString("N");
+            _revisions[revisionId] = stored with
+            {
+                Revision = finalizing, FinalizingAt = _time.GetUtcNow(), FinalizationToken = token
+            };
+            return Task.FromResult<PrivateAssetFinalizationClaim?>(new(finalizing, token));
         }
     }
 
-    public Task CancelFinalizationAsync(string workspaceId, string revisionId, CancellationToken cancellationToken = default)
+    public Task CancelFinalizationAsync(string workspaceId, string revisionId, string claimToken,
+        CancellationToken cancellationToken = default)
     {
         lock (_gate)
         {
             if (_revisions.TryGetValue(revisionId, out var stored) && stored.Revision.WorkspaceId == workspaceId
-                && stored.Revision.Status == AssetRevisionStatus.Finalizing)
+                && stored.Revision.Status == AssetRevisionStatus.Finalizing
+                && stored.FinalizationToken == claimToken)
                 _revisions[revisionId] = stored with
                 {
-                    Revision = stored.Revision with { Status = AssetRevisionStatus.Draft }, FinalizingAt = null
+                    Revision = stored.Revision with { Status = AssetRevisionStatus.Draft }, FinalizingAt = null,
+                    FinalizationToken = null
                 };
         }
         return Task.CompletedTask;

--- a/Nuotti.Backend/Assets/PostgresPrivateAssetMetadataStore.cs
+++ b/Nuotti.Backend/Assets/PostgresPrivateAssetMetadataStore.cs
@@ -1,0 +1,170 @@
+using System.Text.Json;
+using Npgsql;
+
+namespace Nuotti.Backend.Assets;
+
+public sealed class PostgresPrivateAssetMetadataStore(NpgsqlDataSource dataSource, TimeProvider? timeProvider = null)
+    : IPrivateAssetMetadataStore
+{
+    readonly SemaphoreSlim _gate = new(1, 1);
+    readonly TimeProvider _time = timeProvider ?? TimeProvider.System;
+    volatile bool _initialized;
+
+    public async Task<PrivateCatalogEntry> CreateEntryAsync(string workspaceId, string title, string artist, string userId,
+        CancellationToken cancellationToken = default)
+    {
+        await EnsureSchemaAsync(cancellationToken);
+        var entry = new PrivateCatalogEntry($"entry_{Guid.NewGuid():N}", workspaceId, title.Trim(), artist.Trim(), userId, _time.GetUtcNow());
+        await using var command = dataSource.CreateCommand("""
+            INSERT INTO nuotti_private_catalog_entry(id, workspace_id, title, artist, created_by, created_at)
+            VALUES ($1,$2,$3,$4,$5,$6)
+            """);
+        command.Parameters.AddWithValue(entry.CatalogEntryId); command.Parameters.AddWithValue(workspaceId);
+        command.Parameters.AddWithValue(entry.Title); command.Parameters.AddWithValue(entry.Artist);
+        command.Parameters.AddWithValue(userId); command.Parameters.AddWithValue(entry.CreatedAt);
+        await command.ExecuteNonQueryAsync(cancellationToken);
+        return entry;
+    }
+
+    public async Task<(PrivateAssetRevision Revision, string ObjectKey)?> CreateDraftAsync(
+        string workspaceId, string catalogEntryId, string assetType, string contentType, long declaredSize,
+        AssetProvenance provenance, string userId, CancellationToken cancellationToken = default)
+    {
+        await EnsureSchemaAsync(cancellationToken);
+        await using var connection = await dataSource.OpenConnectionAsync(cancellationToken);
+        await using var exists = new NpgsqlCommand(
+            "SELECT 1 FROM nuotti_private_catalog_entry WHERE id=$1 AND workspace_id=$2", connection);
+        exists.Parameters.AddWithValue(catalogEntryId); exists.Parameters.AddWithValue(workspaceId);
+        if (await exists.ExecuteScalarAsync(cancellationToken) is null) return null;
+        var revision = new PrivateAssetRevision($"rev_{Guid.NewGuid():N}", catalogEntryId, workspaceId,
+            AssetRevisionStatus.Draft, assetType, contentType, declaredSize, null, null, provenance,
+            userId, _time.GetUtcNow(), null, null);
+        var key = $"asset_{Guid.NewGuid():N}";
+        await using var insert = new NpgsqlCommand("""
+            INSERT INTO nuotti_private_asset_revision(
+                id,catalog_entry_id,workspace_id,status,asset_type,content_type,declared_size,
+                provenance,uploaded_by,created_at,object_key)
+            VALUES ($1,$2,$3,'Draft',$4,$5,$6,$7::jsonb,$8,$9,$10)
+            """, connection);
+        insert.Parameters.AddWithValue(revision.RevisionId); insert.Parameters.AddWithValue(catalogEntryId);
+        insert.Parameters.AddWithValue(workspaceId); insert.Parameters.AddWithValue(assetType);
+        insert.Parameters.AddWithValue(contentType); insert.Parameters.AddWithValue(declaredSize);
+        insert.Parameters.AddWithValue(JsonSerializer.Serialize(provenance)); insert.Parameters.AddWithValue(userId);
+        insert.Parameters.AddWithValue(revision.CreatedAt); insert.Parameters.AddWithValue(key);
+        await insert.ExecuteNonQueryAsync(cancellationToken);
+        return (revision, key);
+    }
+
+    public async Task<PrivateAssetRevision?> PublishAsync(string workspaceId, string revisionId, string sealedObjectKey,
+        long storedSize, string sha256,
+        CancellationToken cancellationToken = default)
+    {
+        await EnsureSchemaAsync(cancellationToken);
+        await using var command = dataSource.CreateCommand("""
+            UPDATE nuotti_private_asset_revision SET status='Published', object_key=$3, stored_size=$4, sha256=$5,
+                published_at=$6, finalizing_at=NULL
+            WHERE id=$1 AND workspace_id=$2 AND status='Finalizing' AND declared_size=$4
+            """);
+        command.Parameters.AddWithValue(revisionId); command.Parameters.AddWithValue(workspaceId);
+        command.Parameters.AddWithValue(sealedObjectKey); command.Parameters.AddWithValue(storedSize);
+        command.Parameters.AddWithValue(sha256.ToLowerInvariant()); command.Parameters.AddWithValue(_time.GetUtcNow());
+        return await command.ExecuteNonQueryAsync(cancellationToken) == 1
+            ? await GetAsync(workspaceId, revisionId, cancellationToken) : null;
+    }
+
+    public async Task<PrivateAssetRevision?> TryBeginFinalizationAsync(string workspaceId, string revisionId,
+        CancellationToken cancellationToken = default)
+    {
+        await EnsureSchemaAsync(cancellationToken);
+        await using var command = dataSource.CreateCommand("""
+            UPDATE nuotti_private_asset_revision SET status='Finalizing', finalizing_at=$3
+            WHERE id=$1 AND workspace_id=$2
+              AND (status='Draft' OR (status='Finalizing' AND finalizing_at <= $4))
+            """);
+        command.Parameters.AddWithValue(revisionId); command.Parameters.AddWithValue(workspaceId);
+        command.Parameters.AddWithValue(_time.GetUtcNow()); command.Parameters.AddWithValue(_time.GetUtcNow().AddMinutes(-10));
+        return await command.ExecuteNonQueryAsync(cancellationToken) == 1
+            ? await GetAsync(workspaceId, revisionId, cancellationToken) : null;
+    }
+
+    public async Task CancelFinalizationAsync(string workspaceId, string revisionId, CancellationToken cancellationToken = default)
+    {
+        await EnsureSchemaAsync(cancellationToken);
+        await using var command = dataSource.CreateCommand("""
+            UPDATE nuotti_private_asset_revision SET status='Draft', finalizing_at=NULL
+            WHERE id=$1 AND workspace_id=$2 AND status='Finalizing'
+            """);
+        command.Parameters.AddWithValue(revisionId); command.Parameters.AddWithValue(workspaceId);
+        await command.ExecuteNonQueryAsync(cancellationToken);
+    }
+
+    public async Task<PrivateAssetRevision?> GetAsync(string workspaceId, string revisionId, CancellationToken cancellationToken = default)
+    {
+        await EnsureSchemaAsync(cancellationToken);
+        await using var command = dataSource.CreateCommand("""
+            SELECT catalog_entry_id,status,asset_type,content_type,declared_size,stored_size,sha256,
+                   provenance::text,uploaded_by,created_at,published_at,archived_at
+            FROM nuotti_private_asset_revision WHERE id=$1 AND workspace_id=$2
+            """);
+        command.Parameters.AddWithValue(revisionId); command.Parameters.AddWithValue(workspaceId);
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        if (!await reader.ReadAsync(cancellationToken)) return null;
+        return new(revisionId, reader.GetString(0), workspaceId, Enum.Parse<AssetRevisionStatus>(reader.GetString(1)),
+            reader.GetString(2), reader.GetString(3), reader.GetInt64(4), reader.IsDBNull(5) ? null : reader.GetInt64(5),
+            reader.IsDBNull(6) ? null : reader.GetString(6), JsonSerializer.Deserialize<AssetProvenance>(reader.GetString(7))!,
+            reader.GetString(8), reader.GetFieldValue<DateTimeOffset>(9),
+            reader.IsDBNull(10) ? null : reader.GetFieldValue<DateTimeOffset>(10),
+            reader.IsDBNull(11) ? null : reader.GetFieldValue<DateTimeOffset>(11));
+    }
+
+    public async Task<string?> GetObjectKeyAsync(string workspaceId, string revisionId, CancellationToken cancellationToken = default)
+    {
+        await EnsureSchemaAsync(cancellationToken);
+        await using var command = dataSource.CreateCommand(
+            "SELECT object_key FROM nuotti_private_asset_revision WHERE id=$1 AND workspace_id=$2");
+        command.Parameters.AddWithValue(revisionId); command.Parameters.AddWithValue(workspaceId);
+        return await command.ExecuteScalarAsync(cancellationToken) as string;
+    }
+
+    public async Task<PrivateAssetRevision?> ArchiveAsync(string workspaceId, string revisionId, CancellationToken cancellationToken = default)
+    {
+        await EnsureSchemaAsync(cancellationToken);
+        await using var command = dataSource.CreateCommand("""
+            UPDATE nuotti_private_asset_revision SET status='Archived', archived_at=$3
+            WHERE id=$1 AND workspace_id=$2 AND status='Published'
+            """);
+        command.Parameters.AddWithValue(revisionId); command.Parameters.AddWithValue(workspaceId);
+        command.Parameters.AddWithValue(_time.GetUtcNow());
+        return await command.ExecuteNonQueryAsync(cancellationToken) == 1
+            ? await GetAsync(workspaceId, revisionId, cancellationToken) : null;
+    }
+
+    async Task EnsureSchemaAsync(CancellationToken ct)
+    {
+        if (_initialized) return;
+        await _gate.WaitAsync(ct);
+        try
+        {
+            if (_initialized) return;
+            await using var command = dataSource.CreateCommand("""
+                CREATE TABLE IF NOT EXISTS nuotti_private_catalog_entry(
+                    id text NOT NULL, workspace_id text NOT NULL, title text NOT NULL, artist text NOT NULL,
+                    created_by text NOT NULL, created_at timestamptz NOT NULL, PRIMARY KEY(workspace_id,id));
+                CREATE INDEX IF NOT EXISTS ix_nuotti_private_catalog_workspace ON nuotti_private_catalog_entry(workspace_id,id);
+                CREATE TABLE IF NOT EXISTS nuotti_private_asset_revision(
+                    id text NOT NULL, catalog_entry_id text NOT NULL,
+                    workspace_id text NOT NULL, status text NOT NULL, asset_type text NOT NULL, content_type text NOT NULL,
+                    declared_size bigint NOT NULL, stored_size bigint NULL, sha256 text NULL, provenance jsonb NOT NULL,
+                    uploaded_by text NOT NULL, created_at timestamptz NOT NULL, published_at timestamptz NULL,
+                    archived_at timestamptz NULL, finalizing_at timestamptz NULL, object_key text NOT NULL UNIQUE,
+                    PRIMARY KEY(workspace_id,id), FOREIGN KEY(workspace_id,catalog_entry_id)
+                    REFERENCES nuotti_private_catalog_entry(workspace_id,id));
+                ALTER TABLE nuotti_private_asset_revision ADD COLUMN IF NOT EXISTS finalizing_at timestamptz NULL;
+                CREATE INDEX IF NOT EXISTS ix_nuotti_private_revision_workspace ON nuotti_private_asset_revision(workspace_id,id);
+                """);
+            await command.ExecuteNonQueryAsync(ct);
+            _initialized = true;
+        }
+        finally { _gate.Release(); }
+    }
+}

--- a/Nuotti.Backend/Assets/PostgresPrivateAssetMetadataStore.cs
+++ b/Nuotti.Backend/Assets/PostgresPrivateAssetMetadataStore.cs
@@ -56,45 +56,51 @@ public sealed class PostgresPrivateAssetMetadataStore(NpgsqlDataSource dataSourc
     }
 
     public async Task<PrivateAssetRevision?> PublishAsync(string workspaceId, string revisionId, string sealedObjectKey,
-        long storedSize, string sha256,
+        string claimToken, long storedSize, string sha256,
         CancellationToken cancellationToken = default)
     {
         await EnsureSchemaAsync(cancellationToken);
         await using var command = dataSource.CreateCommand("""
-            UPDATE nuotti_private_asset_revision SET status='Published', object_key=$3, stored_size=$4, sha256=$5,
-                published_at=$6, finalizing_at=NULL
-            WHERE id=$1 AND workspace_id=$2 AND status='Finalizing' AND declared_size=$4
+            UPDATE nuotti_private_asset_revision SET status='Published', object_key=$3, stored_size=$5, sha256=$6,
+                published_at=$7, finalizing_at=NULL, finalization_token=NULL
+            WHERE id=$1 AND workspace_id=$2 AND status='Finalizing' AND finalization_token=$4 AND declared_size=$5
             """);
         command.Parameters.AddWithValue(revisionId); command.Parameters.AddWithValue(workspaceId);
-        command.Parameters.AddWithValue(sealedObjectKey); command.Parameters.AddWithValue(storedSize);
-        command.Parameters.AddWithValue(sha256.ToLowerInvariant()); command.Parameters.AddWithValue(_time.GetUtcNow());
+        command.Parameters.AddWithValue(sealedObjectKey); command.Parameters.AddWithValue(claimToken);
+        command.Parameters.AddWithValue(storedSize); command.Parameters.AddWithValue(sha256.ToLowerInvariant());
+        command.Parameters.AddWithValue(_time.GetUtcNow());
         return await command.ExecuteNonQueryAsync(cancellationToken) == 1
             ? await GetAsync(workspaceId, revisionId, cancellationToken) : null;
     }
 
-    public async Task<PrivateAssetRevision?> TryBeginFinalizationAsync(string workspaceId, string revisionId,
+    public async Task<PrivateAssetFinalizationClaim?> TryBeginFinalizationAsync(string workspaceId, string revisionId,
         CancellationToken cancellationToken = default)
     {
         await EnsureSchemaAsync(cancellationToken);
+        var token = Guid.NewGuid().ToString("N");
         await using var command = dataSource.CreateCommand("""
-            UPDATE nuotti_private_asset_revision SET status='Finalizing', finalizing_at=$3
+            UPDATE nuotti_private_asset_revision SET status='Finalizing', finalizing_at=$3, finalization_token=$5
             WHERE id=$1 AND workspace_id=$2
               AND (status='Draft' OR (status='Finalizing' AND finalizing_at <= $4))
             """);
         command.Parameters.AddWithValue(revisionId); command.Parameters.AddWithValue(workspaceId);
         command.Parameters.AddWithValue(_time.GetUtcNow()); command.Parameters.AddWithValue(_time.GetUtcNow().AddMinutes(-10));
-        return await command.ExecuteNonQueryAsync(cancellationToken) == 1
-            ? await GetAsync(workspaceId, revisionId, cancellationToken) : null;
+        command.Parameters.AddWithValue(token);
+        if (await command.ExecuteNonQueryAsync(cancellationToken) != 1) return null;
+        var revision = await GetAsync(workspaceId, revisionId, cancellationToken);
+        return revision is null ? null : new(revision, token);
     }
 
-    public async Task CancelFinalizationAsync(string workspaceId, string revisionId, CancellationToken cancellationToken = default)
+    public async Task CancelFinalizationAsync(string workspaceId, string revisionId, string claimToken,
+        CancellationToken cancellationToken = default)
     {
         await EnsureSchemaAsync(cancellationToken);
         await using var command = dataSource.CreateCommand("""
-            UPDATE nuotti_private_asset_revision SET status='Draft', finalizing_at=NULL
-            WHERE id=$1 AND workspace_id=$2 AND status='Finalizing'
+            UPDATE nuotti_private_asset_revision SET status='Draft', finalizing_at=NULL, finalization_token=NULL
+            WHERE id=$1 AND workspace_id=$2 AND status='Finalizing' AND finalization_token=$3
             """);
         command.Parameters.AddWithValue(revisionId); command.Parameters.AddWithValue(workspaceId);
+        command.Parameters.AddWithValue(claimToken);
         await command.ExecuteNonQueryAsync(cancellationToken);
     }
 
@@ -156,10 +162,12 @@ public sealed class PostgresPrivateAssetMetadataStore(NpgsqlDataSource dataSourc
                     workspace_id text NOT NULL, status text NOT NULL, asset_type text NOT NULL, content_type text NOT NULL,
                     declared_size bigint NOT NULL, stored_size bigint NULL, sha256 text NULL, provenance jsonb NOT NULL,
                     uploaded_by text NOT NULL, created_at timestamptz NOT NULL, published_at timestamptz NULL,
-                    archived_at timestamptz NULL, finalizing_at timestamptz NULL, object_key text NOT NULL UNIQUE,
+                    archived_at timestamptz NULL, finalizing_at timestamptz NULL, finalization_token text NULL,
+                    object_key text NOT NULL UNIQUE,
                     PRIMARY KEY(workspace_id,id), FOREIGN KEY(workspace_id,catalog_entry_id)
                     REFERENCES nuotti_private_catalog_entry(workspace_id,id));
                 ALTER TABLE nuotti_private_asset_revision ADD COLUMN IF NOT EXISTS finalizing_at timestamptz NULL;
+                ALTER TABLE nuotti_private_asset_revision ADD COLUMN IF NOT EXISTS finalization_token text NULL;
                 CREATE INDEX IF NOT EXISTS ix_nuotti_private_revision_workspace ON nuotti_private_asset_revision(workspace_id,id);
                 """);
             await command.ExecuteNonQueryAsync(ct);

--- a/Nuotti.Backend/Assets/PrivateAssetModel.cs
+++ b/Nuotti.Backend/Assets/PrivateAssetModel.cs
@@ -22,6 +22,7 @@ public sealed record PrivateAssetUploadGrant(
 public sealed record PrivateAssetDownloadGrant(Uri DownloadUri, DateTimeOffset ExpiresAt);
 public sealed record PrivateObjectEvidence(long Size, string ContentType, string Sha256, string ETag);
 public sealed record SealedPrivateObject(string ObjectKey, PrivateObjectEvidence Evidence);
+public sealed record PrivateAssetFinalizationClaim(PrivateAssetRevision Revision, string Token);
 
 public interface IPrivateAssetMetadataStore
 {
@@ -30,11 +31,12 @@ public interface IPrivateAssetMetadataStore
     Task<(PrivateAssetRevision Revision, string ObjectKey)?> CreateDraftAsync(
         string workspaceId, string catalogEntryId, string assetType, string contentType, long declaredSize,
         AssetProvenance provenance, string userId, CancellationToken cancellationToken = default);
-    Task<PrivateAssetRevision?> TryBeginFinalizationAsync(string workspaceId, string revisionId,
+    Task<PrivateAssetFinalizationClaim?> TryBeginFinalizationAsync(string workspaceId, string revisionId,
         CancellationToken cancellationToken = default);
-    Task CancelFinalizationAsync(string workspaceId, string revisionId, CancellationToken cancellationToken = default);
+    Task CancelFinalizationAsync(string workspaceId, string revisionId, string claimToken,
+        CancellationToken cancellationToken = default);
     Task<PrivateAssetRevision?> PublishAsync(string workspaceId, string revisionId, string sealedObjectKey,
-        long storedSize, string sha256,
+        string claimToken, long storedSize, string sha256,
         CancellationToken cancellationToken = default);
     Task<PrivateAssetRevision?> GetAsync(string workspaceId, string revisionId, CancellationToken cancellationToken = default);
     Task<string?> GetObjectKeyAsync(string workspaceId, string revisionId, CancellationToken cancellationToken = default);

--- a/Nuotti.Backend/Assets/PrivateAssetModel.cs
+++ b/Nuotti.Backend/Assets/PrivateAssetModel.cs
@@ -1,0 +1,52 @@
+using System.Text.Json.Serialization;
+
+namespace Nuotti.Backend.Assets;
+
+[JsonConverter(typeof(JsonStringEnumConverter<AssetRevisionStatus>))]
+public enum AssetRevisionStatus { Draft, Finalizing, Published, Archived }
+
+public sealed record AssetProvenance(
+    string Source, string RightsBasis, string Territory,
+    IReadOnlyList<string> PermittedUses, DateTimeOffset? RightsExpiresAt,
+    string? SupportingDocumentReference);
+public sealed record PrivateCatalogEntry(
+    string CatalogEntryId, string WorkspaceId, string Title, string Artist,
+    string CreatedBy, DateTimeOffset CreatedAt);
+public sealed record PrivateAssetRevision(
+    string RevisionId, string CatalogEntryId, string WorkspaceId, AssetRevisionStatus Status,
+    string AssetType, string ContentType, long DeclaredSize, long? StoredSize, string? Sha256,
+    AssetProvenance Provenance, string UploadedBy, DateTimeOffset CreatedAt,
+    DateTimeOffset? PublishedAt, DateTimeOffset? ArchivedAt);
+public sealed record PrivateAssetUploadGrant(
+    PrivateAssetRevision Revision, Uri UploadUri, DateTimeOffset ExpiresAt);
+public sealed record PrivateAssetDownloadGrant(Uri DownloadUri, DateTimeOffset ExpiresAt);
+public sealed record PrivateObjectEvidence(long Size, string ContentType, string Sha256, string ETag);
+public sealed record SealedPrivateObject(string ObjectKey, PrivateObjectEvidence Evidence);
+
+public interface IPrivateAssetMetadataStore
+{
+    Task<PrivateCatalogEntry> CreateEntryAsync(string workspaceId, string title, string artist, string userId,
+        CancellationToken cancellationToken = default);
+    Task<(PrivateAssetRevision Revision, string ObjectKey)?> CreateDraftAsync(
+        string workspaceId, string catalogEntryId, string assetType, string contentType, long declaredSize,
+        AssetProvenance provenance, string userId, CancellationToken cancellationToken = default);
+    Task<PrivateAssetRevision?> TryBeginFinalizationAsync(string workspaceId, string revisionId,
+        CancellationToken cancellationToken = default);
+    Task CancelFinalizationAsync(string workspaceId, string revisionId, CancellationToken cancellationToken = default);
+    Task<PrivateAssetRevision?> PublishAsync(string workspaceId, string revisionId, string sealedObjectKey,
+        long storedSize, string sha256,
+        CancellationToken cancellationToken = default);
+    Task<PrivateAssetRevision?> GetAsync(string workspaceId, string revisionId, CancellationToken cancellationToken = default);
+    Task<string?> GetObjectKeyAsync(string workspaceId, string revisionId, CancellationToken cancellationToken = default);
+    Task<PrivateAssetRevision?> ArchiveAsync(string workspaceId, string revisionId, CancellationToken cancellationToken = default);
+}
+
+public interface IPrivateAssetObjectStore
+{
+    Task<(Uri Uri, DateTimeOffset ExpiresAt)> CreateUploadGrantAsync(string objectKey, string contentType,
+        CancellationToken cancellationToken = default);
+    Task<(Uri Uri, DateTimeOffset ExpiresAt)> CreateDownloadGrantAsync(string objectKey,
+        CancellationToken cancellationToken = default);
+    Task<SealedPrivateObject?> SealAsync(string objectKey, CancellationToken cancellationToken = default);
+    Task DiscardSealedAsync(string objectKey, CancellationToken cancellationToken = default);
+}

--- a/Nuotti.Backend/Endpoints/PrivateAssetEndpoints.cs
+++ b/Nuotti.Backend/Endpoints/PrivateAssetEndpoints.cs
@@ -64,9 +64,10 @@ public static class PrivateAssetEndpoints
             if (revision.Status != AssetRevisionStatus.Draft || RightsExpired(revision.Provenance))
                 return ProblemResults.Conflict("Revision cannot be published.",
                     "The revision is not a publishable draft with current usage rights.", ReasonCode.InvalidStateTransition);
-            revision = await metadata.TryBeginFinalizationAsync(workspaceId, revisionId, ct);
-            if (revision is null) return ProblemResults.Conflict("Revision cannot be published.",
+            var claim = await metadata.TryBeginFinalizationAsync(workspaceId, revisionId, ct);
+            if (claim is null) return ProblemResults.Conflict("Revision cannot be published.",
                 "Another publication attempt already claimed this revision.", ReasonCode.InvalidStateTransition);
+            revision = claim.Revision;
             SealedPrivateObject? sealedObject = null;
             var completed = false;
             try
@@ -82,7 +83,7 @@ public static class PrivateAssetEndpoints
                         "Stored bytes, size, content type, or digest differ from the immutable draft metadata.",
                         ReasonCode.InvalidStateTransition);
                 var published = await metadata.PublishAsync(workspaceId, revisionId, sealedObject.ObjectKey,
-                    sealedObject.Evidence.Size, sealedObject.Evidence.Sha256, ct);
+                    claim.Token, sealedObject.Evidence.Size, sealedObject.Evidence.Sha256, ct);
                 completed = published is not null;
                 return published is null
                     ? ProblemResults.Conflict("Revision cannot be published.",
@@ -100,7 +101,7 @@ public static class PrivateAssetEndpoints
                     }
                     finally
                     {
-                        await metadata.CancelFinalizationAsync(workspaceId, revisionId, CancellationToken.None);
+                        await metadata.CancelFinalizationAsync(workspaceId, revisionId, claim.Token, CancellationToken.None);
                     }
                 }
             }

--- a/Nuotti.Backend/Endpoints/PrivateAssetEndpoints.cs
+++ b/Nuotti.Backend/Endpoints/PrivateAssetEndpoints.cs
@@ -61,7 +61,8 @@ public static class PrivateAssetEndpoints
             if (!ValidSha(request.Sha256)) return Invalid("sha256", "A lowercase or uppercase SHA-256 hex digest is required.");
             var revision = await metadata.GetAsync(workspaceId, revisionId, ct);
             if (revision is null) return Results.NotFound();
-            if (revision.Status != AssetRevisionStatus.Draft || RightsExpired(revision.Provenance))
+            if (revision.Status is not (AssetRevisionStatus.Draft or AssetRevisionStatus.Finalizing)
+                || RightsExpired(revision.Provenance))
                 return ProblemResults.Conflict("Revision cannot be published.",
                     "The revision is not a publishable draft with current usage rights.", ReasonCode.InvalidStateTransition);
             var claim = await metadata.TryBeginFinalizationAsync(workspaceId, revisionId, ct);

--- a/Nuotti.Backend/Endpoints/PrivateAssetEndpoints.cs
+++ b/Nuotti.Backend/Endpoints/PrivateAssetEndpoints.cs
@@ -1,0 +1,204 @@
+using Nuotti.Backend.Assets;
+using Nuotti.Backend.Exception;
+using Nuotti.Backend.Workspaces;
+using Nuotti.Contracts.V1.Enum;
+
+namespace Nuotti.Backend.Endpoints;
+
+public sealed record CreatePrivateCatalogEntryRequest(string Title, string Artist);
+public sealed record CreatePrivateAssetUploadRequest(
+    string AssetType, string ContentType, long Size, AssetProvenance Provenance);
+public sealed record PublishPrivateAssetRevisionRequest(string Sha256);
+
+public static class PrivateAssetEndpoints
+{
+    public static void MapPrivateAssetEndpoints(this WebApplication app)
+    {
+        app.MapPost("/v1/workspaces/{workspaceId}/catalog", async (
+            HttpContext http, string workspaceId, CreatePrivateCatalogEntryRequest request,
+            IWorkspaceAccessStore access, IPrivateAssetMetadataStore metadata, CancellationToken ct) =>
+        {
+            var selected = await WorkspaceHttpAccess.RequireSelectedAsync(http, access, workspaceId, ct);
+            if (selected.Principal is null) return Results.Unauthorized();
+            if (selected.Access is null) return Results.NotFound();
+            if (!Text(request.Title, 200) || !Text(request.Artist, 200)) return Invalid("title", "Title and artist are required.");
+            return Results.Ok(await metadata.CreateEntryAsync(
+                workspaceId, request.Title, request.Artist, selected.Principal.UserId, ct));
+        });
+
+        app.MapPost("/v1/workspaces/{workspaceId}/catalog/{catalogEntryId}/asset-uploads", async (
+            HttpContext http, string workspaceId, string catalogEntryId, CreatePrivateAssetUploadRequest request,
+            IWorkspaceAccessStore access, IPrivateAssetMetadataStore metadata, IPrivateAssetObjectStore objects,
+            CancellationToken ct) =>
+        {
+            var selected = await WorkspaceHttpAccess.RequireSelectedAsync(http, access, workspaceId, ct);
+            if (selected.Principal is null) return Results.Unauthorized();
+            if (selected.Access is null) return Results.NotFound();
+            var normalized = NormalizeUpload(request);
+            if (normalized is null) return Invalid("asset", "Asset metadata and complete, current rights provenance are required.");
+            var draft = await metadata.CreateDraftAsync(workspaceId, catalogEntryId, normalized.AssetType,
+                normalized.ContentType, normalized.Size, normalized.Provenance, selected.Principal.UserId, ct);
+            if (draft is null) return Results.NotFound();
+            try
+            {
+                var grant = await objects.CreateUploadGrantAsync(draft.Value.ObjectKey, normalized.ContentType, ct);
+                return Results.Ok(new PrivateAssetUploadGrant(draft.Value.Revision, grant.Uri, grant.ExpiresAt));
+            }
+            catch (PrivateAssetGrantUnavailableException)
+            {
+                return Results.Problem("Direct private-asset grants are unavailable.", statusCode: 503);
+            }
+        });
+
+        app.MapPost("/v1/workspaces/{workspaceId}/revisions/{revisionId}/publish", async (
+            HttpContext http, string workspaceId, string revisionId, PublishPrivateAssetRevisionRequest request,
+            IWorkspaceAccessStore access, IPrivateAssetMetadataStore metadata, IPrivateAssetObjectStore objects,
+            CancellationToken ct) =>
+        {
+            var selected = await WorkspaceHttpAccess.RequireSelectedAsync(http, access, workspaceId, ct);
+            if (selected.Principal is null) return Results.Unauthorized();
+            if (selected.Access is null) return Results.NotFound();
+            if (!ValidSha(request.Sha256)) return Invalid("sha256", "A lowercase or uppercase SHA-256 hex digest is required.");
+            var revision = await metadata.GetAsync(workspaceId, revisionId, ct);
+            if (revision is null) return Results.NotFound();
+            if (revision.Status != AssetRevisionStatus.Draft || RightsExpired(revision.Provenance))
+                return ProblemResults.Conflict("Revision cannot be published.",
+                    "The revision is not a publishable draft with current usage rights.", ReasonCode.InvalidStateTransition);
+            revision = await metadata.TryBeginFinalizationAsync(workspaceId, revisionId, ct);
+            if (revision is null) return ProblemResults.Conflict("Revision cannot be published.",
+                "Another publication attempt already claimed this revision.", ReasonCode.InvalidStateTransition);
+            SealedPrivateObject? sealedObject = null;
+            var completed = false;
+            try
+            {
+                var key = await metadata.GetObjectKeyAsync(workspaceId, revisionId, ct);
+                if (key is null) return Results.NotFound();
+                sealedObject = await objects.SealAsync(key, ct);
+                if (sealedObject is null
+                    || sealedObject.Evidence.Size != revision.DeclaredSize
+                    || !sealedObject.Evidence.ContentType.Equals(revision.ContentType, StringComparison.OrdinalIgnoreCase)
+                    || !sealedObject.Evidence.Sha256.Equals(request.Sha256, StringComparison.OrdinalIgnoreCase))
+                    return ProblemResults.Conflict("Uploaded object evidence does not match.",
+                        "Stored bytes, size, content type, or digest differ from the immutable draft metadata.",
+                        ReasonCode.InvalidStateTransition);
+                var published = await metadata.PublishAsync(workspaceId, revisionId, sealedObject.ObjectKey,
+                    sealedObject.Evidence.Size, sealedObject.Evidence.Sha256, ct);
+                completed = published is not null;
+                return published is null
+                    ? ProblemResults.Conflict("Revision cannot be published.",
+                        "The revision is no longer a publishable draft.", ReasonCode.InvalidStateTransition)
+                    : Results.Ok(published);
+            }
+            finally
+            {
+                if (!completed)
+                {
+                    try
+                    {
+                        if (sealedObject is not null)
+                            await objects.DiscardSealedAsync(sealedObject.ObjectKey, CancellationToken.None);
+                    }
+                    finally
+                    {
+                        await metadata.CancelFinalizationAsync(workspaceId, revisionId, CancellationToken.None);
+                    }
+                }
+            }
+        });
+
+        app.MapGet("/v1/workspaces/{workspaceId}/revisions/{revisionId}", async (
+            HttpContext http, string workspaceId, string revisionId, IWorkspaceAccessStore access,
+            IPrivateAssetMetadataStore metadata, CancellationToken ct) =>
+        {
+            var selected = await WorkspaceHttpAccess.RequireSelectedAsync(http, access, workspaceId, ct);
+            if (selected.Principal is null) return Results.Unauthorized();
+            if (selected.Access is null) return Results.NotFound();
+            var revision = await metadata.GetAsync(workspaceId, revisionId, ct);
+            return revision is null ? Results.NotFound() : Results.Ok(revision);
+        });
+
+        app.MapPost("/v1/workspaces/{workspaceId}/revisions/{revisionId}/download", async (
+            HttpContext http, string workspaceId, string revisionId, IWorkspaceAccessStore access,
+            IPrivateAssetMetadataStore metadata, IPrivateAssetObjectStore objects, CancellationToken ct) =>
+        {
+            var selected = await WorkspaceHttpAccess.RequireSelectedAsync(http, access, workspaceId, ct);
+            if (selected.Principal is null) return Results.Unauthorized();
+            if (selected.Access is null) return Results.NotFound();
+            var revision = await metadata.GetAsync(workspaceId, revisionId, ct);
+            if (revision?.Status != AssetRevisionStatus.Published || RightsExpired(revision.Provenance)) return Results.NotFound();
+            var key = await metadata.GetObjectKeyAsync(workspaceId, revisionId, ct);
+            if (key is null) return Results.NotFound();
+            try
+            {
+                var grant = await objects.CreateDownloadGrantAsync(key, ct);
+                return Results.Ok(new PrivateAssetDownloadGrant(grant.Uri, grant.ExpiresAt));
+            }
+            catch (PrivateAssetGrantUnavailableException)
+            {
+                return Results.Problem("Direct private-asset grants are unavailable.", statusCode: 503);
+            }
+        });
+
+        app.MapDelete("/v1/workspaces/{workspaceId}/revisions/{revisionId}", async (
+            HttpContext http, string workspaceId, string revisionId, IWorkspaceAccessStore access,
+            IPrivateAssetMetadataStore metadata, CancellationToken ct) =>
+        {
+            var selected = await WorkspaceHttpAccess.RequireSelectedAsync(http, access, workspaceId, ct);
+            if (selected.Principal is null) return Results.Unauthorized();
+            if (selected.Access?.Role != WorkspaceRole.Owner) return Results.NotFound();
+            var archived = await metadata.ArchiveAsync(workspaceId, revisionId, ct);
+            return archived is null ? Results.NotFound() : Results.Ok(archived);
+        });
+    }
+
+    static readonly IReadOnlyDictionary<string, string[]> AssetUses = new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase)
+    {
+        ["backing-track"] = ["backing-track", "live-performance"],
+        ["click-track"] = ["click-track"],
+        ["visual-hint"] = ["visual-hint", "projector-media"],
+        ["image"] = ["visual-hint", "projector-media"],
+        ["lyrics"] = ["lyrics", "projector-media"],
+        ["video"] = ["projector-media"]
+    };
+    static readonly IReadOnlyDictionary<string, string[]> AssetContentTypes = new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase)
+    {
+        ["backing-track"] = ["audio/wav", "audio/mpeg", "audio/flac"],
+        ["click-track"] = ["audio/wav", "audio/mpeg", "audio/flac"],
+        ["visual-hint"] = ["image/png", "image/jpeg", "image/webp"],
+        ["image"] = ["image/png", "image/jpeg", "image/webp"],
+        ["lyrics"] = ["text/plain", "application/lrc"],
+        ["video"] = ["video/mp4", "video/webm"]
+    };
+    static readonly HashSet<string> AllowedUses = AssetUses.Values.SelectMany(x => x).ToHashSet(StringComparer.Ordinal);
+
+    static CreatePrivateAssetUploadRequest? NormalizeUpload(CreatePrivateAssetUploadRequest request)
+    {
+        var assetType = request.AssetType?.Trim().ToLowerInvariant();
+        var contentType = request.ContentType?.Trim().ToLowerInvariant();
+        var provenance = request.Provenance;
+        if (assetType is null || !AssetUses.TryGetValue(assetType, out var compatibleUses)
+            || !Text(contentType, 200) || !AssetContentTypes[assetType].Contains(contentType, StringComparer.Ordinal)
+            || request.Size is <= 0 or > 2_000_000_000
+            || !Text(provenance.Source, 500) || !Text(provenance.RightsBasis, 500)
+            || !Text(provenance.Territory, 100) || RightsExpired(provenance)
+            || !Text(provenance.SupportingDocumentReference, 500)
+            || provenance.PermittedUses is not { Count: > 0 and <= 8 }) return null;
+        var uses = provenance.PermittedUses.Select(x => x?.Trim().ToLowerInvariant()).ToArray();
+        if (uses.Any(x => !Text(x, 80) || !AllowedUses.Contains(x!))
+            || uses.Distinct(StringComparer.Ordinal).Count() != uses.Length
+            || !uses.Any(x => compatibleUses.Contains(x, StringComparer.Ordinal))) return null;
+        var normalizedProvenance = provenance with
+        {
+            Source = provenance.Source.Trim(), RightsBasis = provenance.RightsBasis.Trim(),
+            Territory = provenance.Territory.Trim().ToUpperInvariant(), PermittedUses = uses!,
+            SupportingDocumentReference = provenance.SupportingDocumentReference!.Trim()
+        };
+        return request with { AssetType = assetType, ContentType = contentType!, Provenance = normalizedProvenance };
+    }
+    static bool RightsExpired(AssetProvenance provenance) => provenance.RightsExpiresAt is { } expiry
+        && expiry <= DateTimeOffset.UtcNow;
+    static bool ValidSha(string value) => value?.Length == 64 && value.All(Uri.IsHexDigit);
+    static bool Text(string? value, int max) => !string.IsNullOrWhiteSpace(value) && value.Trim().Length <= max;
+    static IResult Invalid(string field, string message) => Results.ValidationProblem(
+        new Dictionary<string, string[]> { [field] = [message] });
+}

--- a/Nuotti.Backend/Program.cs
+++ b/Nuotti.Backend/Program.cs
@@ -12,6 +12,7 @@ using Nuotti.Backend.Persistence;
 using Nuotti.Backend.Sessions;
 using Nuotti.Backend.Workspaces;
 using Nuotti.Backend.ShowAgents;
+using Nuotti.Backend.Assets;
 using Nuotti.Contracts.V1.Eventing;
 using Microsoft.Extensions.Options;
 using System.Threading.RateLimiting;
@@ -122,6 +123,7 @@ if (!string.IsNullOrWhiteSpace(databaseConnection))
 {
     builder.Services.AddSingleton<IWorkspaceAccessStore, PostgresWorkspaceAccessStore>();
     builder.Services.AddSingleton<IShowAgentAccessStore, PostgresShowAgentAccessStore>();
+    builder.Services.AddSingleton<IPrivateAssetMetadataStore, PostgresPrivateAssetMetadataStore>();
     builder.Services.AddSingleton<IDurableSessionCommitStore, PostgresDurableSessionCommitStore>();
 }
 else
@@ -130,8 +132,13 @@ else
     // isolated tests. Production replaces only the adapter, not the authorization boundary.
     builder.Services.AddSingleton<IWorkspaceAccessStore, InMemoryWorkspaceAccessStore>();
     builder.Services.AddSingleton<IShowAgentAccessStore, InMemoryShowAgentAccessStore>();
+    builder.Services.AddSingleton<IPrivateAssetMetadataStore, InMemoryPrivateAssetMetadataStore>();
     builder.Services.AddSingleton<IDurableSessionCommitStore, InMemoryDurableSessionCommitStore>();
 }
+if (!string.IsNullOrWhiteSpace(assetsConnection))
+    builder.Services.AddSingleton<IPrivateAssetObjectStore, AzurePrivateAssetObjectStore>();
+else
+    builder.Services.AddSingleton<IPrivateAssetObjectStore, InMemoryPrivateAssetObjectStore>();
 builder.Services.AddSingleton<DurableOutboxDispatcher>();
 builder.Services.AddHostedService<DurableOutboxWorker>();
 
@@ -204,6 +211,7 @@ app.MapDevEndpoints();
 app.MapInfrastructureProofEndpoints();
 app.MapWorkspaceEndpoints();
 app.MapShowAgentEndpoints();
+app.MapPrivateAssetEndpoints();
 app.MapRecoveryEndpoints();
 app.MapNuottiEndpoints("Nuotti.Backend");
 


### PR DESCRIPTION
Closes #252

Implements tenant-private catalog entries, direct scoped upload/download grants, immutable snapshot publication with trusted SHA-256 evidence, durable provenance/status metadata, rights-expiry gates, archive behavior, and adversarial tenant-isolation tests.

Verification: focused private-asset suite 4/4; full Backend suite 146/146 before final lease-only recovery change; final focused suite remains green.