### PR TITLE
Create a Session snapshot and verify its venue cache

### DIFF
--- a/Nuotti.AudioEngine.Tests/ShowAgentCloudClientTests.cs
+++ b/Nuotti.AudioEngine.Tests/ShowAgentCloudClientTests.cs
@@ -50,9 +50,10 @@ public sealed class ShowAgentCloudClientTests
     public void Playback_payload_uses_web_json_names()
     {
         using var document = System.Text.Json.JsonDocument.Parse(
-            """{"fileUrl":"track.wav","sessionCode":"SHOW1","issuedByRole":"Performer","issuedById":"performer-1"}""");
+            """{"fileUrl":"track.wav","assetRevisionId":"rev-1","sessionCode":"SHOW1","issuedByRole":"Performer","issuedById":"performer-1"}""");
         var command = ShowAgentCloudClient.DeserializePayload<Nuotti.Contracts.V1.Message.PlayTrack>(document.RootElement);
         Assert.Equal("track.wav", command!.FileUrl);
+        Assert.Equal("rev-1", command.AssetRevisionId);
     }
 
     static HttpResponseMessage Json(HttpStatusCode status, string json) => new(status)

--- a/Nuotti.AudioEngine.Tests/VenueAssetCacheTests.cs
+++ b/Nuotti.AudioEngine.Tests/VenueAssetCacheTests.cs
@@ -1,0 +1,164 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Security.Cryptography;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+using Nuotti.Contracts.V1.Message;
+
+namespace Nuotti.AudioEngine.Tests;
+
+public sealed class VenueAssetCacheTests
+{
+    [Fact]
+    public async Task Downloads_required_asset_and_verifies_hash_before_ready()
+    {
+        var bytes = new byte[] { 1, 2, 3, 4 };
+        var asset = Asset(bytes, required: true);
+        var root = Temp();
+        try
+        {
+            using var http = new HttpClient(new BytesHandler(bytes));
+            var cache = new VenueAssetCache(http, root);
+            var result = await cache.PrepareAsync(Snapshot("snap-1", asset),
+                (_, _) => Task.FromResult(new CloudAssetGrant(new Uri("https://objects.test/file"), DateTimeOffset.MaxValue)));
+            Assert.True(result.Ready);
+            Assert.True(File.Exists(result.LocalPaths[asset.RevisionId]));
+        }
+        finally { Directory.Delete(root, true); }
+    }
+
+    [Fact]
+    public async Task Corrupt_required_download_blocks_preflight_and_is_not_promoted()
+    {
+        var asset = Asset([1, 2, 3], required: true);
+        var root = Temp();
+        try
+        {
+            using var http = new HttpClient(new BytesHandler([9, 9, 9]));
+            var result = await new VenueAssetCache(http, root).PrepareAsync(Snapshot("snap-1", asset),
+                (_, _) => Task.FromResult(new CloudAssetGrant(new Uri("https://objects.test/file"), DateTimeOffset.MaxValue)));
+            Assert.False(result.Ready);
+            Assert.Contains(result.Findings, x => x.Code.Contains("hash-mismatch") && x.Blocking);
+            Assert.Empty(result.LocalPaths);
+        }
+        finally { Directory.Delete(root, true); }
+    }
+
+    [Fact]
+    public async Task Different_snapshot_for_same_session_is_rejected_as_stale()
+    {
+        var root = Temp();
+        try
+        {
+            var empty = new CloudSessionSnapshot("snap-1", "ws", "SHOW", 1, []);
+            var cache = new VenueAssetCache(new HttpClient(new BytesHandler([])), root);
+            Assert.True((await cache.PrepareAsync(empty, (_, _) => throw new InvalidOperationException())).Ready);
+            var stale = await cache.PrepareAsync(empty with { SnapshotId = "snap-2" },
+                (_, _) => throw new InvalidOperationException());
+            Assert.False(stale.Ready);
+            Assert.Contains(stale.Findings, x => x.Code == "cache.stale-snapshot" && x.Blocking);
+        }
+        finally { Directory.Delete(root, true); }
+    }
+
+    [Fact]
+    public async Task Manifest_from_another_session_is_rejected()
+    {
+        var root = Temp();
+        try
+        {
+            var cache = new VenueAssetCache(new HttpClient(new BytesHandler([])), root);
+            Assert.True((await cache.PrepareAsync(new("snap-1", "ws", "OTHER", 1, []),
+                (_, _) => throw new InvalidOperationException())).Ready);
+            var result = await cache.PrepareAsync(Snapshot("snap-1"), (_, _) => throw new InvalidOperationException());
+            Assert.False(result.Ready);
+            Assert.Contains(result.Findings, x => x.Code == "cache.stale-snapshot" && x.Blocking);
+        }
+        finally { Directory.Delete(root, true); }
+    }
+
+    [Fact]
+    public async Task Optional_media_failure_requires_the_named_safe_override()
+    {
+        var asset = Asset([1, 2, 3], required: false);
+        var root = Temp();
+        try
+        {
+            using var http = new HttpClient(new BytesHandler([9, 9, 9]));
+            var cache = new VenueAssetCache(http, root);
+            var blocked = await cache.PrepareAsync(Snapshot("snap-1", asset),
+                (_, _) => Task.FromResult(new CloudAssetGrant(new Uri("https://objects.test/file"), DateTimeOffset.MaxValue)));
+            var warning = Assert.Single(blocked.Findings);
+            Assert.False(blocked.Ready);
+            Assert.False(warning.Blocking);
+            Assert.True(warning.CanOverride);
+            var accepted = await cache.PrepareAsync(Snapshot("snap-1", asset),
+                (_, _) => Task.FromResult(new CloudAssetGrant(new Uri("https://objects.test/file"), DateTimeOffset.MaxValue)),
+                new HashSet<string> { warning.Code });
+            Assert.True(accepted.Ready);
+        }
+        finally { Directory.Delete(root, true); }
+    }
+
+    [Fact]
+    public void Playback_resolves_only_a_revision_present_in_the_verified_cache()
+    {
+        var paths = new Dictionary<string, string> { ["rev-1"] = @"C:\cache\rev-1.audio" };
+        Assert.True(VenueAssetCache.TryResolveCapturedSource(Play("ignored") with { AssetRevisionId = "rev-1" },
+            paths, out var source));
+        Assert.Equal(paths["rev-1"], source);
+        Assert.False(VenueAssetCache.TryResolveCapturedSource(Play("https://outside.test/file"), paths, out _));
+    }
+
+    [Fact]
+    public async Task Corrupt_manifest_is_a_named_blocker_not_an_exception()
+    {
+        var root = Temp();
+        try
+        {
+            await File.WriteAllTextAsync(Path.Combine(root, "snapshot.json"), "{torn");
+            var result = await new VenueAssetCache(new HttpClient(new BytesHandler([])), root)
+                .PrepareAsync(Snapshot("snap-1"), (_, _) => throw new InvalidOperationException());
+            Assert.False(result.Ready);
+            Assert.Contains(result.Findings, x => x.Code == "cache.manifest-invalid" && x.Blocking);
+        }
+        finally { Directory.Delete(root, true); }
+    }
+
+    [Fact]
+    public async Task Oversized_body_is_stopped_and_never_promoted()
+    {
+        var asset = Asset([1, 2, 3], required: true); var root = Temp();
+        try
+        {
+            var result = await new VenueAssetCache(new HttpClient(new BytesHandler(new byte[1000], true)), root)
+                .PrepareAsync(Snapshot("snap-1", asset),
+                    (_, _) => Task.FromResult(new CloudAssetGrant(new Uri("https://objects.test/file"), DateTimeOffset.MaxValue)));
+            Assert.False(result.Ready); Assert.Empty(result.LocalPaths);
+            Assert.False(File.Exists(Path.Combine(root, "rev-1.audio.partial")));
+        }
+        finally { Directory.Delete(root, true); }
+    }
+
+    static CloudSnapshotAsset Asset(byte[] bytes, bool required) => new("rev-1", "backing-track",
+        Convert.ToHexString(SHA256.HashData(bytes)).ToLowerInvariant(), bytes.Length, required);
+    static PlayTrack Play(string file) => new(file)
+        { SessionCode = "SHOW", IssuedById = "performer", IssuedByRole = Nuotti.Contracts.V1.Enum.Role.Performer };
+    static CloudSessionSnapshot Snapshot(string id, params CloudSnapshotAsset[] assets) => new(id, "ws", "SHOW", 1, assets);
+    static string Temp() { var path = Path.Combine(Path.GetTempPath(), $"nuotti-cache-{Guid.NewGuid():N}"); Directory.CreateDirectory(path); return path; }
+    sealed class BytesHandler(byte[] bytes, bool omitLength = false) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct) =>
+            Task.FromResult(Response());
+        HttpResponseMessage Response()
+        {
+            var content = new ByteArrayContent(bytes);
+            if (omitLength) content.Headers.ContentLength = null;
+            return new(HttpStatusCode.OK) { Content = content };
+        }
+    }
+}

--- a/Nuotti.AudioEngine/Program.cs
+++ b/Nuotti.AudioEngine/Program.cs
@@ -245,6 +245,28 @@ try
             ?? throw new InvalidOperationException("Show Agent credential is missing or revoked. Pair this computer again.");
         Log.Information("Outbound Show Agent lease established. Workspace={WorkspaceId}, Session={SessionCode}, ExpiresAt={ExpiresAt}",
             lease.WorkspaceId, lease.SessionCode, lease.ExpiresAt);
+        var showSnapshot = await cloudAgent.GetSnapshotAsync(cts.Token)
+            ?? throw new InvalidOperationException("This Session has no immutable Session Setlist Snapshot.");
+        if (showSnapshot.WorkspaceId != lease.WorkspaceId || showSnapshot.SessionCode != lease.SessionCode)
+            throw new InvalidOperationException("Show Agent received a snapshot outside its paired Session.");
+        var cacheRoot = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "Nuotti", "show-cache", lease.WorkspaceId, lease.SessionCode);
+        var venueCache = new VenueAssetCache(httpClient, cacheRoot);
+        var cacheOverrides = GetArg(args, "cache-overrides", envVar: "NUOTTI_CACHE_OVERRIDES")
+            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .ToHashSet(StringComparer.Ordinal);
+        var cachePreflight = await venueCache.PrepareAsync(showSnapshot, cloudAgent.GetAssetGrantAsync,
+            cacheOverrides, cts.Token);
+        foreach (var finding in cachePreflight.Findings)
+            Log.Warning("Venue cache preflight {Code}: {Detail}", finding.Code, finding.Detail);
+        if (!cachePreflight.Ready)
+        {
+            await cloudAgent.ReportStatusAsync("Error", string.Join(" ", cachePreflight.Findings
+                .Select(x => x.Detail)), cts.Token);
+            throw new InvalidOperationException("Venue cache preflight failed. Resolve or explicitly accept the named safe degradations.");
+        }
+        Log.Information("Venue cache ready. Snapshot={SnapshotId}, Assets={AssetCount}",
+            showSnapshot.SnapshotId, cachePreflight.LocalPaths.Count);
         long cursor = cloudAgent.LoadCursor();
         var nextHeartbeat = DateTimeOffset.MinValue;
         while (!cts.IsCancellationRequested)
@@ -263,7 +285,16 @@ try
                 {
                     case "PlayTrack":
                         var play = ShowAgentCloudClient.DeserializePayload<PlayTrack>(command.Payload);
-                        if (play is not null) await engine.OnTrackPlayRequested(play.FileUrl);
+                        if (play is not null)
+                        {
+                            if (!VenueAssetCache.TryResolveCapturedSource(play, cachePreflight.LocalPaths, out var source))
+                            {
+                                await cloudAgent.ReportStatusAsync("Error",
+                                    $"PlayTrack rejected: asset '{play.AssetRevisionId ?? play.FileUrl}' is not in the verified Session cache.", cts.Token);
+                                throw new InvalidOperationException("Playback command referenced material outside the Session Setlist Snapshot.");
+                            }
+                            await engine.OnTrackPlayRequested(new Uri(source).AbsoluteUri);
+                        }
                         break;
                     case "StopTrack":
                         await engine.OnTrackStopped();

--- a/Nuotti.AudioEngine/ShowAgentCloudClient.cs
+++ b/Nuotti.AudioEngine/ShowAgentCloudClient.cs
@@ -8,6 +8,10 @@ namespace Nuotti.AudioEngine;
 
 public sealed record CloudAgentCommand(long Sequence, string MessageType, JsonElement Payload);
 public sealed record CloudAgentLease(string AccessToken, DateTimeOffset ExpiresAt, string WorkspaceId, string SessionCode);
+public sealed record CloudSnapshotAsset(string RevisionId, string AssetType, string Sha256, long Size, bool Required);
+public sealed record CloudSessionSnapshot(string SnapshotId, string WorkspaceId, string SessionCode, int Version,
+    IReadOnlyList<CloudSnapshotAsset> Assets);
+public sealed record CloudAssetGrant(Uri DownloadUri, DateTimeOffset ExpiresAt);
 sealed record PairResponse(string AgentId, string Credential, string AccessToken, DateTimeOffset AccessTokenExpiresAt);
 
 public sealed class ShowAgentCloudClient(HttpClient http, IShowAgentCredentialStore credentials)
@@ -57,6 +61,28 @@ public sealed class ShowAgentCloudClient(HttpClient http, IShowAgentCredentialSt
         return await response.Content.ReadFromJsonAsync<CloudAgentCommand[]>(Json, ct) ?? [];
     }
 
+    public async Task<CloudSessionSnapshot?> GetSnapshotAsync(CancellationToken ct = default)
+    {
+        var lease = await EnsureLeaseAsync(ct);
+        if (lease is null) return null;
+        using var request = AgentRequest(HttpMethod.Get, "/v1/show-agent/setlist-snapshot", lease.AccessToken);
+        using var response = await http.SendAsync(request, ct);
+        if (response.StatusCode == HttpStatusCode.NotFound) return null;
+        if (response.StatusCode == HttpStatusCode.Unauthorized) { _lease = null; return null; }
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync<CloudSessionSnapshot>(Json, ct);
+    }
+
+    public async Task<CloudAssetGrant> GetAssetGrantAsync(string revisionId, CancellationToken ct = default)
+    {
+        var lease = await EnsureLeaseAsync(ct) ?? throw new InvalidOperationException("Show Agent lease is unavailable.");
+        using var request = AgentRequest(HttpMethod.Post,
+            $"/v1/show-agent/assets/{Uri.EscapeDataString(revisionId)}/download", lease.AccessToken);
+        using var response = await http.SendAsync(request, ct);
+        response.EnsureSuccessStatusCode();
+        return (await response.Content.ReadFromJsonAsync<CloudAssetGrant>(Json, ct))!;
+    }
+
     public async Task<bool> ReportStatusAsync(string state, string? detail, CancellationToken ct = default)
     {
         var lease = await EnsureLeaseAsync(ct);
@@ -81,4 +107,11 @@ public sealed class ShowAgentCloudClient(HttpClient http, IShowAgentCredentialSt
     }
 
     public static T? DeserializePayload<T>(JsonElement payload) => payload.Deserialize<T>(Json);
+
+    static HttpRequestMessage AgentRequest(HttpMethod method, string path, string token)
+    {
+        var request = new HttpRequestMessage(method, path);
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        return request;
+    }
 }

--- a/Nuotti.AudioEngine/VenueAssetCache.cs
+++ b/Nuotti.AudioEngine/VenueAssetCache.cs
@@ -1,0 +1,118 @@
+using System.Security.Cryptography;
+using System.Text.Json;
+using Nuotti.Contracts.V1.Message;
+
+namespace Nuotti.AudioEngine;
+
+public sealed record VenueCacheFinding(string Code, bool Blocking, bool CanOverride, string Detail);
+public sealed record VenueCachePreflight(bool Ready, IReadOnlyList<VenueCacheFinding> Findings,
+    IReadOnlyDictionary<string, string> LocalPaths);
+
+public sealed class VenueAssetCache(HttpClient downloads, string rootDirectory)
+{
+    static readonly JsonSerializerOptions Json = new(JsonSerializerDefaults.Web);
+
+    public async Task<VenueCachePreflight> PrepareAsync(CloudSessionSnapshot snapshot,
+        Func<string, CancellationToken, Task<CloudAssetGrant>> grantFor,
+        IReadOnlySet<string>? acceptedWarnings = null, CancellationToken ct = default)
+    {
+        acceptedWarnings ??= new HashSet<string>();
+        var findings = new List<VenueCacheFinding>();
+        var paths = new Dictionary<string, string>(StringComparer.Ordinal);
+        Directory.CreateDirectory(rootDirectory);
+        var manifestPath = Path.Combine(rootDirectory, "snapshot.json");
+        if (File.Exists(manifestPath))
+        {
+            try
+            {
+                var cached = JsonSerializer.Deserialize<CachedSnapshot>(await File.ReadAllTextAsync(manifestPath, ct), Json);
+                if (cached is null) throw new JsonException("Manifest is empty.");
+                if (cached.WorkspaceId != snapshot.WorkspaceId || cached.SessionCode != snapshot.SessionCode
+                    || cached.SnapshotId != snapshot.SnapshotId)
+                    findings.Add(new("cache.stale-snapshot", true, false,
+                        $"Venue cache belongs to {cached.WorkspaceId}/{cached.SessionCode}/{cached.SnapshotId}, not {snapshot.WorkspaceId}/{snapshot.SessionCode}/{snapshot.SnapshotId}."));
+            }
+            catch (Exception ex) when (ex is JsonException or IOException)
+            {
+                findings.Add(new("cache.manifest-invalid", true, false,
+                    $"Venue cache manifest is damaged or unreadable: {ex.Message}"));
+            }
+        }
+
+        foreach (var asset in snapshot.Assets)
+        {
+            var extension = asset.AssetType is "backing-track" or "click-track" ? ".audio" : ".media";
+            var path = Path.Combine(rootDirectory, Safe(asset.RevisionId) + extension);
+            if (!await ValidAsync(path, asset, ct))
+            {
+                try
+                {
+                    var grant = await grantFor(asset.RevisionId, ct);
+                    var temp = path + ".partial";
+                    using var response = await downloads.GetAsync(grant.DownloadUri, HttpCompletionOption.ResponseHeadersRead, ct);
+                    response.EnsureSuccessStatusCode();
+                    if (response.Content.Headers.ContentLength is { } length && length != asset.Size)
+                        throw new InvalidDataException($"Content-Length {length} does not match expected {asset.Size} bytes.");
+                    await using (var destination = new FileStream(temp, FileMode.Create, FileAccess.Write, FileShare.None))
+                        await CopyBoundedAsync(await response.Content.ReadAsStreamAsync(ct), destination, asset.Size, ct);
+                    if (!await ValidAsync(temp, asset, ct))
+                    {
+                        File.Delete(temp);
+                        findings.Add(new($"asset.{asset.RevisionId}.hash-mismatch", asset.Required, !asset.Required,
+                            $"Downloaded {asset.AssetType} bytes do not match the immutable snapshot hash and size."));
+                        continue;
+                    }
+                    File.Move(temp, path, true);
+                }
+                catch (Exception ex) when (ex is HttpRequestException or IOException or InvalidDataException)
+                {
+                    try { File.Delete(path + ".partial"); } catch { }
+                    findings.Add(new($"asset.{asset.RevisionId}.download-failed", asset.Required, !asset.Required,
+                        $"{asset.AssetType} could not be cached: {ex.Message}"));
+                    continue;
+                }
+            }
+            paths[asset.RevisionId] = path;
+        }
+        var ready = findings.All(x => !x.Blocking && (!x.CanOverride || acceptedWarnings.Contains(x.Code)))
+            && snapshot.Assets.Where(x => x.Required)
+            .All(x => paths.ContainsKey(x.RevisionId));
+        if (ready)
+        {
+            var tempManifest = manifestPath + ".partial";
+            await File.WriteAllTextAsync(tempManifest,
+                JsonSerializer.Serialize(new CachedSnapshot(snapshot.SnapshotId, snapshot.WorkspaceId, snapshot.SessionCode), Json), ct);
+            File.Move(tempManifest, manifestPath, true);
+        }
+        return new(ready, findings, paths);
+    }
+
+    static async Task<bool> ValidAsync(string path, CloudSnapshotAsset asset, CancellationToken ct)
+    {
+        var info = new FileInfo(path);
+        if (!info.Exists || info.Length != asset.Size) return false;
+        await using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read);
+        var digest = Convert.ToHexString(await SHA256.HashDataAsync(stream, ct));
+        return digest.Equals(asset.Sha256, StringComparison.OrdinalIgnoreCase);
+    }
+    static string Safe(string value) => string.Concat(value.Select(x => char.IsAsciiLetterOrDigit(x) || x is '-' or '_' ? x : '_'));
+    static async Task CopyBoundedAsync(Stream source, Stream destination, long expectedSize, CancellationToken ct)
+    {
+        var buffer = new byte[81920]; long total = 0;
+        while (true)
+        {
+            var read = await source.ReadAsync(buffer, ct); if (read == 0) break;
+            total += read; if (total > expectedSize) throw new InvalidDataException("Download exceeded immutable asset size.");
+            await destination.WriteAsync(buffer.AsMemory(0, read), ct);
+        }
+        if (total != expectedSize) throw new InvalidDataException($"Download ended at {total} of {expectedSize} bytes.");
+    }
+    sealed record CachedSnapshot(string SnapshotId, string WorkspaceId, string SessionCode);
+
+    public static bool TryResolveCapturedSource(PlayTrack command, IReadOnlyDictionary<string, string> localPaths,
+        out string source)
+    {
+        var revisionId = !string.IsNullOrWhiteSpace(command.AssetRevisionId) ? command.AssetRevisionId : command.FileUrl;
+        return localPaths.TryGetValue(revisionId, out source!);
+    }
+}

--- a/Nuotti.Backend.Tests/SessionSnapshotBuilderTests.cs
+++ b/Nuotti.Backend.Tests/SessionSnapshotBuilderTests.cs
@@ -1,0 +1,127 @@
+using Nuotti.Backend.Assets;
+using Nuotti.Backend.SessionSnapshots;
+using Nuotti.Backend.SongPackages;
+
+namespace Nuotti.Backend.Tests;
+
+public sealed class SessionSnapshotBuilderTests
+{
+    readonly InMemoryPrivateAssetMetadataStore _assets = new();
+    readonly InMemorySongPackageStore _packages = new();
+    readonly InMemoryLyricTrackRevisionStore _lyrics = new();
+    readonly MvpScoringPolicyCatalog _policies = new();
+
+    [Fact]
+    public async Task Captures_exact_revision_hint_order_lyrics_scoring_and_verified_assets()
+    {
+        var entry = await _assets.CreateEntryAsync("ws", "Song", "Artist", "member");
+        var backing = await PublishedAsync(entry.CatalogEntryId, "backing-track", [1, 2, 3, 4]);
+        var document = new SongPackageDocument(new(PlaybackMode.BackingOnly, backing.RevisionId, null, 1000,
+            5000, 4000, null, [1, 2], []),
+            [new("h1", PackageHintType.Text, "First", null, null), new("h2", PackageHintType.LiveBand, null, null, "Riff")],
+            new("[00:01.00]Line", 250));
+        await _packages.SaveDraftAsync("ws", entry.CatalogEntryId, document, "member");
+        var revision = await _packages.PublishAsync("ws", entry.CatalogEntryId, document, "ready", [], "member");
+        await _lyrics.PublishAsync("ws", entry.CatalogEntryId, document.Lyrics!.Lrc, document.Lyrics.OffsetMs, "member");
+        var policy = new ScoringPolicyReference("standard", 1);
+
+        var built = await new SessionSnapshotBuilder(_packages, _assets, _lyrics, _policies).BuildAsync("ws",
+            [new(revision.RevisionId)], policy, new HashSet<string>());
+
+        Assert.True(built.Preflight.CanCreate);
+        var song = Assert.Single(built.Songs);
+        Assert.Equal(revision.RevisionId, song.PackageRevisionId);
+        Assert.Equal(["h1", "h2"], song.Hints.Select(x => x.HintId));
+        Assert.Equal(document.Lyrics!.Lrc, song.LyricTrack!.Lrc);
+        Assert.StartsWith("lyric_", song.LyricTrack.TrackRevisionId);
+        Assert.Equal(64, song.LyricTrack.Sha256.Length);
+        Assert.Equal(backing.Sha256, Assert.Single(built.Preflight.Assets).Sha256);
+    }
+
+    [Fact]
+    public async Task Missing_lyrics_is_safe_override_but_missing_revision_is_never_overridable()
+    {
+        var entry = await _assets.CreateEntryAsync("ws", "Live", "Band", "member");
+        var document = new SongPackageDocument(new(PlaybackMode.LiveOnly, null, null, 0, null, null, null, [], []),
+            [new("h", PackageHintType.Text, "Clue", null, null)], null);
+        await _packages.SaveDraftAsync("ws", entry.CatalogEntryId, document, "member");
+        var revision = await _packages.PublishAsync("ws", entry.CatalogEntryId, document, "ready", [], "member");
+        var builder = new SessionSnapshotBuilder(_packages, _assets, _lyrics, _policies);
+        var policy = new ScoringPolicyReference("standard", 1);
+        var warning = await builder.BuildAsync("ws", [new(revision.RevisionId)], policy, new HashSet<string>());
+        Assert.False(warning.Preflight.CanCreate);
+        var code = Assert.Single(warning.Preflight.Findings.Where(x => x.Severity == ReadinessSeverity.Warning)).Code;
+        Assert.True((await builder.BuildAsync("ws", [new(revision.RevisionId)], policy, new HashSet<string>([code]))).Preflight.CanCreate);
+        var blocked = await builder.BuildAsync("ws", [new("missing")], policy, new HashSet<string>(["song.1.revision-missing"]));
+        Assert.False(blocked.Preflight.CanCreate);
+        Assert.False(blocked.Preflight.Findings.Single(x => x.Code == "song.1.revision-missing").CanOverride);
+    }
+
+    [Fact]
+    public async Task Explicit_independent_lyric_revision_is_captured_even_after_later_edits()
+    {
+        var entry = await _assets.CreateEntryAsync("ws", "Song", "Artist", "member");
+        var document = new SongPackageDocument(new(PlaybackMode.LiveOnly, null, null, 0, null, null, null, [], []),
+            [new("h", PackageHintType.Text, "Clue", null, null)], null);
+        await _packages.SaveDraftAsync("ws", entry.CatalogEntryId, document, "member");
+        var package = await _packages.PublishAsync("ws", entry.CatalogEntryId, document, "ready", [], "member");
+        var first = await _lyrics.PublishAsync("ws", entry.CatalogEntryId, "[00:01.00]First", 0, "member");
+        await _lyrics.PublishAsync("ws", entry.CatalogEntryId, "[00:01.00]Later edit", 250, "member");
+
+        var built = await new SessionSnapshotBuilder(_packages, _assets, _lyrics, _policies).BuildAsync("ws",
+            [new(package.RevisionId, first.RevisionId)], new("standard", 1), new HashSet<string>());
+
+        Assert.True(built.Preflight.CanCreate);
+        Assert.Equal(first.RevisionId, Assert.Single(built.Songs).LyricTrack!.TrackRevisionId);
+        Assert.Equal("[00:01.00]First", built.Songs[0].LyricTrack!.Lrc);
+    }
+
+    [Fact]
+    public async Task Unknown_scoring_policy_version_is_blocking()
+    {
+        var built = await new SessionSnapshotBuilder(_packages, _assets, _lyrics, _policies).BuildAsync("ws",
+            [new("missing")], new("standard", 999), new HashSet<string>());
+        Assert.False(built.Preflight.CanCreate);
+        Assert.Contains(built.Preflight.Findings, x => x.Code == "scoring.invalid" && !x.CanOverride);
+    }
+
+    [Fact]
+    public async Task Publishing_historical_lyric_content_again_makes_a_new_current_revision()
+    {
+        var entry = await _assets.CreateEntryAsync("ws", "Song", "Artist", "member");
+        var first = await _lyrics.PublishAsync("ws", entry.CatalogEntryId, "[00:01.00]A", 0, "member");
+        var second = await _lyrics.PublishAsync("ws", entry.CatalogEntryId, "[00:01.00]B", 0, "member");
+        var reverted = await _lyrics.PublishAsync("ws", entry.CatalogEntryId, "[00:01.00]A", 0, "member");
+        Assert.Equal(first.Sha256, reverted.Sha256);
+        Assert.Equal(second.Version + 1, reverted.Version);
+        Assert.Equal(reverted.RevisionId, (await _lyrics.GetCurrentAsync("ws", entry.CatalogEntryId))!.RevisionId);
+    }
+
+    [Fact]
+    public async Task Visual_only_hint_is_required_in_the_venue_manifest()
+    {
+        var entry = await _assets.CreateEntryAsync("ws", "Visual Song", "Artist", "member");
+        var visual = await PublishedAsync(entry.CatalogEntryId, "visual-hint", [1, 2, 3]);
+        var document = new SongPackageDocument(new(PlaybackMode.LiveOnly, null, null, 0, null, null, null, [], []),
+            [new("visual", PackageHintType.Visual, null, visual.RevisionId, null)], null);
+        await _packages.SaveDraftAsync("ws", entry.CatalogEntryId, document, "member");
+        var package = await _packages.PublishAsync("ws", entry.CatalogEntryId, document, "ready", [], "member");
+        var warning = "song.1.lyrics-missing";
+        var built = await new SessionSnapshotBuilder(_packages, _assets, _lyrics, _policies).BuildAsync("ws",
+            [new(package.RevisionId)], new("standard", 1), new HashSet<string>([warning]));
+        Assert.True(built.Preflight.CanCreate);
+        Assert.True(Assert.Single(built.Preflight.Assets).Required);
+        Assert.DoesNotContain(built.Preflight.Findings, finding =>
+            finding.Title.Contains("required audio", StringComparison.OrdinalIgnoreCase));
+    }
+
+    async Task<PrivateAssetRevision> PublishedAsync(string entryId, string type, byte[] bytes)
+    {
+        var provenance = new AssetProvenance("owned", "original", "NO", [type], null, "evidence");
+        var draft = await _assets.CreateDraftAsync("ws", entryId, type, "audio/wav", bytes.Length, provenance, "member")
+            ?? throw new InvalidOperationException();
+        var claim = await _assets.TryBeginFinalizationAsync("ws", draft.Revision.RevisionId) ?? throw new InvalidOperationException();
+        return await _assets.PublishAsync("ws", draft.Revision.RevisionId, "sealed", claim.Token, bytes.Length,
+            Convert.ToHexString(System.Security.Cryptography.SHA256.HashData(bytes)).ToLowerInvariant()) ?? throw new InvalidOperationException();
+    }
+}

--- a/Nuotti.Backend.Tests/SessionSnapshotJourneyTests.cs
+++ b/Nuotti.Backend.Tests/SessionSnapshotJourneyTests.cs
@@ -1,0 +1,81 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Nuotti.Backend;
+using Nuotti.Backend.Assets;
+using Nuotti.Backend.SessionSnapshots;
+using Nuotti.Backend.ShowAgents;
+using Nuotti.Backend.SongPackages;
+using Nuotti.Backend.Workspaces;
+
+namespace Nuotti.Backend.Tests;
+
+public sealed class SessionSnapshotJourneyTests(WebApplicationFactory<QuizHub> baseFactory)
+    : IClassFixture<WebApplicationFactory<QuizHub>>
+{
+    readonly WebApplicationFactory<QuizHub> _factory = baseFactory.WithWebHostBuilder(_ => { });
+
+    [Fact]
+    public async Task Performer_captures_once_and_only_paired_agent_reads_exact_snapshot()
+    {
+        using var client = _factory.CreateClient();
+        var member = await SignInAsync(client, "snapshot");
+        var workspace = await PostAsync<WorkspaceAccess>(client, "/v1/workspaces", member.SessionToken,
+            new { name = "Snapshot band" });
+        await SendAsync(client, HttpMethod.Post, $"/v1/workspaces/{workspace.WorkspaceId}/select", member.SessionToken);
+        (await SendAsync(client, HttpMethod.Post,
+            $"/v1/workspaces/{workspace.WorkspaceId}/sessions/SNAP1/create", member.SessionToken)).EnsureSuccessStatusCode();
+        var entry = await PostAsync<PrivateCatalogEntry>(client, $"/v1/workspaces/{workspace.WorkspaceId}/catalog",
+            member.SessionToken, new { title = "Song", artist = "Band" });
+        var document = new SongPackageDocument(new(PlaybackMode.LiveOnly, null, null, 0, null, null, null, [], []),
+            [new("hint-1", PackageHintType.Text, "A clue", null, null)], null);
+        (await SendAsync(client, HttpMethod.Put,
+            $"/v1/workspaces/{workspace.WorkspaceId}/catalog/{entry.CatalogEntryId}/package",
+            member.SessionToken, document)).EnsureSuccessStatusCode();
+        var package = await PostAsync<SongPackageRevision>(client,
+            $"/v1/workspaces/{workspace.WorkspaceId}/catalog/{entry.CatalogEntryId}/package/publish", member.SessionToken,
+            new { revisionNote = "Ready", acceptedWarningCodes = new[] { "lyrics.missing" } });
+        var request = new CreateSessionSetlistSnapshotRequest([new(package.RevisionId)],
+            new("standard", 1), ["song.1.lyrics-missing"]);
+        var snapshot = await PostAsync<SessionSetlistSnapshot>(client,
+            $"/v1/workspaces/{workspace.WorkspaceId}/sessions/SNAP1/setlist-snapshot", member.SessionToken, request);
+        Assert.Equal(package.RevisionId, Assert.Single(snapshot.Songs).PackageRevisionId);
+        Assert.Equal("standard", snapshot.ScoringPolicy.PolicyId);
+
+        var duplicate = await SendAsync(client, HttpMethod.Post,
+            $"/v1/workspaces/{workspace.WorkspaceId}/sessions/SNAP1/setlist-snapshot", member.SessionToken, request);
+        Assert.Equal(HttpStatusCode.Conflict, duplicate.StatusCode);
+        var pairing = await PostAsync<ShowAgentPairingCode>(client,
+            $"/v1/workspaces/{workspace.WorkspaceId}/sessions/SNAP1/show-agent/pairings", member.SessionToken, null);
+        var agent = await PostAsync<PairedShowAgent>(client, "/v1/show-agent/pair", null,
+            new { code = pairing.Code, name = "Venue laptop" });
+        var agentSnapshot = await GetAsync<SessionSetlistSnapshot>(client, "/v1/show-agent/setlist-snapshot", agent.AccessToken);
+        Assert.Equal(snapshot.SnapshotId, agentSnapshot.SnapshotId);
+    }
+
+    static async Task<RedeemedMagicLink> SignInAsync(HttpClient client, string prefix)
+    {
+        var link = await PostAsync<IssuedMagicLink>(client, "/v1/auth/magic-links", null,
+            new { email = $"{prefix}-{Guid.NewGuid():N}@example.test" });
+        return await PostAsync<RedeemedMagicLink>(client, "/v1/auth/magic-links/redeem", null, new { token = link.Token });
+    }
+    static async Task<T> PostAsync<T>(HttpClient client, string path, string? token, object? body)
+    {
+        var response = await SendAsync(client, HttpMethod.Post, path, token, body); response.EnsureSuccessStatusCode();
+        return (await response.Content.ReadFromJsonAsync<T>())!;
+    }
+    static async Task<T> GetAsync<T>(HttpClient client, string path, string token)
+    {
+        var response = await SendAsync(client, HttpMethod.Get, path, token); response.EnsureSuccessStatusCode();
+        return (await response.Content.ReadFromJsonAsync<T>())!;
+    }
+    static async Task<HttpResponseMessage> SendAsync(HttpClient client, HttpMethod method, string path,
+        string? token, object? body = null)
+    {
+        using var request = new HttpRequestMessage(method, path);
+        if (token is not null) request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        if (body is not null) request.Content = JsonContent.Create(body);
+        return await client.SendAsync(request);
+    }
+}

--- a/Nuotti.Backend/Endpoints/SessionSnapshotEndpoints.cs
+++ b/Nuotti.Backend/Endpoints/SessionSnapshotEndpoints.cs
@@ -1,0 +1,115 @@
+using Nuotti.Backend.Assets;
+using Nuotti.Backend.Exception;
+using Nuotti.Backend.Persistence;
+using Nuotti.Backend.SessionSnapshots;
+using Nuotti.Backend.ShowAgents;
+using Nuotti.Backend.Workspaces;
+using Nuotti.Contracts.V1.Enum;
+
+namespace Nuotti.Backend.Endpoints;
+
+public static class SessionSnapshotEndpoints
+{
+    public static void MapSessionSnapshotEndpoints(this WebApplication app)
+    {
+        app.MapPost("/v1/workspaces/{workspaceId}/sessions/{sessionCode}/setlist-snapshot/preflight", async (
+            HttpContext http, string workspaceId, string sessionCode, CreateSessionSetlistSnapshotRequest request,
+            IWorkspaceAccessStore access, IDurableSessionCommitStore sessions, SessionSnapshotBuilder builder,
+            CancellationToken ct) =>
+        {
+            var selected = await WorkspaceHttpAccess.RequireSelectedAsync(http, access, workspaceId, ct);
+            if (selected.Principal is null) return Results.Unauthorized();
+            if (selected.Access is null || await sessions.LoadAsync(workspaceId, sessionCode, ct) is null) return Results.NotFound();
+            var accepted = Codes(request.AcceptedWarningCodes);
+            var result = await builder.BuildAsync(workspaceId, request.Songs, request.ScoringPolicy, accepted, ct);
+            return Results.Ok(result.Preflight);
+        });
+
+        app.MapPost("/v1/workspaces/{workspaceId}/sessions/{sessionCode}/setlist-snapshot", async (
+            HttpContext http, string workspaceId, string sessionCode, CreateSessionSetlistSnapshotRequest request,
+            IWorkspaceAccessStore access, IDurableSessionCommitStore sessions, SessionSnapshotBuilder builder,
+            ISessionSetlistSnapshotStore snapshots, CancellationToken ct) =>
+        {
+            var selected = await WorkspaceHttpAccess.RequireSelectedAsync(http, access, workspaceId, ct);
+            if (selected.Principal is null) return Results.Unauthorized();
+            if (selected.Access is null || await sessions.LoadAsync(workspaceId, sessionCode, ct) is null) return Results.NotFound();
+            if (await snapshots.GetAsync(workspaceId, sessionCode, ct) is not null)
+                return ProblemResults.Conflict("Session Setlist Snapshot already exists.",
+                    "A Session captures its exact show material only once.", ReasonCode.InvalidStateTransition);
+            var accepted = Codes(request.AcceptedWarningCodes);
+            var built = await builder.BuildAsync(workspaceId, request.Songs, request.ScoringPolicy, accepted, ct);
+            var actualWarnings = built.Preflight.Findings.Where(x => x.Severity == SongPackages.ReadinessSeverity.Warning)
+                .Select(x => x.Code).ToHashSet(StringComparer.Ordinal);
+            if (accepted.Any(x => !actualWarnings.Contains(x)))
+                return ProblemResults.BadRequest("Unknown snapshot override.",
+                    "Only current safe preflight warnings may be accepted.", ReasonCode.InvalidStateTransition);
+            if (!built.Preflight.CanCreate)
+                return ProblemResults.UnprocessableEntity("Session Setlist Snapshot is not ready.",
+                    string.Join(" ", built.Preflight.Findings.Where(x => x.Severity != SongPackages.ReadinessSeverity.Ready
+                        && (!x.CanOverride || !accepted.Contains(x.Code))).Select(x => $"{x.Title} {x.Action}")),
+                    ReasonCode.InvalidStateTransition);
+            try
+            {
+                return Results.Ok(await snapshots.CreateAsync(workspaceId, sessionCode, built.Songs,
+                    built.Policy!, built.Preflight.Assets, accepted.ToArray(), selected.Principal.UserId, ct));
+            }
+            catch (InvalidOperationException)
+            {
+                return ProblemResults.Conflict("Session Setlist Snapshot already exists.",
+                    "A concurrent request already captured this Session.", ReasonCode.InvalidStateTransition);
+            }
+        });
+
+        app.MapGet("/v1/workspaces/{workspaceId}/sessions/{sessionCode}/setlist-snapshot", async (
+            HttpContext http, string workspaceId, string sessionCode, IWorkspaceAccessStore access,
+            ISessionSetlistSnapshotStore snapshots, CancellationToken ct) =>
+        {
+            var selected = await WorkspaceHttpAccess.RequireSelectedAsync(http, access, workspaceId, ct);
+            if (selected.Principal is null) return Results.Unauthorized();
+            if (selected.Access is null) return Results.NotFound();
+            var snapshot = await snapshots.GetAsync(workspaceId, sessionCode, ct);
+            return snapshot is null ? Results.NotFound() : Results.Ok(snapshot);
+        });
+
+        app.MapGet("/v1/show-agent/setlist-snapshot", async (HttpContext http, IShowAgentAccessStore agents,
+            ISessionSetlistSnapshotStore snapshots, CancellationToken ct) =>
+        {
+            var lease = await AgentAsync(http, agents, ct);
+            if (lease is null) return Results.Unauthorized();
+            var snapshot = await snapshots.GetAsync(lease.WorkspaceId, lease.SessionCode, ct);
+            return snapshot is null ? Results.NotFound() : Results.Ok(snapshot);
+        });
+
+        app.MapPost("/v1/show-agent/assets/{revisionId}/download", async (HttpContext http, string revisionId,
+            IShowAgentAccessStore agents, ISessionSetlistSnapshotStore snapshots, IPrivateAssetMetadataStore metadata,
+            IPrivateAssetObjectStore objects, CancellationToken ct) =>
+        {
+            var lease = await AgentAsync(http, agents, ct);
+            if (lease is null) return Results.Unauthorized();
+            var snapshot = await snapshots.GetAsync(lease.WorkspaceId, lease.SessionCode, ct);
+            if (snapshot is null || !snapshot.Assets.Any(x => x.RevisionId == revisionId)) return Results.NotFound();
+            var revision = await metadata.GetAsync(lease.WorkspaceId, revisionId, ct);
+            if (revision?.Status != AssetRevisionStatus.Published || string.IsNullOrWhiteSpace(revision.Sha256)
+                || revision.Provenance.RightsExpiresAt is { } expiry && expiry <= DateTimeOffset.UtcNow
+                || !snapshot.Assets.Any(x => x.RevisionId == revisionId
+                    && x.Sha256.Equals(revision.Sha256, StringComparison.OrdinalIgnoreCase))) return Results.NotFound();
+            var key = await metadata.GetObjectKeyAsync(lease.WorkspaceId, revisionId, ct);
+            if (key is null) return Results.NotFound();
+            try
+            {
+                var grant = await objects.CreateDownloadGrantAsync(key, ct);
+                return Results.Ok(new PrivateAssetDownloadGrant(grant.Uri, grant.ExpiresAt));
+            }
+            catch (PrivateAssetGrantUnavailableException) { return Results.StatusCode(503); }
+        });
+    }
+
+    static HashSet<string> Codes(IReadOnlyList<string>? values) => (values ?? [])
+        .Where(x => !string.IsNullOrWhiteSpace(x)).Select(x => x.Trim()).ToHashSet(StringComparer.Ordinal);
+    static async Task<ShowAgentLease?> AgentAsync(HttpContext http, IShowAgentAccessStore store, CancellationToken ct)
+    {
+        var value = http.Request.Headers.Authorization.ToString();
+        return value.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase)
+            ? await store.AuthenticateAsync(value[7..].Trim(), ct) : null;
+    }
+}

--- a/Nuotti.Backend/Endpoints/SongPackageEndpoints.cs
+++ b/Nuotti.Backend/Endpoints/SongPackageEndpoints.cs
@@ -1,6 +1,7 @@
 using Nuotti.Backend.Assets;
 using Nuotti.Backend.Exception;
 using Nuotti.Backend.SongPackages;
+using Nuotti.Backend.SessionSnapshots;
 using Nuotti.Backend.Workspaces;
 using Nuotti.Contracts.V1.Enum;
 
@@ -56,7 +57,7 @@ public static class SongPackageEndpoints
         app.MapPost("/v1/workspaces/{workspaceId}/catalog/{catalogEntryId}/package/publish", async (
             HttpContext http, string workspaceId, string catalogEntryId, PublishSongPackageRequest request,
             IWorkspaceAccessStore access, ISongPackageStore packages, SongPackageReadinessEvaluator evaluator,
-            CancellationToken ct) =>
+            ILyricTrackRevisionStore lyricTracks, CancellationToken ct) =>
         {
             var selected = await WorkspaceHttpAccess.RequireSelectedAsync(http, access, workspaceId, ct);
             if (selected.Principal is null) return Results.Unauthorized();
@@ -82,8 +83,30 @@ public static class SongPackageEndpoints
                 return ProblemResults.UnprocessableEntity("Song Package is not Show Ready.", string.Join(" ", unresolved),
                     ReasonCode.InvalidStateTransition);
             }
+            if (draft.Document.Lyrics is { } lyric)
+                await lyricTracks.PublishAsync(workspaceId, catalogEntryId, lyric.Lrc, lyric.OffsetMs,
+                    selected.Principal.UserId, ct);
             return Results.Ok(await packages.PublishAsync(workspaceId, catalogEntryId, draft.Document,
                 request.RevisionNote, accepted.Order(StringComparer.Ordinal).ToArray(), selected.Principal.UserId, ct));
+        });
+
+        app.MapPost("/v1/workspaces/{workspaceId}/catalog/{catalogEntryId}/lyric-track/revisions", async (
+            HttpContext http, string workspaceId, string catalogEntryId, LyricTrackDraft lyric,
+            IWorkspaceAccessStore access, IPrivateAssetMetadataStore assets, ILyricTrackRevisionStore tracks,
+            CancellationToken ct) =>
+        {
+            var selected = await WorkspaceHttpAccess.RequireSelectedAsync(http, access, workspaceId, ct);
+            if (selected.Principal is null) return Results.Unauthorized();
+            if (selected.Access is null || await assets.GetEntryAsync(workspaceId, catalogEntryId, ct) is null)
+                return Results.NotFound();
+            var error = "Use valid LRC and an offset within five minutes.";
+            var validLrc = !string.IsNullOrWhiteSpace(lyric.Lrc) && lyric.Lrc.Length <= 1_000_000
+                && SongPackageReadinessEvaluator.TryParseLrc(lyric.Lrc, out _, out error);
+            if (!validLrc || lyric.OffsetMs is < -300_000 or > 300_000)
+                return ProblemResults.BadRequest("Lyric Track is invalid.", error,
+                    ReasonCode.InvalidStateTransition);
+            return Results.Ok(await tracks.PublishAsync(workspaceId, catalogEntryId, lyric.Lrc, lyric.OffsetMs,
+                selected.Principal.UserId, ct));
         });
 
         app.MapGet("/v1/workspaces/{workspaceId}/catalog/{catalogEntryId}/package/revisions", async (

--- a/Nuotti.Backend/Program.cs
+++ b/Nuotti.Backend/Program.cs
@@ -14,6 +14,7 @@ using Nuotti.Backend.Workspaces;
 using Nuotti.Backend.ShowAgents;
 using Nuotti.Backend.Assets;
 using Nuotti.Backend.SongPackages;
+using Nuotti.Backend.SessionSnapshots;
 using Nuotti.Contracts.V1.Eventing;
 using Microsoft.Extensions.Options;
 using System.Threading.RateLimiting;
@@ -126,6 +127,8 @@ if (!string.IsNullOrWhiteSpace(databaseConnection))
     builder.Services.AddSingleton<IShowAgentAccessStore, PostgresShowAgentAccessStore>();
     builder.Services.AddSingleton<IPrivateAssetMetadataStore, PostgresPrivateAssetMetadataStore>();
     builder.Services.AddSingleton<ISongPackageStore, PostgresSongPackageStore>();
+    builder.Services.AddSingleton<ISessionSetlistSnapshotStore, PostgresSessionSetlistSnapshotStore>();
+    builder.Services.AddSingleton<ILyricTrackRevisionStore, PostgresLyricTrackRevisionStore>();
     builder.Services.AddSingleton<IDurableSessionCommitStore, PostgresDurableSessionCommitStore>();
 }
 else
@@ -136,6 +139,8 @@ else
     builder.Services.AddSingleton<IShowAgentAccessStore, InMemoryShowAgentAccessStore>();
     builder.Services.AddSingleton<IPrivateAssetMetadataStore, InMemoryPrivateAssetMetadataStore>();
     builder.Services.AddSingleton<ISongPackageStore, InMemorySongPackageStore>();
+    builder.Services.AddSingleton<ISessionSetlistSnapshotStore, InMemorySessionSetlistSnapshotStore>();
+    builder.Services.AddSingleton<ILyricTrackRevisionStore, InMemoryLyricTrackRevisionStore>();
     builder.Services.AddSingleton<IDurableSessionCommitStore, InMemoryDurableSessionCommitStore>();
 }
 if (!string.IsNullOrWhiteSpace(assetsConnection))
@@ -143,6 +148,8 @@ if (!string.IsNullOrWhiteSpace(assetsConnection))
 else
     builder.Services.AddSingleton<IPrivateAssetObjectStore, InMemoryPrivateAssetObjectStore>();
 builder.Services.AddSingleton<SongPackageReadinessEvaluator>();
+builder.Services.AddSingleton<SessionSnapshotBuilder>();
+builder.Services.AddSingleton<IScoringPolicyCatalog, MvpScoringPolicyCatalog>();
 builder.Services.AddSingleton<DurableOutboxDispatcher>();
 builder.Services.AddHostedService<DurableOutboxWorker>();
 
@@ -217,6 +224,7 @@ app.MapWorkspaceEndpoints();
 app.MapShowAgentEndpoints();
 app.MapPrivateAssetEndpoints();
 app.MapSongPackageEndpoints();
+app.MapSessionSnapshotEndpoints();
 app.MapRecoveryEndpoints();
 app.MapNuottiEndpoints("Nuotti.Backend");
 

--- a/Nuotti.Backend/SessionSnapshots/InMemorySessionSetlistSnapshotStore.cs
+++ b/Nuotti.Backend/SessionSnapshots/InMemorySessionSetlistSnapshotStore.cs
@@ -1,0 +1,32 @@
+namespace Nuotti.Backend.SessionSnapshots;
+
+public sealed class InMemorySessionSetlistSnapshotStore(TimeProvider? timeProvider = null)
+    : ISessionSetlistSnapshotStore
+{
+    readonly TimeProvider _time = timeProvider ?? TimeProvider.System;
+    readonly object _gate = new();
+    readonly Dictionary<(string Workspace, string Session), SessionSetlistSnapshot> _snapshots = [];
+
+    public Task<SessionSetlistSnapshot?> GetAsync(string workspaceId, string sessionCode,
+        CancellationToken cancellationToken = default)
+    {
+        lock (_gate) return Task.FromResult(_snapshots.GetValueOrDefault((workspaceId, sessionCode)));
+    }
+
+    public Task<SessionSetlistSnapshot> CreateAsync(string workspaceId, string sessionCode,
+        IReadOnlyList<SessionSetlistItem> songs, ScoringPolicySnapshot scoringPolicy,
+        IReadOnlyList<SnapshotAsset> assets, IReadOnlyList<string> acceptedWarnings, string userId,
+        CancellationToken cancellationToken = default)
+    {
+        lock (_gate)
+        {
+            var key = (workspaceId, sessionCode);
+            if (_snapshots.ContainsKey(key)) throw new InvalidOperationException("Session Setlist Snapshot already exists.");
+            var snapshot = new SessionSetlistSnapshot($"snap_{Guid.NewGuid():N}", workspaceId, sessionCode, 1,
+                songs.ToArray(), scoringPolicy, assets.ToArray(), acceptedWarnings.Order(StringComparer.Ordinal).ToArray(),
+                userId, _time.GetUtcNow());
+            _snapshots[key] = snapshot;
+            return Task.FromResult(snapshot);
+        }
+    }
+}

--- a/Nuotti.Backend/SessionSnapshots/PostgresSessionSetlistSnapshotStore.cs
+++ b/Nuotti.Backend/SessionSnapshots/PostgresSessionSetlistSnapshotStore.cs
@@ -1,0 +1,61 @@
+using System.Text.Json;
+using Npgsql;
+
+namespace Nuotti.Backend.SessionSnapshots;
+
+public sealed class PostgresSessionSetlistSnapshotStore(NpgsqlDataSource dataSource, TimeProvider? timeProvider = null)
+    : ISessionSetlistSnapshotStore
+{
+    static readonly JsonSerializerOptions Json = new(JsonSerializerDefaults.Web);
+    readonly TimeProvider _time = timeProvider ?? TimeProvider.System;
+    readonly SemaphoreSlim _gate = new(1, 1);
+    volatile bool _initialized;
+
+    public async Task<SessionSetlistSnapshot?> GetAsync(string workspaceId, string sessionCode,
+        CancellationToken cancellationToken = default)
+    {
+        await EnsureSchemaAsync(cancellationToken);
+        await using var command = dataSource.CreateCommand(
+            "SELECT snapshot::text FROM nuotti_session_setlist_snapshot WHERE workspace_id=$1 AND session_code=$2");
+        command.Parameters.AddWithValue(workspaceId); command.Parameters.AddWithValue(sessionCode);
+        var value = await command.ExecuteScalarAsync(cancellationToken);
+        return value is string json ? JsonSerializer.Deserialize<SessionSetlistSnapshot>(json, Json) : null;
+    }
+
+    public async Task<SessionSetlistSnapshot> CreateAsync(string workspaceId, string sessionCode,
+        IReadOnlyList<SessionSetlistItem> songs, ScoringPolicySnapshot scoringPolicy,
+        IReadOnlyList<SnapshotAsset> assets, IReadOnlyList<string> acceptedWarnings, string userId,
+        CancellationToken cancellationToken = default)
+    {
+        await EnsureSchemaAsync(cancellationToken);
+        var snapshot = new SessionSetlistSnapshot($"snap_{Guid.NewGuid():N}", workspaceId, sessionCode, 1,
+            songs.ToArray(), scoringPolicy, assets.ToArray(), acceptedWarnings.Order(StringComparer.Ordinal).ToArray(),
+            userId, _time.GetUtcNow());
+        await using var command = dataSource.CreateCommand("""
+            INSERT INTO nuotti_session_setlist_snapshot(workspace_id,session_code,snapshot)
+            VALUES ($1,$2,$3::jsonb) ON CONFLICT(workspace_id,session_code) DO NOTHING
+            """);
+        command.Parameters.AddWithValue(workspaceId); command.Parameters.AddWithValue(sessionCode);
+        command.Parameters.AddWithValue(JsonSerializer.Serialize(snapshot, Json));
+        if (await command.ExecuteNonQueryAsync(cancellationToken) != 1)
+            throw new InvalidOperationException("Session Setlist Snapshot already exists.");
+        return snapshot;
+    }
+
+    async Task EnsureSchemaAsync(CancellationToken ct)
+    {
+        if (_initialized) return;
+        await _gate.WaitAsync(ct);
+        try
+        {
+            if (_initialized) return;
+            await using var command = dataSource.CreateCommand("""
+                CREATE TABLE IF NOT EXISTS nuotti_session_setlist_snapshot(
+                    workspace_id text NOT NULL, session_code text NOT NULL, snapshot jsonb NOT NULL,
+                    created_at timestamptz NOT NULL DEFAULT now(), PRIMARY KEY(workspace_id,session_code));
+                """);
+            await command.ExecuteNonQueryAsync(ct); _initialized = true;
+        }
+        finally { _gate.Release(); }
+    }
+}

--- a/Nuotti.Backend/SessionSnapshots/PreparationReferenceStores.cs
+++ b/Nuotti.Backend/SessionSnapshots/PreparationReferenceStores.cs
@@ -1,0 +1,95 @@
+using System.Text.Json;
+using Npgsql;
+
+namespace Nuotti.Backend.SessionSnapshots;
+
+public sealed record LyricTrackRevision(string WorkspaceId, string CatalogEntryId, string RevisionId,
+    int Version, string Lrc, long OffsetMs, string Sha256, string PublishedBy, DateTimeOffset PublishedAt);
+public interface ILyricTrackRevisionStore
+{
+    Task<LyricTrackRevision> PublishAsync(string workspaceId, string catalogEntryId, string lrc, long offsetMs,
+        string userId, CancellationToken cancellationToken = default);
+    Task<LyricTrackRevision?> GetAsync(string workspaceId, string revisionId, CancellationToken cancellationToken = default);
+    Task<LyricTrackRevision?> GetCurrentAsync(string workspaceId, string catalogEntryId,
+        CancellationToken cancellationToken = default);
+}
+
+public sealed class InMemoryLyricTrackRevisionStore(TimeProvider? timeProvider = null) : ILyricTrackRevisionStore
+{
+    readonly TimeProvider _time = timeProvider ?? TimeProvider.System;
+    readonly object _gate = new();
+    readonly List<LyricTrackRevision> _revisions = [];
+    public Task<LyricTrackRevision> PublishAsync(string workspaceId, string catalogEntryId, string lrc, long offsetMs,
+        string userId, CancellationToken cancellationToken = default)
+    {
+        lock (_gate)
+        {
+            var prior = _revisions.Where(x => x.WorkspaceId == workspaceId && x.CatalogEntryId == catalogEntryId).ToArray();
+            var sha = Digest(lrc, offsetMs);
+            var current = prior.LastOrDefault();
+            if (current?.Sha256 == sha) return Task.FromResult(current);
+            var revision = new LyricTrackRevision(workspaceId, catalogEntryId, $"lyric_{Guid.NewGuid():N}",
+                prior.Length + 1, lrc, offsetMs, sha, userId, _time.GetUtcNow());
+            _revisions.Add(revision); return Task.FromResult(revision);
+        }
+    }
+    public Task<LyricTrackRevision?> GetAsync(string workspaceId, string revisionId,
+        CancellationToken cancellationToken = default) { lock (_gate) return Task.FromResult(_revisions.FirstOrDefault(x => x.WorkspaceId == workspaceId && x.RevisionId == revisionId)); }
+    public Task<LyricTrackRevision?> GetCurrentAsync(string workspaceId, string catalogEntryId,
+        CancellationToken cancellationToken = default) { lock (_gate) return Task.FromResult(_revisions.LastOrDefault(x => x.WorkspaceId == workspaceId && x.CatalogEntryId == catalogEntryId)); }
+    internal static string Digest(string lrc, long offsetMs) => Convert.ToHexString(System.Security.Cryptography.SHA256.HashData(
+        System.Text.Encoding.UTF8.GetBytes($"{offsetMs}\n{lrc}"))).ToLowerInvariant();
+}
+
+public sealed class PostgresLyricTrackRevisionStore(NpgsqlDataSource dataSource, TimeProvider? timeProvider = null)
+    : ILyricTrackRevisionStore
+{
+    readonly TimeProvider _time = timeProvider ?? TimeProvider.System;
+    public async Task<LyricTrackRevision> PublishAsync(string workspaceId, string catalogEntryId, string lrc, long offsetMs,
+        string userId, CancellationToken cancellationToken = default)
+    {
+        await EnsureAsync(cancellationToken); var sha = InMemoryLyricTrackRevisionStore.Digest(lrc, offsetMs);
+        await using var connection = await dataSource.OpenConnectionAsync(cancellationToken);
+        await using var transaction = await connection.BeginTransactionAsync(cancellationToken);
+        await using var lockCommand = new NpgsqlCommand("SELECT pg_advisory_xact_lock(hashtext($1))", connection, transaction);
+        lockCommand.Parameters.AddWithValue($"lyric:{workspaceId}:{catalogEntryId}");
+        await lockCommand.ExecuteNonQueryAsync(cancellationToken);
+        await using var find = new NpgsqlCommand("SELECT id,version,lrc,offset_ms,sha256,published_by,published_at FROM nuotti_lyric_track_revision WHERE workspace_id=$1 AND catalog_entry_id=$2 ORDER BY version DESC LIMIT 1", connection, transaction);
+        find.Parameters.AddWithValue(workspaceId); find.Parameters.AddWithValue(catalogEntryId);
+        await using (var reader = await find.ExecuteReaderAsync(cancellationToken))
+            if (await reader.ReadAsync(cancellationToken) && reader.GetString(4) == sha)
+                return new(workspaceId, catalogEntryId, reader.GetString(0), reader.GetInt32(1), reader.GetString(2),
+                    reader.GetInt64(3), reader.GetString(4), reader.GetString(5), reader.GetFieldValue<DateTimeOffset>(6));
+        await using var count = new NpgsqlCommand("SELECT count(*) FROM nuotti_lyric_track_revision WHERE workspace_id=$1 AND catalog_entry_id=$2", connection, transaction);
+        count.Parameters.AddWithValue(workspaceId); count.Parameters.AddWithValue(catalogEntryId);
+        var version = Convert.ToInt32(await count.ExecuteScalarAsync(cancellationToken)) + 1;
+        var revision = new LyricTrackRevision(workspaceId, catalogEntryId, $"lyric_{Guid.NewGuid():N}", version,
+            lrc, offsetMs, sha, userId, _time.GetUtcNow());
+        await using var insert = new NpgsqlCommand("INSERT INTO nuotti_lyric_track_revision(workspace_id,catalog_entry_id,id,version,lrc,offset_ms,sha256,published_by,published_at) VALUES($1,$2,$3,$4,$5,$6,$7,$8,$9)", connection, transaction);
+        insert.Parameters.AddWithValue(workspaceId); insert.Parameters.AddWithValue(catalogEntryId); insert.Parameters.AddWithValue(revision.RevisionId);
+        insert.Parameters.AddWithValue(version); insert.Parameters.AddWithValue(lrc); insert.Parameters.AddWithValue(offsetMs);
+        insert.Parameters.AddWithValue(sha); insert.Parameters.AddWithValue(userId); insert.Parameters.AddWithValue(revision.PublishedAt);
+        await insert.ExecuteNonQueryAsync(cancellationToken); await transaction.CommitAsync(cancellationToken); return revision;
+    }
+    public Task<LyricTrackRevision?> GetAsync(string workspaceId, string revisionId, CancellationToken cancellationToken = default) =>
+        QueryAsync("workspace_id=$1 AND id=$2", workspaceId, revisionId, cancellationToken);
+    public Task<LyricTrackRevision?> GetCurrentAsync(string workspaceId, string catalogEntryId, CancellationToken cancellationToken = default) =>
+        QueryAsync("workspace_id=$1 AND catalog_entry_id=$2 ORDER BY version DESC", workspaceId, catalogEntryId, cancellationToken);
+    async Task<LyricTrackRevision?> QueryAsync(string where, string first, string second, CancellationToken ct, string? third = null)
+    {
+        await EnsureAsync(ct); await using var command = dataSource.CreateCommand($"SELECT workspace_id,catalog_entry_id,id,version,lrc,offset_ms,sha256,published_by,published_at FROM nuotti_lyric_track_revision WHERE {where} LIMIT 1");
+        command.Parameters.AddWithValue(first); command.Parameters.AddWithValue(second); if (third is not null) command.Parameters.AddWithValue(third);
+        await using var reader = await command.ExecuteReaderAsync(ct); return await reader.ReadAsync(ct)
+            ? new(reader.GetString(0), reader.GetString(1), reader.GetString(2), reader.GetInt32(3), reader.GetString(4), reader.GetInt64(5), reader.GetString(6), reader.GetString(7), reader.GetFieldValue<DateTimeOffset>(8)) : null;
+    }
+    async Task EnsureAsync(CancellationToken ct) { await using var command = dataSource.CreateCommand("CREATE TABLE IF NOT EXISTS nuotti_lyric_track_revision(workspace_id text NOT NULL,catalog_entry_id text NOT NULL,id text NOT NULL,version integer NOT NULL,lrc text NOT NULL,offset_ms bigint NOT NULL,sha256 text NOT NULL,published_by text NOT NULL,published_at timestamptz NOT NULL,PRIMARY KEY(workspace_id,id),UNIQUE(workspace_id,catalog_entry_id,version)); ALTER TABLE nuotti_lyric_track_revision DROP CONSTRAINT IF EXISTS nuotti_lyric_track_revision_workspace_id_catalog_entry_id_sha256_key"); await command.ExecuteNonQueryAsync(ct); }
+}
+
+public sealed record ScoringPolicyReference(string PolicyId, int Version);
+public interface IScoringPolicyCatalog { ScoringPolicySnapshot? Resolve(ScoringPolicyReference reference); }
+public sealed class MvpScoringPolicyCatalog : IScoringPolicyCatalog
+{
+    static readonly ScoringPolicySnapshot Standard = new("standard", 1, 1000, 500, 10_000);
+    public ScoringPolicySnapshot? Resolve(ScoringPolicyReference reference) =>
+        reference.PolicyId == Standard.PolicyId && reference.Version == Standard.Version ? Standard : null;
+}

--- a/Nuotti.Backend/SessionSnapshots/SessionSnapshotBuilder.cs
+++ b/Nuotti.Backend/SessionSnapshots/SessionSnapshotBuilder.cs
@@ -1,0 +1,109 @@
+using Nuotti.Backend.Assets;
+using Nuotti.Backend.SongPackages;
+
+namespace Nuotti.Backend.SessionSnapshots;
+
+public sealed class SessionSnapshotBuilder(ISongPackageStore packages, IPrivateAssetMetadataStore assets,
+    ILyricTrackRevisionStore lyrics, IScoringPolicyCatalog scoringPolicies)
+{
+    public async Task<(IReadOnlyList<SessionSetlistItem> Songs, ScoringPolicySnapshot? Policy,
+        SessionSnapshotPreflight Preflight)> BuildAsync(
+        string workspaceId, IReadOnlyList<SessionSetlistSelection> selections, ScoringPolicyReference policyReference,
+        IReadOnlySet<string> acceptedWarnings, CancellationToken ct = default)
+    {
+        var findings = new List<SnapshotPreflightFinding>();
+        var songs = new List<SessionSetlistItem>();
+        var manifest = new Dictionary<string, SnapshotAsset>(StringComparer.Ordinal);
+        if (selections is not { Count: > 0 and <= 200 })
+            Block(findings, "setlist.invalid", "Setlist must contain between 1 and 200 exact Song Package Revisions.",
+                "The Session cannot determine its Rounds.", "Select at least one published revision.");
+        var policy = policyReference is null ? null : scoringPolicies.Resolve(policyReference);
+        if (policy is null)
+            Block(findings, "scoring.invalid", "Scoring Policy is invalid.",
+                "Audience scores would not be reproducible.", "Select a versioned non-negative Scoring Policy.");
+
+        for (var index = 0; index < Math.Min(selections?.Count ?? 0, 200); index++)
+        {
+            var revisionId = selections![index].PackageRevisionId?.Trim();
+            var revision = string.IsNullOrWhiteSpace(revisionId) ? null
+                : await packages.GetRevisionAsync(workspaceId, revisionId, ct);
+            if (revision is null)
+            {
+                Block(findings, $"song.{index + 1}.revision-missing", $"Song {index + 1} revision is unavailable.",
+                    "The Session would not capture the selected immutable package.", "Select an existing Workspace revision.");
+                continue;
+            }
+            var requestedLyricRevision = !string.IsNullOrWhiteSpace(selections[index].LyricTrackRevisionId);
+            var lyricRevision = !requestedLyricRevision
+                ? await lyrics.GetCurrentAsync(workspaceId, revision.CatalogEntryId, ct)
+                : await lyrics.GetAsync(workspaceId, selections[index].LyricTrackRevisionId!, ct);
+            if (requestedLyricRevision && lyricRevision is null)
+                Block(findings, $"song.{index + 1}.lyrics-revision-missing",
+                    $"Song {index + 1} selected Lyric Track Revision is unavailable.",
+                    "The Session cannot capture the exact selected lyrics.", "Select an existing Lyric Track Revision.");
+            if (lyricRevision is not null && lyricRevision.CatalogEntryId != revision.CatalogEntryId)
+            {
+                Block(findings, $"song.{index + 1}.lyrics-wrong-song", $"Song {index + 1} Lyric Track belongs to another song.",
+                    "The Projector would show incorrect lyrics.", "Select a Lyric Track Revision for this Song Package.");
+                lyricRevision = null;
+            }
+            var lyric = lyricRevision is null ? null : new CapturedLyricTrack(lyricRevision.RevisionId,
+                lyricRevision.Version, lyricRevision.Sha256, lyricRevision.Lrc, lyricRevision.OffsetMs);
+            songs.Add(new(index + 1, revision.CatalogEntryId, revision.RevisionId, revision.RevisionNumber,
+                revision.Document.Playback, revision.Document.Hints.ToArray(), lyric));
+            await AddAssetsAsync(workspaceId, index + 1, revision.Document, manifest, findings, ct);
+            if (lyricRevision is null && !requestedLyricRevision)
+                Warn(findings, $"song.{index + 1}.lyrics-missing", $"Song {index + 1} has no Lyric Track.",
+                    "The Projector will use the reveal state during playback.", "Accept lyric-free playback for this Session.");
+        }
+        if (songs.Count == selections?.Count && songs.Count > 0)
+            Ready(findings, "setlist.exact-revisions", $"{songs.Count} exact Song Package Revision{(songs.Count == 1 ? "" : "s")} captured.");
+        var warningsAccepted = findings.Where(x => x.Severity == ReadinessSeverity.Warning)
+            .All(x => acceptedWarnings.Contains(x.Code));
+        return (songs, policy, new(findings.All(x => x.Severity != ReadinessSeverity.Blocking) && warningsAccepted,
+            findings, manifest.Values.OrderBy(x => x.RevisionId, StringComparer.Ordinal).ToArray()));
+    }
+
+    async Task AddAssetsAsync(string workspaceId, int position, SongPackageDocument document,
+        Dictionary<string, SnapshotAsset> manifest, List<SnapshotPreflightFinding> findings, CancellationToken ct)
+    {
+        var required = new[] { document.Playback.BackingAssetRevisionId, document.Playback.ClickAssetRevisionId }
+            .Where(x => !string.IsNullOrWhiteSpace(x)).Select(x => x!).ToHashSet(StringComparer.Ordinal);
+        var visual = document.Hints.Where(x => x.Type is PackageHintType.Image or PackageHintType.Visual)
+            .Select(x => x.AssetRevisionId).Where(x => !string.IsNullOrWhiteSpace(x)).Select(x => x!).ToArray();
+        var hasNonVisualHint = document.Hints.Any(x => x.Type == PackageHintType.Text && !string.IsNullOrWhiteSpace(x.Text)
+            || x.Type == PackageHintType.LiveBand && !string.IsNullOrWhiteSpace(x.PerformerCue));
+        foreach (var revisionId in required.Concat(visual).Distinct(StringComparer.Ordinal))
+        {
+            var asset = await assets.GetAsync(workspaceId, revisionId, ct);
+            var isRequired = required.Contains(revisionId) || visual.Contains(revisionId) && !hasNonVisualHint;
+            var usable = asset?.Status == AssetRevisionStatus.Published && !string.IsNullOrWhiteSpace(asset.Sha256)
+                && asset.StoredSize is > 0 && (asset.Provenance.RightsExpiresAt is null
+                    || asset.Provenance.RightsExpiresAt > DateTimeOffset.UtcNow);
+            if (usable)
+            {
+                var requiredByAnySong = isRequired || manifest.GetValueOrDefault(revisionId)?.Required == true;
+                manifest[revisionId] = new(revisionId, asset!.AssetType, asset.Sha256!, asset.StoredSize!.Value,
+                    requiredByAnySong);
+            }
+            else if (required.Contains(revisionId))
+                Block(findings, $"song.{position}.asset.{revisionId}.unavailable", $"Song {position} required audio is unavailable.",
+                    "The Show Agent cannot cache verified playback.", "Restore current rights or publish a replacement package revision.");
+        }
+        var hasFallback = hasNonVisualHint || visual.Any(id => manifest.ContainsKey(id));
+        foreach (var revisionId in visual.Where(id => !manifest.ContainsKey(id)).Distinct(StringComparer.Ordinal))
+            if (hasFallback)
+                Warn(findings, $"song.{position}.visual.{revisionId}.unavailable", $"Song {position} visual media is unavailable.",
+                    "That Hint cannot be rendered at the venue.", "Accept the missing visual because another usable Hint remains.");
+            else
+                Block(findings, $"song.{position}.visual.{revisionId}.required", $"Song {position} has no usable Hint at the venue.",
+                    "The Audience would receive no fair clue.", "Restore the visual or publish a package with another usable Hint.");
+    }
+
+    static void Ready(List<SnapshotPreflightFinding> target, string code, string title) =>
+        target.Add(new(code, ReadinessSeverity.Ready, title, "", "", false));
+    static void Warn(List<SnapshotPreflightFinding> target, string code, string title, string consequence, string action) =>
+        target.Add(new(code, ReadinessSeverity.Warning, title, consequence, action, true));
+    static void Block(List<SnapshotPreflightFinding> target, string code, string title, string consequence, string action) =>
+        target.Add(new(code, ReadinessSeverity.Blocking, title, consequence, action, false));
+}

--- a/Nuotti.Backend/SessionSnapshots/SessionSnapshotModel.cs
+++ b/Nuotti.Backend/SessionSnapshots/SessionSnapshotModel.cs
@@ -1,0 +1,32 @@
+using Nuotti.Backend.SongPackages;
+
+namespace Nuotti.Backend.SessionSnapshots;
+
+public sealed record ScoringPolicySnapshot(string PolicyId, int Version, int CorrectPoints,
+    int SpeedBonusPoints, long SpeedBonusWindowMs);
+public sealed record SessionSetlistSelection(string PackageRevisionId, string? LyricTrackRevisionId = null);
+public sealed record CreateSessionSetlistSnapshotRequest(IReadOnlyList<SessionSetlistSelection> Songs,
+    ScoringPolicyReference ScoringPolicy, IReadOnlyList<string> AcceptedWarningCodes);
+public sealed record SnapshotAsset(string RevisionId, string AssetType, string Sha256, long Size, bool Required);
+public sealed record CapturedLyricTrack(string TrackRevisionId, int Version, string Sha256, string Lrc, long OffsetMs);
+public sealed record SessionSetlistItem(int Position, string CatalogEntryId, string PackageRevisionId,
+    int PackageRevisionNumber, PlaybackConfiguration Playback, IReadOnlyList<PackageHint> Hints,
+    CapturedLyricTrack? LyricTrack);
+public sealed record SessionSetlistSnapshot(string SnapshotId, string WorkspaceId, string SessionCode,
+    int Version, IReadOnlyList<SessionSetlistItem> Songs, ScoringPolicySnapshot ScoringPolicy,
+    IReadOnlyList<SnapshotAsset> Assets, IReadOnlyList<string> AcceptedWarningCodes,
+    string CreatedBy, DateTimeOffset CreatedAt);
+public sealed record SnapshotPreflightFinding(string Code, ReadinessSeverity Severity, string Title,
+    string Consequence, string Action, bool CanOverride);
+public sealed record SessionSnapshotPreflight(bool CanCreate, IReadOnlyList<SnapshotPreflightFinding> Findings,
+    IReadOnlyList<SnapshotAsset> Assets);
+
+public interface ISessionSetlistSnapshotStore
+{
+    Task<SessionSetlistSnapshot?> GetAsync(string workspaceId, string sessionCode,
+        CancellationToken cancellationToken = default);
+    Task<SessionSetlistSnapshot> CreateAsync(string workspaceId, string sessionCode,
+        IReadOnlyList<SessionSetlistItem> songs, ScoringPolicySnapshot scoringPolicy,
+        IReadOnlyList<SnapshotAsset> assets, IReadOnlyList<string> acceptedWarnings, string userId,
+        CancellationToken cancellationToken = default);
+}

--- a/Nuotti.Backend/SongPackages/InMemorySongPackageStore.cs
+++ b/Nuotti.Backend/SongPackages/InMemorySongPackageStore.cs
@@ -47,4 +47,11 @@ public sealed class InMemorySongPackageStore(TimeProvider? timeProvider = null) 
         lock (_gate) return Task.FromResult<IReadOnlyList<SongPackageRevision>>(
             _revisions.GetValueOrDefault((workspaceId, catalogEntryId))?.ToArray() ?? []);
     }
+
+    public Task<SongPackageRevision?> GetRevisionAsync(string workspaceId, string revisionId,
+        CancellationToken cancellationToken = default)
+    {
+        lock (_gate) return Task.FromResult(_revisions.Values.SelectMany(x => x)
+            .FirstOrDefault(x => x.WorkspaceId == workspaceId && x.RevisionId == revisionId));
+    }
 }

--- a/Nuotti.Backend/SongPackages/PostgresSongPackageStore.cs
+++ b/Nuotti.Backend/SongPackages/PostgresSongPackageStore.cs
@@ -93,6 +93,22 @@ public sealed class PostgresSongPackageStore(NpgsqlDataSource dataSource, TimePr
         return result;
     }
 
+    public async Task<SongPackageRevision?> GetRevisionAsync(string workspaceId, string revisionId,
+        CancellationToken cancellationToken = default)
+    {
+        await EnsureSchemaAsync(cancellationToken);
+        await using var command = dataSource.CreateCommand("""
+            SELECT catalog_entry_id,revision_number,document::text,revision_note,published_by,published_at,accepted_warnings::text
+            FROM nuotti_song_package_revision WHERE workspace_id=$1 AND id=$2
+            """);
+        command.Parameters.AddWithValue(workspaceId); command.Parameters.AddWithValue(revisionId);
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        return await reader.ReadAsync(cancellationToken) ? new(workspaceId, reader.GetString(0), revisionId,
+            reader.GetInt32(1), JsonSerializer.Deserialize<SongPackageDocument>(reader.GetString(2), Json)!,
+            reader.GetString(3), reader.GetString(4), reader.GetFieldValue<DateTimeOffset>(5),
+            JsonSerializer.Deserialize<string[]>(reader.GetString(6), Json) ?? []) : null;
+    }
+
     async Task EnsureSchemaAsync(CancellationToken ct)
     {
         if (_initialized) return;

--- a/Nuotti.Backend/SongPackages/SongPackageModel.cs
+++ b/Nuotti.Backend/SongPackages/SongPackageModel.cs
@@ -51,4 +51,6 @@ public interface ISongPackageStore
         CancellationToken cancellationToken = default);
     Task<IReadOnlyList<SongPackageRevision>> GetRevisionsAsync(string workspaceId, string catalogEntryId,
         CancellationToken cancellationToken = default);
+    Task<SongPackageRevision?> GetRevisionAsync(string workspaceId, string revisionId,
+        CancellationToken cancellationToken = default);
 }

--- a/Nuotti.Contracts/V1/Message/PlayTrack.cs
+++ b/Nuotti.Contracts/V1/Message/PlayTrack.cs
@@ -7,6 +7,10 @@ namespace Nuotti.Contracts.V1.Message;
 /// <param name="FileUrl">Public or accessible URL to the audio file to play.</param>
 public record PlayTrack(string FileUrl) : CommandBase
 {
+    /// <summary>Immutable private asset revision captured by the Session Setlist Snapshot.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? AssetRevisionId { get; init; }
+
     /// <summary>The playback attempt this relay targets. Null preserves the legacy relay contract.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? PlaybackInstanceId { get; init; }


### PR DESCRIPTION
Closes #254

## Summary
- capture immutable tenant-scoped Session Setlist Snapshots with exact package, lyric, hint, and scoring revisions
- preflight named degradations with safe override gating
- download and hash-verify a Session-scoped venue cache before playback
- restrict Show Agent snapshot and asset access to its paired Session

## Verification
- 186 Contracts tests
- 162 Backend tests
- 82 Audio Engine tests
- 35 Performer tests
- parallel standards and spec reviews: clean