### PR TITLE
feat: progressive Windows, scoring, Reveal, and leaderboard (#257)

### DIFF
--- a/Nuotti.Audience/Pages/Question.razor
+++ b/Nuotti.Audience/Pages/Question.razor
@@ -34,9 +34,9 @@
                      aria-describedby="answer-instructions">
                     <div id="answer-instructions" class="sr-only">
                         Choose one of the following @q.Options.Length options to answer the question.
-                        @if (_hasAnswered)
+                        @if (_selectedChoice is not null)
                         {
-                            <span>You have already submitted your answer.</span>
+                            <span>Current choice is option @(_selectedChoice.Value + 1). You may revise until Lock.</span>
                         }
                     </div>
                     @for (var i = 0; i < q.Options.Length; i++)
@@ -52,7 +52,7 @@
                                        FullWidth="true"
                                        StartIcon="@icon"
                                        OnClick="@(() => Submit(idx))"
-                                       Disabled="@_hasAnswered"
+                                       Disabled="@IsLocked"
                                        Class="@($"option-button option-{idx + 1} slide-up")"
                                        id="@($"option-{idx + 1}")"
                                        aria-label="@($"Option {idx + 1}: {q.Options[idx]}")"
@@ -69,9 +69,13 @@
                                 </div>
                             </MudButton>
                             <div id="@($"option-{idx + 1}-status")" class="sr-only">
-                                @if (_hasAnswered)
+                                @if (_selectedChoice == idx)
                                 {
-                                    <span>Answer submitted</span>
+                                    <span>Currently selected</span>
+                                }
+                                else if (IsLocked)
+                                {
+                                    <span>Locked</span>
                                 }
                                 else
                                 {
@@ -82,7 +86,18 @@
                     }
                 </div>
 
-                @if (_hasAnswered)
+                @if (Hub.HasPendingAnswer)
+                {
+                    <MudAlert Severity="Severity.Warning"
+                              Class="mt-4"
+                              Variant="Variant.Filled"
+                              Icon="@Material.Filled.CloudOff"
+                              role="status"
+                              aria-live="polite">
+                        Waiting to send…
+                    </MudAlert>
+                }
+                else if (_selectedChoice is int selected)
                 {
                     <MudAlert Severity="Severity.Success"
                               Class="mt-4"
@@ -90,7 +105,7 @@
                               Icon="@Material.Filled.CheckCircle"
                               role="status"
                               aria-live="polite">
-                        Answer submitted! Waiting for others...
+                        Answer @(selected + 1) held. You can revise until Lock.
                     </MudAlert>
                 }
             </div>
@@ -444,12 +459,13 @@
 
 @code {
     private string fileUrl = "https://www.soundhelix.com/examples/mp3/SoundHelix-Song-1.mp3";
-    private bool _hasAnswered = false;
+    private int? _selectedChoice;
     private bool _showDevPanel = false;
     private bool _showDevTools = false;
     private List<string> _participantsList = new();
     private bool _isWaiting => Hub.CurrentQuestion is null;
     private DateTime _lastSubmissionAttempt = DateTime.MinValue;
+    private bool IsLocked => Hub.CurrentGameState?.Phase is Phase.Lock or Phase.Reveal or Phase.Play or Phase.Intermission or Phase.Finished;
 
     protected override async Task OnInitializedAsync()
     {
@@ -470,7 +486,7 @@
 
     private async void OnQuestionPushed(QuestionPushed _)
     {
-        _hasAnswered = false; // Reset for new question
+        _selectedChoice = Hub.MyAnswerChoiceIndex; // may restore after reconnect mid-round
         await InvokeAsync(StateHasChanged);
     }
 
@@ -500,7 +516,7 @@
         // This is a simplified version - in a real implementation, you'd need to track
         // the player's answer and compare it with the correct answer from the game state
         // For now, we'll trigger confetti if the player submitted an answer
-        if (_hasAnswered)
+        if (_selectedChoice is not null)
         {
             // Simulate checking if the answer was correct (you'd get this from the server)
             var isCorrect = Random.Shared.NextDouble() > 0.5; // 50% chance for demo
@@ -538,7 +554,7 @@
 
     private async Task Submit(int index)
     {
-        if (_hasAnswered) return;
+        if (IsLocked) return;
 
         // Anti-spam: Debounce rapid submissions
         var timeSinceLastAttempt = DateTime.Now - _lastSubmissionAttempt;
@@ -548,6 +564,7 @@
         }
 
         _lastSubmissionAttempt = DateTime.Now;
+        _selectedChoice = index;
 
         try
         {
@@ -555,12 +572,12 @@
             await Feedback.TriggerHapticFeedbackAsync(HapticType.Medium);
 
             await Hub.SubmitAnswerAsync(index);
-            _hasAnswered = true;
 
             // Pulse animation on the submitted button
             await Feedback.TriggerPulseAnimationAsync($"option-{index + 1}");
 
-            Snackbar.Add("Answer submitted successfully!", Severity.Success);
+            Snackbar.Add(Hub.HasPendingAnswer ? "Waiting to send…" : "Answer held on server.",
+                Hub.HasPendingAnswer ? Severity.Warning : Severity.Success);
         }
         catch (Exception ex)
         {

--- a/Nuotti.Audience/Services/AudienceHubClient.cs
+++ b/Nuotti.Audience/Services/AudienceHubClient.cs
@@ -20,6 +20,15 @@ public class AudienceHubClient : IAsyncDisposable
     public string? BackendBaseUrl { get; }
     public string? SessionCode { get; private set; }
     public string? AudienceName { get; private set; }
+    public string? ParticipantId { get; private set; }
+    public string DeviceSecret { get; private set; } = Guid.NewGuid().ToString("N");
+    public int? MyAnswerChoiceIndex { get; private set; }
+    public bool HasPendingAnswer => _pendingAnswer is not null;
+    public string? PendingAnswerLabel => _pendingAnswer is null ? null : "Waiting to send";
+
+    PendingAnswer? _pendingAnswer;
+
+    sealed record PendingAnswer(int ChoiceIndex, Guid CommandId);
 
     public QuestionPushed? CurrentQuestion { get; private set; }
     public GameStateSnapshot? CurrentGameState { get; private set; }
@@ -126,6 +135,28 @@ public class AudienceHubClient : IAsyncDisposable
                 JoinedAudience?.Invoke(j);
             });
 
+            _connection.On<System.Text.Json.JsonElement>("ParticipantRestored", payload =>
+            {
+                if (payload.TryGetProperty("ParticipantId", out var id))
+                    ParticipantId = id.GetString();
+                else if (payload.TryGetProperty("participantId", out var idCamel))
+                    ParticipantId = idCamel.GetString();
+                Log($"[Audience] ParticipantRestored: {ParticipantId}");
+            });
+
+            _connection.On<System.Text.Json.JsonElement>("AnswerAccepted", payload =>
+            {
+                Guid? acceptedId = null;
+                if (payload.TryGetProperty("CommandId", out var cmd) || payload.TryGetProperty("commandId", out cmd))
+                    acceptedId = cmd.TryGetGuid(out var g) ? g : null;
+                if (_pendingAnswer is not null && (acceptedId is null || acceptedId == _pendingAnswer.CommandId))
+                {
+                    MyAnswerChoiceIndex = _pendingAnswer.ChoiceIndex;
+                    _pendingAnswer = null;
+                }
+                Log($"[Audience] AnswerAccepted: {acceptedId}");
+            });
+
             _connection.On<AnswerSubmitted>("AnswerSubmitted", a =>
             {
                 Log($"[Audience] AnswerSubmitted: choiceIndex={a.ChoiceIndex}");
@@ -176,11 +207,13 @@ public class AudienceHubClient : IAsyncDisposable
         {
             try
             {
-                // Rejoin the session
-                await _connection!.InvokeAsync("Join", SessionCode, "audience", AudienceName);
+                // Rejoin the session with the same device-bound identity
+                await _connection!.InvokeAsync("Join", SessionCode, "audience", AudienceName, DeviceSecret);
                 
-                // Fetch current game state
+                // Fetch current game state and server-held answer
                 await FetchGameStateAsync();
+                await FetchMyAnswerAsync();
+                await FlushPendingAnswerAsync();
                 
                 Log($"[Audience] Session state restored for: {SessionCode}");
             }
@@ -212,7 +245,8 @@ public class AudienceHubClient : IAsyncDisposable
         }
         
         Log($"[Audience] Invoking Join: session={sessionCode} name={audienceName}");
-        await _connection!.InvokeAsync("Join", sessionCode, "audience", audienceName);
+        await _connection!.InvokeAsync("Join", sessionCode, "audience", audienceName, DeviceSecret);
+        await FetchMyAnswerAsync();
     }
 
     public async Task SubmitAnswerAsync(int choiceIndex)
@@ -222,9 +256,71 @@ public class AudienceHubClient : IAsyncDisposable
             Log("[Audience] SubmitAnswer skipped: no session");
             return;
         }
-        await EnsureConnectedAsync();
-        Log($"[Audience] Submitting answer: session={SessionCode} choiceIndex={choiceIndex}");
-        await _connection!.InvokeAsync("SubmitAnswer", SessionCode!, choiceIndex);
+
+        var commandId = _pendingAnswer?.ChoiceIndex == choiceIndex
+            ? _pendingAnswer.CommandId
+            : Guid.NewGuid();
+        _pendingAnswer = new PendingAnswer(choiceIndex, commandId);
+        MyAnswerChoiceIndex = choiceIndex;
+
+        try
+        {
+            await EnsureConnectedAsync();
+            Log($"[Audience] Submitting answer: session={SessionCode} choiceIndex={choiceIndex} commandId={commandId}");
+            await _connection!.InvokeAsync("SubmitAnswer", SessionCode!, choiceIndex, commandId);
+        }
+        catch (Exception ex)
+        {
+            Log($"[Audience] SubmitAnswer deferred (Waiting to send): {ex.Message}");
+        }
+    }
+
+    async Task FlushPendingAnswerAsync()
+    {
+        if (_pendingAnswer is null || string.IsNullOrWhiteSpace(SessionCode)) return;
+        var pending = _pendingAnswer;
+        try
+        {
+            await _connection!.InvokeAsync("SubmitAnswer", SessionCode!, pending.ChoiceIndex, pending.CommandId);
+        }
+        catch (Exception ex)
+        {
+            Log($"[Audience] Flush pending answer failed: {ex.Message}");
+        }
+    }
+
+    public async Task<int?> FetchMyAnswerAsync()
+    {
+        if (string.IsNullOrWhiteSpace(SessionCode) || string.IsNullOrWhiteSpace(ParticipantId))
+            return MyAnswerChoiceIndex;
+
+        try
+        {
+            var response = await _http.GetAsync(
+                $"{BackendBaseUrl}/status/{SessionCode}/answer?participantId={Uri.EscapeDataString(ParticipantId)}");
+            if (!response.IsSuccessStatusCode) return MyAnswerChoiceIndex;
+            var json = await response.Content.ReadAsStringAsync();
+            using var doc = System.Text.Json.JsonDocument.Parse(json);
+            if (doc.RootElement.TryGetProperty("choiceIndex", out var choice)
+                || doc.RootElement.TryGetProperty("ChoiceIndex", out choice))
+            {
+                if (choice.ValueKind == System.Text.Json.JsonValueKind.Number)
+                {
+                    MyAnswerChoiceIndex = choice.GetInt32();
+                    return MyAnswerChoiceIndex;
+                }
+                if (choice.ValueKind == System.Text.Json.JsonValueKind.Null)
+                {
+                    MyAnswerChoiceIndex = null;
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            Log($"[Audience] Failed to fetch my answer: {ex.Message}");
+        }
+
+        return MyAnswerChoiceIndex;
     }
 
     public async Task RequestPlayAsync(string fileUrl)

--- a/Nuotti.AudioEngine/Program.cs
+++ b/Nuotti.AudioEngine/Program.cs
@@ -319,7 +319,7 @@ try
     {
         // Development compatibility only. Paired Windows agents use outbound HTTPS polling above.
         await connection.StartAsync(cts.Token);
-        await connection.InvokeAsync("Join", session, "engine", null, cancellationToken: cts.Token);
+        await connection.InvokeAsync("Join", session, "engine", null, null, cancellationToken: cts.Token);
         var initLat = (player as IHasLatency)?.OutputLatencyMs ?? 0d;
         await connection.InvokeAsync("EngineStatusChanged", session, new EngineStatusChanged(EngineStatus.Ready, initLat), cancellationToken: cts.Token);
         _ = RunHeartbeatAsync(cts.Token);

--- a/Nuotti.AudioEngine/Program.cs
+++ b/Nuotti.AudioEngine/Program.cs
@@ -283,6 +283,10 @@ try
             {
                 switch (command.MessageType)
                 {
+                    case "Prepare":
+                        Log.Information("Prepare received from cloud Backend; venue cache already verified at pair time");
+                        await cloudAgent.ReportStatusAsync("Ready", "prepared", cts.Token);
+                        break;
                     case "PlayTrack":
                         var play = ShowAgentCloudClient.DeserializePayload<PlayTrack>(command.Payload);
                         if (play is not null)

--- a/Nuotti.Backend.Tests/AudienceCatalogSearchTests.cs
+++ b/Nuotti.Backend.Tests/AudienceCatalogSearchTests.cs
@@ -1,0 +1,56 @@
+using Nuotti.Backend.Assets;
+using Nuotti.Backend.Catalog;
+using Nuotti.Backend.Sessions;
+using Nuotti.Contracts.V1.Model;
+
+namespace Nuotti.Backend.Tests;
+
+public sealed class AudienceCatalogSearchTests
+{
+    [Fact]
+    public async Task Search_combines_shared_and_workspace_catalog_and_isolates_tenants()
+    {
+        var shared = new InMemorySharedSongCatalog();
+        shared.Seed([
+            new SongRef(new SongId("shared-1"), "Shared Alpha", "Artist A"),
+            new SongRef(new SongId("shared-2"), "Shared Beta", "Artist B")
+        ]);
+        var privateStore = new InMemoryPrivateAssetMetadataStore();
+        await privateStore.CreateEntryAsync("ws-a", "Private Alpha", "Band A", "user-1");
+        await privateStore.CreateEntryAsync("ws-b", "Secret Beta", "Band B", "user-2");
+        var binder = new InMemorySessionWorkspaceBinder();
+        binder.Bind("SESS-A", "ws-a");
+        binder.Bind("SESS-B", "ws-b");
+        var search = new AudienceCatalogSearch(shared, privateStore, binder);
+
+        var resultsA = await search.SearchAsync("SESS-A", "Alpha", limit: 50);
+        Assert.Contains(resultsA, r => r.Title == "Shared Alpha");
+        Assert.Contains(resultsA, r => r.Title == "Private Alpha");
+        Assert.DoesNotContain(resultsA, r => r.Title == "Secret Beta");
+
+        var resultsB = await search.SearchAsync("SESS-B", "Beta", limit: 50);
+        Assert.Contains(resultsB, r => r.Title == "Shared Beta");
+        Assert.Contains(resultsB, r => r.Title == "Secret Beta");
+        Assert.DoesNotContain(resultsB, r => r.Title == "Private Alpha");
+    }
+
+    [Fact]
+    public async Task Search_over_one_thousand_entries_stays_under_budget()
+    {
+        var shared = new InMemorySharedSongCatalog();
+        shared.Seed(Enumerable.Range(0, 1200).Select(i =>
+            new SongRef(new SongId($"shared-{i}"), $"Song {i:D4}", $"Artist {i % 40}")));
+        var privateStore = new InMemoryPrivateAssetMetadataStore();
+        var binder = new InMemorySessionWorkspaceBinder();
+        binder.Bind("SESS-L", "ws-large");
+        var search = new AudienceCatalogSearch(shared, privateStore, binder);
+
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        var results = await search.SearchAsync("SESS-L", "Song 11", limit: 25);
+        sw.Stop();
+
+        Assert.NotEmpty(results);
+        Assert.True(results.Count <= 25);
+        Assert.True(sw.ElapsedMilliseconds < 250, $"search took {sw.ElapsedMilliseconds}ms");
+    }
+}

--- a/Nuotti.Backend.Tests/AudienceIdentityCatalogGuessingTests.cs
+++ b/Nuotti.Backend.Tests/AudienceIdentityCatalogGuessingTests.cs
@@ -1,0 +1,162 @@
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.SignalR.Client;
+using Microsoft.Extensions.DependencyInjection;
+using Nuotti.Backend;
+using Nuotti.Backend.Assets;
+using Nuotti.Backend.Catalog;
+using Nuotti.Backend.Commands;
+using Nuotti.Backend.Endpoints;
+using Nuotti.Backend.Participants;
+using Nuotti.Backend.Sessions;
+using Nuotti.Backend.Workspaces;
+using Nuotti.Contracts.V1.Enum;
+using Nuotti.Contracts.V1.Message;
+using Nuotti.Contracts.V1.Message.Phase;
+using Nuotti.Contracts.V1.Model;
+
+namespace Nuotti.Backend.Tests;
+
+/// <summary>
+/// Issue #256 — anonymous Audience identity, large-Catalog search privacy, and idempotent waiting answers.
+/// </summary>
+public sealed class AudienceIdentityCatalogGuessingTests(WebApplicationFactory<QuizHub> baseFactory)
+    : IClassFixture<WebApplicationFactory<QuizHub>>
+{
+    readonly WebApplicationFactory<QuizHub> _factory = baseFactory.WithWebHostBuilder(_ => { });
+
+    [Fact]
+    public async Task Device_identity_moderated_name_catalog_search_and_waiting_answer_roundtrip()
+    {
+        using var client = _factory.CreateClient();
+        var member = await SignInAsync(client, "aud256");
+        var workspace = await PostAsync<WorkspaceAccess>(client, "/v1/workspaces", member.SessionToken,
+            new { name = "Audience band" });
+        await SelectAsync(client, member.SessionToken, workspace.WorkspaceId);
+
+        const string session = "AUD256";
+        (await SendAsync(client, HttpMethod.Post,
+            $"/v1/workspaces/{workspace.WorkspaceId}/sessions/{session}/create", member.SessionToken))
+            .EnsureSuccessStatusCode();
+
+        await _factory.Services.GetRequiredService<IPrivateAssetMetadataStore>()
+            .CreateEntryAsync(workspace.WorkspaceId, "Private Hit", "Us", member.Principal.UserId);
+        var other = await PostAsync<WorkspaceAccess>(client, "/v1/workspaces", member.SessionToken,
+            new { name = "Other tenant" });
+        await _factory.Services.GetRequiredService<IPrivateAssetMetadataStore>()
+            .CreateEntryAsync(other.WorkspaceId, "Leaked Song", "Them", member.Principal.UserId);
+
+        var shared = _factory.Services.GetRequiredService<ISharedSongCatalog>();
+        shared.Seed([
+            new SongRef(new SongId("shared-hit"), "Shared Hit", "Nuotti"),
+            ..Enumerable.Range(0, 1100).Select(i =>
+                new SongRef(new SongId($"pad-{i}"), $"Pad {i:D4}", "Pad Artist"))
+        ]);
+
+        var search = await client.GetFromJsonAsync<SongRef[]>(
+            $"/api/sessions/{session}/catalog/search?q=Hit&limit=20");
+        Assert.NotNull(search);
+        Assert.Contains(search!, s => s.Title == "Shared Hit");
+        Assert.Contains(search!, s => s.Title == "Private Hit");
+        Assert.DoesNotContain(search!, s => s.Title == "Leaked Song");
+
+        var participants = _factory.Services.GetRequiredService<IParticipantIdentityStore>();
+        string? participantId = null;
+        await using var hub = new HubConnectionBuilder()
+            .WithUrl(new Uri(client.BaseAddress!, "/hub"),
+                o => o.HttpMessageHandlerFactory = _ => _factory.Server.CreateHandler())
+            .Build();
+        hub.On<object>("ParticipantRestored", payload =>
+        {
+            var json = System.Text.Json.JsonSerializer.Serialize(payload);
+            using var doc = System.Text.Json.JsonDocument.Parse(json);
+            participantId = doc.RootElement.GetProperty("ParticipantId").GetString();
+        });
+        await hub.StartAsync();
+        await hub.InvokeAsync("Join", session, "audience", "PlayerOne", "device-aud-256");
+        Assert.False(string.IsNullOrWhiteSpace(participantId));
+
+        Assert.True(participants.TryModerateName(session, participantId!, "StageSafe", out var moderated));
+        Assert.Equal("StageSafe", moderated!.DisplayName);
+
+        var restored = participants.JoinOrRestore(session, "device-aud-256", "ignored-because-moderated");
+        Assert.Equal(participantId, restored.ParticipantId);
+        Assert.Equal("StageSafe", restored.DisplayName);
+        Assert.NotEqual(participantId,
+            participants.JoinOrRestore("OTHER", "device-aud-256", "OtherRoom").ParticipantId);
+
+        var state = _factory.Services.GetRequiredService<IGameStateStore>();
+        await PostPhaseAsync(client, "start-game", session, new StartGame
+        {
+            SessionCode = session, IssuedByRole = Role.Performer, IssuedById = member.Principal.UserId
+        });
+        await PostJsonAsync(client, $"/api/pushQuestion/{session}", new QuestionPushed("Guess?", ["A", "B", "C"])
+        {
+            SessionCode = session, IssuedByRole = Role.Performer, IssuedById = member.Principal.UserId
+        });
+        await PostPhaseAsync(client, "open-answers", session, new OpenAnswers
+        {
+            SessionCode = session, IssuedByRole = Role.Performer, IssuedById = member.Principal.UserId
+        });
+
+        var commandId = Guid.Parse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+        await hub.InvokeAsync("SubmitAnswer", session, 1, commandId);
+        await Task.Delay(600); // outside SubmitAnswer debounce window
+        await hub.InvokeAsync("SubmitAnswer", session, 1, commandId);
+
+        Assert.True(state.TryGet(session, out var mid));
+        Assert.Equal(1, mid!.Answers[participantId!]);
+        Assert.Equal(new[] { 0, 1, 0 }, mid.Tallies.ToArray());
+
+        await Task.Delay(600);
+        await hub.InvokeAsync("SubmitAnswer", session, 2, Guid.NewGuid());
+        Assert.True(state.TryGet(session, out mid));
+        Assert.Equal(2, mid!.Answers[participantId!]);
+        Assert.Equal(new[] { 0, 0, 1 }, mid.Tallies.ToArray());
+
+        var answerResp = await client.GetFromJsonAsync<AudienceAnswerStatusEndpoints.MyAnswerResponse>(
+            $"/status/{session}/answer?participantId={participantId}");
+        Assert.Equal(2, answerResp!.ChoiceIndex);
+
+        // Idempotent waiting retry: same CommandId through the hub is accepted without double-counting.
+        Assert.Equal(1, mid.Tallies.Sum());
+    }
+
+    static async Task PostPhaseAsync(HttpClient client, string route, string session, CommandBase cmd)
+    {
+        var response = await client.PostAsJsonAsync($"/v1/message/phase/{route}/{session}", cmd);
+        response.EnsureSuccessStatusCode();
+    }
+
+    static async Task PostJsonAsync(HttpClient client, string path, object body)
+    {
+        (await SendAsync(client, HttpMethod.Post, path, null, body)).EnsureSuccessStatusCode();
+    }
+
+    static async Task SelectAsync(HttpClient client, string token, string workspaceId) =>
+        (await SendAsync(client, HttpMethod.Post, $"/v1/workspaces/{workspaceId}/select", token)).EnsureSuccessStatusCode();
+
+    static async Task<RedeemedMagicLink> SignInAsync(HttpClient client, string prefix)
+    {
+        var link = await PostAsync<IssuedMagicLink>(client, "/v1/auth/magic-links", null,
+            new { email = $"{prefix}-{Guid.NewGuid():N}@example.test" });
+        return await PostAsync<RedeemedMagicLink>(client, "/v1/auth/magic-links/redeem", null, new { token = link.Token });
+    }
+
+    static async Task<T> PostAsync<T>(HttpClient client, string path, string? token, object? body)
+    {
+        var response = await SendAsync(client, HttpMethod.Post, path, token, body);
+        response.EnsureSuccessStatusCode();
+        return (await response.Content.ReadFromJsonAsync<T>())!;
+    }
+
+    static async Task<HttpResponseMessage> SendAsync(HttpClient client, HttpMethod method, string path,
+        string? token, object? body = null)
+    {
+        using var request = new HttpRequestMessage(method, path);
+        if (token is not null) request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        if (body is not null) request.Content = JsonContent.Create(body);
+        return await client.SendAsync(request);
+    }
+}

--- a/Nuotti.Backend.Tests/BackendCommandFlowTests.cs
+++ b/Nuotti.Backend.Tests/BackendCommandFlowTests.cs
@@ -50,7 +50,7 @@ public class BackendCommandFlowTests : IClassFixture<WebApplicationFactory<QuizH
         });
 
         await connection.StartAsync();
-        await connection.InvokeAsync("Join", session, "projector", null);
+        await connection.InvokeAsync("Join", session, "projector", null, null);
 
         // Send StartGame without explicit session creation; server initializes state lazily
         var resp = await client.PostAsJsonAsync($"/v1/message/phase/start-game/{session}", MakeStart(session));

--- a/Nuotti.Backend.Tests/LoadScenarioTests.cs
+++ b/Nuotti.Backend.Tests/LoadScenarioTests.cs
@@ -40,8 +40,8 @@ public class LoadScenarioTests
                 var ctx = new TestContext($"load-aud-{i}");
                 hub.SetContext(ctx);
 
-                await hub.Join(session, "Audience", name: $"A-{i}");
-                await hub.SubmitAnswer(session, choiceIndex: i % 4);
+                await hub.Join(session, "Audience", name: $"A-{i}", deviceSecret: $"dev-A-{i}");
+                await hub.SubmitAnswer(session, i % 4, Guid.Empty);
             }
             catch (System.Exception ex)
             {

--- a/Nuotti.Backend.Tests/OneSongWalkingSkeletonTests.cs
+++ b/Nuotti.Backend.Tests/OneSongWalkingSkeletonTests.cs
@@ -1,0 +1,275 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Security.Cryptography;
+using System.Text.Json;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.SignalR.Client;
+using Microsoft.Extensions.DependencyInjection;
+using Nuotti.Backend;
+using Nuotti.Backend.Assets;
+using Nuotti.Backend.Commands;
+using Nuotti.Backend.Sessions;
+using Nuotti.Backend.SessionSnapshots;
+using Nuotti.Backend.ShowAgents;
+using Nuotti.Backend.SongPackages;
+using Nuotti.Backend.Workspaces;
+using Nuotti.Contracts.V1.Enum;
+using Nuotti.Contracts.V1.Message;
+using Nuotti.Contracts.V1.Message.Phase;
+using Nuotti.Contracts.V1.Model;
+
+namespace Nuotti.Backend.Tests;
+
+/// <summary>
+/// Issue #255 — one-song cloud-to-venue walking skeleton at the HTTP + Show Agent seam:
+/// Participant joins, Hint + Window, answer, Reveal, Prepare, Start with cache-resolved PlayTrack,
+/// and one lyric line from the captured Session Setlist Snapshot.
+/// </summary>
+public sealed class OneSongWalkingSkeletonTests(WebApplicationFactory<QuizHub> baseFactory)
+    : IClassFixture<WebApplicationFactory<QuizHub>>
+{
+    readonly WebApplicationFactory<QuizHub> _factory = baseFactory.WithWebHostBuilder(_ => { });
+
+    [Fact]
+    public async Task Performer_drives_hint_window_answer_reveal_prepare_and_start_to_show_agent()
+    {
+        using var client = _factory.CreateClient();
+        var member = await SignInAsync(client, "walk");
+        var workspace = await PostAsync<WorkspaceAccess>(client, "/v1/workspaces", member.SessionToken,
+            new { name = "Walking skeleton band" });
+        await SelectAsync(client, member.SessionToken, workspace.WorkspaceId);
+
+        const string session = "WALK1";
+        (await SendAsync(client, HttpMethod.Post,
+            $"/v1/workspaces/{workspace.WorkspaceId}/sessions/{session}/create", member.SessionToken))
+            .EnsureSuccessStatusCode();
+        Assert.Equal(workspace.WorkspaceId,
+            _factory.Services.GetRequiredService<ISessionWorkspaceBinder>().Resolve(session));
+
+        var entry = await PostAsync<PrivateCatalogEntry>(client,
+            $"/v1/workspaces/{workspace.WorkspaceId}/catalog", member.SessionToken,
+            new { title = "Walking Song", artist = "The Band" });
+        var bytes = "walking-skeleton-audio"u8.ToArray();
+        var upload = await PostAsync<PrivateAssetUploadGrant>(client,
+            $"/v1/workspaces/{workspace.WorkspaceId}/catalog/{entry.CatalogEntryId}/asset-uploads", member.SessionToken,
+            new
+            {
+                assetType = "backing-track", contentType = "audio/wav", size = bytes.LongLength,
+                provenance = new
+                {
+                    source = "owned", rightsBasis = "original recording", territory = "NO",
+                    permittedUses = new[] { "backing-track" }, rightsExpiresAt = (DateTimeOffset?)null,
+                    supportingDocumentReference = "walk-case"
+                }
+            });
+        var objects = Assert.IsType<InMemoryPrivateAssetObjectStore>(
+            _factory.Services.GetRequiredService<IPrivateAssetObjectStore>());
+        var metadata = _factory.Services.GetRequiredService<IPrivateAssetMetadataStore>();
+        var objectKey = await metadata.GetObjectKeyAsync(workspace.WorkspaceId, upload.Revision.RevisionId);
+        objects.PutDirect(objectKey!, bytes, "audio/wav");
+        var sha256 = Convert.ToHexString(SHA256.HashData(bytes)).ToLowerInvariant();
+        var publishedAsset = await PostAsync<PrivateAssetRevision>(client,
+            $"/v1/workspaces/{workspace.WorkspaceId}/revisions/{upload.Revision.RevisionId}/publish",
+            member.SessionToken, new { sha256 });
+
+        const string lrc = "[00:00.00]First line of the reveal\n[00:05.00]Second line";
+        var document = new SongPackageDocument(
+            new(PlaybackMode.BackingOnly, publishedAsset.RevisionId, null, 2_000, 10_000, 8_000, null, [1, 2], []),
+            [new("hint-1", PackageHintType.Text, "A walking clue", null, null)],
+            new(lrc, 0));
+        (await SendAsync(client, HttpMethod.Put,
+            $"/v1/workspaces/{workspace.WorkspaceId}/catalog/{entry.CatalogEntryId}/package",
+            member.SessionToken, document)).EnsureSuccessStatusCode();
+        var publishResponse = await SendAsync(client, HttpMethod.Post,
+            $"/v1/workspaces/{workspace.WorkspaceId}/catalog/{entry.CatalogEntryId}/package/publish",
+            member.SessionToken, new { revisionNote = "Walk", acceptedWarningCodes = Array.Empty<string>() });
+        if (!publishResponse.IsSuccessStatusCode)
+        {
+            var body = await publishResponse.Content.ReadAsStringAsync();
+            Assert.Fail($"Package publish failed: {(int)publishResponse.StatusCode} {body}");
+        }
+        var package = (await publishResponse.Content.ReadFromJsonAsync<SongPackageRevision>())!;
+
+        var snapshot = await PostAsync<SessionSetlistSnapshot>(client,
+            $"/v1/workspaces/{workspace.WorkspaceId}/sessions/{session}/setlist-snapshot", member.SessionToken,
+            new CreateSessionSetlistSnapshotRequest([new(package.RevisionId)], new("standard", 1), []));
+        Assert.Equal(publishedAsset.RevisionId, Assert.Single(snapshot.Assets).RevisionId);
+        var capturedLyric = Assert.Single(snapshot.Songs).LyricTrack;
+        Assert.NotNull(capturedLyric);
+        Assert.Contains("First line of the reveal", capturedLyric!.Lrc);
+
+        var pairing = await PostAsync<ShowAgentPairingCode>(client,
+            $"/v1/workspaces/{workspace.WorkspaceId}/sessions/{session}/show-agent/pairings",
+            member.SessionToken, null);
+        var agent = await PostAsync<PairedShowAgent>(client, "/v1/show-agent/pair", null,
+            new { code = pairing.Code, name = "Venue laptop" });
+
+        await PostPhaseAsync(client, "start-game", session, new StartGame
+        {
+            SessionCode = session, IssuedByRole = Role.Performer, IssuedById = member.Principal.UserId
+        });
+        // Catalog comes from UpdateCatalog for RevealAnswer's SongRef; keep it aligned with the package.
+        var manifest = new SetlistManifest
+        {
+            Songs = { new SetlistManifest.SongEntry { Title = "Walking Song", Artist = "The Band", File = "https://example.test/walking-song.mp3" } }
+        };
+        var manifestResponse = await SendAsync(client, HttpMethod.Post, $"/api/manifest/{session}", null, manifest);
+        manifestResponse.EnsureSuccessStatusCode();
+
+        await PostJsonAsync(client, $"/api/pushQuestion/{session}", new QuestionPushed("Who sang it?", ["A", "B", "C"])
+        {
+            SessionCode = session, IssuedByRole = Role.Performer, IssuedById = member.Principal.UserId
+        });
+        await PostPhaseAsync(client, "open-answers", session, new OpenAnswers
+        {
+            SessionCode = session, IssuedByRole = Role.Performer, IssuedById = member.Principal.UserId
+        });
+
+        await using var audienceHub = new HubConnectionBuilder()
+            .WithUrl(new Uri(client.BaseAddress!, "/hub"), o => o.HttpMessageHandlerFactory = _ => _factory.Server.CreateHandler())
+            .Build();
+        await audienceHub.StartAsync();
+        await audienceHub.InvokeAsync("Join", session, "audience", "walker-1");
+        await audienceHub.InvokeAsync("SubmitAnswer", session, 0);
+
+        var stateStore = _factory.Services.GetRequiredService<IGameStateStore>();
+        if (!stateStore.TryGet(session, out var mid) || mid!.Answers.Count == 0)
+        {
+            var answer = new SubmitAnswer(null, 0)
+            {
+                SessionCode = session, IssuedByRole = Role.Audience, IssuedById = "walker-1"
+            };
+            var answered = await _factory.Services.GetRequiredService<ISessionCommandProcessor>()
+                .ApplyAsync(session, Actor.Verified(Role.Audience, "walker-1"), answer,
+                    workspaceId: workspace.WorkspaceId);
+            Assert.Equal(Nuotti.Contracts.V1.Protocol.Outcome.Applied, answered.Outcome);
+            Assert.True(answered.State is { Answers.Count: > 0 });
+        }
+
+        var songId = new SongId("song-1-walkingsong");
+        await PostPhaseAsync(client, "give-hint", session, new GiveHint(new Hint(0, "A walking clue", null, songId))
+        {
+            SessionCode = session, IssuedByRole = Role.Performer, IssuedById = member.Principal.UserId
+        });
+        await PostPhaseAsync(client, "lock-answers", session, new LockAnswers
+        {
+            SessionCode = session, IssuedByRole = Role.Performer, IssuedById = member.Principal.UserId
+        });
+        var revealSong = new SongRef(songId, "Walking Song", "The Band");
+        await PostPhaseAsync(client, "reveal-answer", session, new RevealAnswer(revealSong, 0)
+        {
+            SessionCode = session, IssuedByRole = Role.Performer, IssuedById = member.Principal.UserId
+        });
+
+        var prepareCorrelation = Guid.Parse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+        using (var prepareRequest = new HttpRequestMessage(HttpMethod.Post,
+                   $"/v1/message/phase/prepare-playback/{session}"))
+        {
+            prepareRequest.Headers.Add("X-Correlation-Id", prepareCorrelation.ToString());
+            prepareRequest.Content = JsonContent.Create(new PreparePlayback
+            {
+                CommandId = prepareCorrelation,
+                SessionCode = session,
+                IssuedByRole = Role.Performer,
+                IssuedById = member.Principal.UserId
+            });
+            (await client.SendAsync(prepareRequest)).EnsureSuccessStatusCode();
+        }
+
+        var startCorrelation = Guid.Parse("11111111-2222-3333-4444-555555555555");
+        using (var startRequest = new HttpRequestMessage(HttpMethod.Post,
+                   $"/v1/message/phase/start-playback/{session}"))
+        {
+            startRequest.Headers.Add("X-Correlation-Id", startCorrelation.ToString());
+            startRequest.Content = JsonContent.Create(new StartPlayback(revealSong.Id, publishedAsset.RevisionId)
+            {
+                CommandId = startCorrelation,
+                SessionCode = session,
+                IssuedByRole = Role.Performer,
+                IssuedById = member.Principal.UserId
+            });
+            (await client.SendAsync(startRequest)).EnsureSuccessStatusCode();
+        }
+
+        var commands = await GetAsync<ShowAgentCommand[]>(client, "/v1/show-agent/commands?after=0", agent.AccessToken);
+        Assert.Contains(commands, c => c.MessageType == "Prepare");
+        var play = Assert.Single(commands, c => c.MessageType == "PlayTrack");
+        var playPayload = JsonSerializer.SerializeToElement(play.Payload);
+        Assert.Equal(publishedAsset.RevisionId,
+            playPayload.TryGetProperty("assetRevisionId", out var assetProp)
+                ? assetProp.GetString()
+                : playPayload.GetProperty("AssetRevisionId").GetString());
+
+        var state = _factory.Services.GetRequiredService<IGameStateStore>();
+        Assert.True(state.TryGet(session, out var snapshotState));
+        Assert.Equal(Phase.Play, snapshotState!.Phase);
+        Assert.True(snapshotState.HintIndex >= 1);
+        Assert.Single(snapshotState.Answers);
+    }
+
+    [Fact]
+    public void Aspire_app_host_composes_every_walking_skeleton_role()
+    {
+        var host = File.ReadAllText(Path.Combine(RepoRoot(), "Nuotti", "Program.cs"));
+        Assert.Contains("DistributedApplication.CreateBuilder", host);
+        Assert.Contains("Nuotti_Backend", host);
+        Assert.Contains("Nuotti_AudioEngine", host);
+        Assert.Contains("Nuotti_Performer", host);
+        Assert.Contains("Nuotti_Audience", host);
+        Assert.Contains("Nuotti_Projector", host);
+        Assert.Contains("show-agent", host);
+    }
+
+    static string RepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "Nuotti.sln")))
+            dir = dir.Parent;
+        return dir?.FullName ?? throw new InvalidOperationException("Repo root not found.");
+    }
+
+    static async Task PostPhaseAsync(HttpClient client, string route, string session, CommandBase cmd)
+    {
+        var response = await client.PostAsJsonAsync($"/v1/message/phase/{route}/{session}", cmd);
+        response.EnsureSuccessStatusCode();
+    }
+
+    static async Task PostJsonAsync(HttpClient client, string path, object body)
+    {
+        (await SendAsync(client, HttpMethod.Post, path, null, body)).EnsureSuccessStatusCode();
+    }
+
+    static async Task SelectAsync(HttpClient client, string token, string workspaceId) =>
+        (await SendAsync(client, HttpMethod.Post, $"/v1/workspaces/{workspaceId}/select", token)).EnsureSuccessStatusCode();
+
+    static async Task<RedeemedMagicLink> SignInAsync(HttpClient client, string prefix)
+    {
+        var link = await PostAsync<IssuedMagicLink>(client, "/v1/auth/magic-links", null,
+            new { email = $"{prefix}-{Guid.NewGuid():N}@example.test" });
+        return await PostAsync<RedeemedMagicLink>(client, "/v1/auth/magic-links/redeem", null, new { token = link.Token });
+    }
+
+    static async Task<T> PostAsync<T>(HttpClient client, string path, string? token, object? body)
+    {
+        var response = await SendAsync(client, HttpMethod.Post, path, token, body);
+        response.EnsureSuccessStatusCode();
+        return (await response.Content.ReadFromJsonAsync<T>())!;
+    }
+
+    static async Task<T> GetAsync<T>(HttpClient client, string path, string token)
+    {
+        var response = await SendAsync(client, HttpMethod.Get, path, token);
+        response.EnsureSuccessStatusCode();
+        return (await response.Content.ReadFromJsonAsync<T>())!;
+    }
+
+    static async Task<HttpResponseMessage> SendAsync(HttpClient client, HttpMethod method, string path,
+        string? token, object? body = null)
+    {
+        using var request = new HttpRequestMessage(method, path);
+        if (token is not null) request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        if (body is not null) request.Content = JsonContent.Create(body);
+        return await client.SendAsync(request);
+    }
+}

--- a/Nuotti.Backend.Tests/OneSongWalkingSkeletonTests.cs
+++ b/Nuotti.Backend.Tests/OneSongWalkingSkeletonTests.cs
@@ -130,8 +130,8 @@ public sealed class OneSongWalkingSkeletonTests(WebApplicationFactory<QuizHub> b
             .WithUrl(new Uri(client.BaseAddress!, "/hub"), o => o.HttpMessageHandlerFactory = _ => _factory.Server.CreateHandler())
             .Build();
         await audienceHub.StartAsync();
-        await audienceHub.InvokeAsync("Join", session, "audience", "walker-1");
-        await audienceHub.InvokeAsync("SubmitAnswer", session, 0);
+        await audienceHub.InvokeAsync("Join", session, "audience", "walker-1", "device-walk-1");
+        await audienceHub.InvokeAsync("SubmitAnswer", session, 0, Guid.Empty);
 
         var stateStore = _factory.Services.GetRequiredService<IGameStateStore>();
         if (!stateStore.TryGet(session, out var mid) || mid!.Answers.Count == 0)

--- a/Nuotti.Backend.Tests/ParticipantIdentityStoreTests.cs
+++ b/Nuotti.Backend.Tests/ParticipantIdentityStoreTests.cs
@@ -1,0 +1,55 @@
+using Nuotti.Backend.Participants;
+
+namespace Nuotti.Backend.Tests;
+
+public sealed class ParticipantIdentityStoreTests
+{
+    readonly InMemoryParticipantIdentityStore _store = new();
+
+    [Fact]
+    public void Same_device_reconnects_to_same_Participant_within_Session()
+    {
+        var first = _store.JoinOrRestore("SESS01", "device-secret-a", "Alex");
+        var second = _store.JoinOrRestore("SESS01", "device-secret-a", "Alex");
+
+        Assert.Equal(first.ParticipantId, second.ParticipantId);
+        Assert.Equal("SESS01", second.SessionCode);
+        Assert.Equal("Alex", second.DisplayName);
+    }
+
+    [Fact]
+    public void Same_device_in_different_Session_gets_new_Participant()
+    {
+        var first = _store.JoinOrRestore("SESS01", "device-secret-a", "Alex");
+        var second = _store.JoinOrRestore("SESS02", "device-secret-a", "Alex");
+
+        Assert.NotEqual(first.ParticipantId, second.ParticipantId);
+        Assert.Equal("SESS02", second.SessionCode);
+    }
+
+    [Fact]
+    public void TryGet_rejects_Participant_bound_to_another_Session()
+    {
+        var bound = _store.JoinOrRestore("SESS01", "device-secret-a", "Alex");
+
+        Assert.False(_store.TryGet("SESS02", bound.ParticipantId, out _));
+        Assert.True(_store.TryGet("SESS01", bound.ParticipantId, out var found));
+        Assert.Equal(bound.ParticipantId, found!.ParticipantId);
+    }
+
+    [Fact]
+    public void Performer_can_moderate_display_name()
+    {
+        var participant = _store.JoinOrRestore("SESS01", "device-secret-a", "BadWord");
+        Assert.True(_store.TryModerateName("SESS01", participant.ParticipantId, "CleanName", out var moderated));
+        Assert.Equal("CleanName", moderated!.DisplayName);
+        Assert.True(moderated.NameIsModerated);
+    }
+
+    [Fact]
+    public void Join_rejects_empty_or_profane_names()
+    {
+        Assert.Throws<ArgumentException>(() => _store.JoinOrRestore("SESS01", "device-secret-a", "x"));
+        Assert.Throws<ArgumentException>(() => _store.JoinOrRestore("SESS01", "device-secret-a", "damn idiot"));
+    }
+}

--- a/Nuotti.Backend.Tests/QuizHubInProcTests.cs
+++ b/Nuotti.Backend.Tests/QuizHubInProcTests.cs
@@ -30,7 +30,7 @@ public class QuizHubInProcTests
         hub.SetClients(clients);
         hub.SetGroups(groups);
 
-        await hub.Join("sessA", "Audience", name: "Alice");
+        await hub.Join("sessA", "Audience", name: "Alice", deviceSecret: "dev-Alice");
 
         Assert.True(groups.Groups.TryGetValue("sessA", out var sessGroup) && sessGroup.Contains("conn-1"));
         Assert.True(groups.Groups.TryGetValue("sessA:audience", out var roleGroup) && roleGroup.Contains("conn-1"));
@@ -64,8 +64,8 @@ public class QuizHubInProcTests
         // Performer joins
         var performerCtx = new TestContext("perf-1");
         hub.SetContext(performerCtx);
-        await hub.Join("sessB", "Performer");
-        await hub.SubmitAnswer("sessB", 1);
+        await hub.Join("sessB", "Performer", null, null);
+        await hub.SubmitAnswer("sessB", 1, Guid.Empty);
         // Expect a Problem sent to Caller
         Assert.Contains(clients.CallerProxy.Sent, x => x.method == "Problem");
 
@@ -73,8 +73,8 @@ public class QuizHubInProcTests
         var audienceCtx = new TestContext("aud-1");
         clients.CallerProxy.Sent.Clear();
         hub.SetContext(audienceCtx);
-        await hub.Join("sessB", "Audience", name: "Bob");
-        await hub.SubmitAnswer("sessB", 2);
+        await hub.Join("sessB", "Audience", name: "Bob", deviceSecret: "dev-Bob");
+        await hub.SubmitAnswer("sessB", 2, Guid.Empty);
         Assert.Contains(bus.Published, e => e is AnswerSubmitted { ChoiceIndex: 2, SessionCode: "sessB" });
     }
 
@@ -101,12 +101,12 @@ public class QuizHubInProcTests
         // Join session1 as performer
         var ctx1 = new TestContext("conn-1");
         hub.SetContext(ctx1);
-        await hub.Join("session1", "Performer");
+        await hub.Join("session1", "Performer", null, null);
 
         // Join session2 as performer
         var ctx2 = new TestContext("conn-2");
         hub.SetContext(ctx2);
-        await hub.Join("session2", "Performer");
+        await hub.Join("session2", "Performer", null, null);
 
         // Verify groups are separate
         Assert.True(groups.Groups.TryGetValue("session1", out var sess1Group) && sess1Group.Contains("conn-1"));
@@ -146,16 +146,16 @@ public class QuizHubInProcTests
         // Join session1 as audience
         var ctx1 = new TestContext("conn-sess1");
         hub.SetContext(ctx1);
-        await hub.Join("session1", "Audience", name: "Alice");
+        await hub.Join("session1", "Audience", name: "Alice", deviceSecret: "dev-Alice");
 
         // Join session2 as audience
         var ctx2 = new TestContext("conn-sess2");
         hub.SetContext(ctx2);
-        await hub.Join("session2", "Audience", name: "Bob");
+        await hub.Join("session2", "Audience", name: "Bob", deviceSecret: "dev-Bob");
 
         // Submit answer in session1
         hub.SetContext(ctx1);
-        await hub.SubmitAnswer("session1", 1);
+        await hub.SubmitAnswer("session1", 1, Guid.Empty);
 
         // Verify only session1 received the event (via event bus, not direct broadcast)
         var session1Events = bus.Published.Where(e => e is AnswerSubmitted a && a.SessionCode == "session1").ToList();
@@ -178,7 +178,7 @@ public class QuizHubInProcTests
         // Join as Performer
         var perfCtx = new TestContext("conn-perf");
         hub.SetContext(perfCtx);
-        await hub.Join("test-session", "Performer");
+        await hub.Join("test-session", "Performer", null, null);
 
         // Verify added to session group and role group
         Assert.True(groups.Groups.TryGetValue("test-session", out var sessGroup) && sessGroup.Contains("conn-perf"));
@@ -187,7 +187,7 @@ public class QuizHubInProcTests
         // Join as Audience
         var audCtx = new TestContext("conn-aud");
         hub.SetContext(audCtx);
-        await hub.Join("test-session", "Audience", name: "Charlie");
+        await hub.Join("test-session", "Audience", name: "Charlie", deviceSecret: "dev-Charlie");
 
         // Verify added to session group and audience role group
         Assert.True(sessGroup.Contains("conn-aud"));
@@ -264,13 +264,13 @@ public class QuizHubInProcTests
         hub.SetClients(clients);
         hub.SetGroups(groups);
 
-        await hub.Join("test-session", "Audience", name: "Alice");
+        await hub.Join("test-session", "Audience", name: "Alice", deviceSecret: "dev-Alice");
 
         // Verify JoinedAudience was sent to session group
         Assert.True(clients.GroupProxies.TryGetValue("test-session", out var groupProxy));
         Assert.Contains(groupProxy.Sent, x => x.method == "JoinedAudience");
         var joinedMsg = (JoinedAudience)groupProxy.Sent.First(x => x.method == "JoinedAudience").args[0]!;
-        Assert.Equal("conn-1", joinedMsg.ConnectionId);
+        Assert.StartsWith("part_", joinedMsg.ConnectionId);
         Assert.Equal("Alice", joinedMsg.Name);
     }
 
@@ -285,7 +285,7 @@ public class QuizHubInProcTests
         hub.SetClients(clients);
         hub.SetGroups(groups);
 
-        await hub.Join("test-session", "Performer");
+        await hub.Join("test-session", "Performer", null, null);
 
         // Verify JoinedAudience was NOT sent (if group proxy exists, it should be empty)
         if (clients.GroupProxies.TryGetValue("test-session", out var groupProxy))
@@ -303,7 +303,7 @@ public class QuizHubInProcTests
         hub.SetContext(new TestContext("conn-1"));
         hub.SetClients(clients);
 
-        await hub.Join("", "Audience");
+        await hub.Join("", "Audience", null, null);
 
         Assert.Contains(clients.CallerProxy.Sent, x => x.method == "Problem");
     }
@@ -317,7 +317,7 @@ public class QuizHubInProcTests
         hub.SetContext(new TestContext("conn-1"));
         hub.SetClients(clients);
 
-        await hub.Join("test-session", "");
+        await hub.Join("test-session", "", null, null);
 
         Assert.Contains(clients.CallerProxy.Sent, x => x.method == "Problem");
     }
@@ -333,7 +333,7 @@ public class QuizHubInProcTests
         hub.SetClients(clients);
         hub.SetGroups(groups);
 
-        await hub.CreateOrJoinWithName("test-session", "Bob");
+        await hub.CreateOrJoinWithName("test-session", "Bob", "dev-Bob");
 
         // Verify added to session and audience role group
         Assert.True(groups.Groups.TryGetValue("test-session", out var sessGroup) && sessGroup.Contains("conn-1"));
@@ -355,7 +355,7 @@ public class QuizHubInProcTests
         hub.SetClients(new FakeClients());
 
         // Join a session
-        await hub.Join("test-session", "Audience", name: "Alice");
+        await hub.Join("test-session", "Audience", name: "Alice", deviceSecret: "dev-Alice");
         Assert.True(groups.Groups.TryGetValue("test-session", out var sessGroup) && sessGroup.Contains("conn-1"));
         Assert.Equal(1, store.GetCounts("test-session").Audiences);
 
@@ -425,7 +425,7 @@ public class QuizHubInProcTests
         hub.SetGroups(groups);
 
         // Join as Performer
-        await hub.Join("test-session", "Performer");
+        await hub.Join("test-session", "Performer", null, null);
 
         // Try to request play
         var cmd = new PlayTrack("https://example.com/track.mp3")
@@ -452,7 +452,7 @@ public class QuizHubInProcTests
         hub.SetGroups(groups);
 
         // Join as Audience
-        await hub.Join("test-session", "Audience", name: "Alice");
+        await hub.Join("test-session", "Audience", name: "Alice", deviceSecret: "dev-Alice");
 
         // Request play
         var cmd = new PlayTrack("https://example.com/track.mp3")
@@ -486,11 +486,11 @@ public class QuizHubInProcTests
 
         // Join session1
         hub.SetContext(new TestContext("conn-1"));
-        await hub.Join("session1", "Audience", name: "Alice");
+        await hub.Join("session1", "Audience", name: "Alice", deviceSecret: "dev-Alice");
 
         // Join session2
         hub.SetContext(new TestContext("conn-2"));
-        await hub.Join("session2", "Audience", name: "Bob");
+        await hub.Join("session2", "Audience", name: "Bob", deviceSecret: "dev-Bob");
 
         // Broadcast EngineStatusChanged to session1
         var evt = new EngineStatusChanged(EngineStatus.Playing, 50.0);

--- a/Nuotti.Backend.Tests/ReconnectTests.cs
+++ b/Nuotti.Backend.Tests/ReconnectTests.cs
@@ -86,7 +86,7 @@ public class ReconnectTests : IClassFixture<WebApplicationFactory<QuizHub>>, IAs
         });
 
         await _connection.StartAsync();
-        await _connection.InvokeAsync("Join", session, "audience", "TestUser");
+        await _connection.InvokeAsync("Join", session, "audience", "TestUser", "dev-TestUser");
 
         // Disconnect
         await _connection.StopAsync();
@@ -94,7 +94,7 @@ public class ReconnectTests : IClassFixture<WebApplicationFactory<QuizHub>>, IAs
 
         // Reconnect and rejoin
         await _connection.StartAsync();
-        await _connection.InvokeAsync("Join", session, "audience", "TestUser");
+        await _connection.InvokeAsync("Join", session, "audience", "TestUser", "dev-TestUser");
 
         // Verify reconnection succeeded
         Assert.Equal(HubConnectionState.Connected, _connection.State);
@@ -118,7 +118,7 @@ public class ReconnectTests : IClassFixture<WebApplicationFactory<QuizHub>>, IAs
 
         // Connect and join
         await _connection.StartAsync();
-        await _connection.InvokeAsync("Join", session, "projector", "projector");
+        await _connection.InvokeAsync("Join", session, "projector", "projector", null);
 
         // Start game (this will broadcast GameStateChanged)
         var start = new StartGame
@@ -141,7 +141,7 @@ public class ReconnectTests : IClassFixture<WebApplicationFactory<QuizHub>>, IAs
 
         // Reconnect and rejoin
         await _connection.StartAsync();
-        await _connection.InvokeAsync("Join", session, "projector", "projector");
+        await _connection.InvokeAsync("Join", session, "projector", "projector", null);
 
         // Fetch latest state via /status endpoint (simulating resync)
         var statusResp = await _httpClient.GetAsync($"/status/{session}");
@@ -166,7 +166,7 @@ public class ReconnectTests : IClassFixture<WebApplicationFactory<QuizHub>>, IAs
 
         // Initial connection
         await _connection.StartAsync();
-        await _connection.InvokeAsync("Join", session, "audience", "User1");
+        await _connection.InvokeAsync("Join", session, "audience", "User1", "dev-User1");
         Assert.Equal(HubConnectionState.Connected, _connection.State);
 
         // Disconnect and reconnect multiple times
@@ -175,7 +175,7 @@ public class ReconnectTests : IClassFixture<WebApplicationFactory<QuizHub>>, IAs
             await _connection.StopAsync();
             await Task.Delay(100);
             await _connection.StartAsync();
-            await _connection.InvokeAsync("Join", session, "audience", "User1");
+            await _connection.InvokeAsync("Join", session, "audience", "User1", "dev-User1");
             await Task.Delay(100);
         }
 
@@ -192,7 +192,7 @@ public class ReconnectTests : IClassFixture<WebApplicationFactory<QuizHub>>, IAs
 
         // Connect and join
         await _connection!.StartAsync();
-        await _connection.InvokeAsync("Join", session, "projector", "projector");
+        await _connection.InvokeAsync("Join", session, "projector", "projector", null);
 
         // Start game
         var start = new StartGame
@@ -222,7 +222,7 @@ public class ReconnectTests : IClassFixture<WebApplicationFactory<QuizHub>>, IAs
 
         // Reconnect and verify can fetch latest state
         await _connection.StartAsync();
-        await _connection.InvokeAsync("Join", session, "projector", "projector");
+        await _connection.InvokeAsync("Join", session, "projector", "projector", null);
 
         var status3 = await _httpClient.GetAsync($"/status/{session}");
         var snapshot3 = await status3.Content.ReadFromJsonAsync<GameStateSnapshot>(ContractsJson.RestOptions);
@@ -246,7 +246,7 @@ public class ReconnectTests : IClassFixture<WebApplicationFactory<QuizHub>>, IAs
 
         // Connect as audience
         await _connection.StartAsync();
-        await _connection.InvokeAsync("Join", session, "audience", "TestUser");
+        await _connection.InvokeAsync("Join", session, "audience", "TestUser", "dev-TestUser");
 
         // Start game
         var start = new StartGame
@@ -264,7 +264,7 @@ public class ReconnectTests : IClassFixture<WebApplicationFactory<QuizHub>>, IAs
 
         // Reconnect and rejoin
         await _connection.StartAsync();
-        await _connection.InvokeAsync("Join", session, "audience", "TestUser");
+        await _connection.InvokeAsync("Join", session, "audience", "TestUser", "dev-TestUser");
 
         // Fetch latest state to resync
         var statusResp = await _httpClient.GetAsync($"/status/{session}");

--- a/Nuotti.Backend.Tests/TestSupport/InProcHub.cs
+++ b/Nuotti.Backend.Tests/TestSupport/InProcHub.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Options;
 using Nuotti.Backend.Commands;
 using Nuotti.Backend.Idempotency;
 using Nuotti.Backend.Models;
+using Nuotti.Backend.Participants;
 using Nuotti.Backend.Sessions;
 using Nuotti.Contracts.V1.Event;
 using Nuotti.Contracts.V1.Eventing;
@@ -113,8 +114,12 @@ public sealed class CapturingEventBus : IEventBus
 /// <summary>
 /// QuizHub with its Context, Groups and Clients settable, which the base class does not allow.
 /// </summary>
-public sealed class TestableQuizHub(ILogStreamer log, ISessionStore sessions, ISessionCommandProcessor processor)
-    : QuizHub(new NullLogger<QuizHub>(), log, sessions, processor)
+public sealed class TestableQuizHub(
+    ILogStreamer log,
+    ISessionStore sessions,
+    ISessionCommandProcessor processor,
+    IParticipantIdentityStore participants)
+    : QuizHub(new NullLogger<QuizHub>(), log, sessions, processor, participants)
 {
     public void SetContext(HubCallerContext ctx) => Context = ctx;
     public void SetGroups(IGroupManager groups) => Groups = groups;
@@ -128,6 +133,8 @@ public static class Harness
 
     public static InMemoryIdempotencyStore IdempotencyStore()
         => new(Options.Create(new NuottiOptions()));
+
+    public static InMemoryParticipantIdentityStore Participants() => new();
 
     /// <summary>
     /// A hub wired to a real processor over in-memory stores, publishing to <paramref name="bus"/>.
@@ -146,7 +153,7 @@ public static class Harness
             state,
             IdempotencyStore(),
             bus,
-            NullLogger<SessionCommandProcessor>.Instance));
+            NullLogger<SessionCommandProcessor>.Instance), Participants());
     }
 
     /// <summary>

--- a/Nuotti.Backend/Assets/InMemoryPrivateAssetStores.cs
+++ b/Nuotti.Backend/Assets/InMemoryPrivateAssetStores.cs
@@ -27,6 +27,19 @@ public sealed class InMemoryPrivateAssetMetadataStore(TimeProvider? timeProvider
             && entry.WorkspaceId == workspaceId ? entry : null);
     }
 
+    public Task<IReadOnlyList<PrivateCatalogEntry>> ListEntriesAsync(string workspaceId,
+        CancellationToken cancellationToken = default)
+    {
+        lock (_gate)
+        {
+            IReadOnlyList<PrivateCatalogEntry> list = _entries.Values
+                .Where(e => e.WorkspaceId == workspaceId)
+                .OrderBy(e => e.Title, StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+            return Task.FromResult(list);
+        }
+    }
+
     public Task<(PrivateAssetRevision Revision, string ObjectKey)?> CreateDraftAsync(
         string workspaceId, string catalogEntryId, string assetType, string contentType, long declaredSize,
         AssetProvenance provenance, string userId, CancellationToken cancellationToken = default)

--- a/Nuotti.Backend/Assets/PostgresPrivateAssetMetadataStore.cs
+++ b/Nuotti.Backend/Assets/PostgresPrivateAssetMetadataStore.cs
@@ -41,6 +41,26 @@ public sealed class PostgresPrivateAssetMetadataStore(NpgsqlDataSource dataSourc
                 reader.GetFieldValue<DateTimeOffset>(3)) : null;
     }
 
+    public async Task<IReadOnlyList<PrivateCatalogEntry>> ListEntriesAsync(string workspaceId,
+        CancellationToken cancellationToken = default)
+    {
+        await EnsureSchemaAsync(cancellationToken);
+        await using var command = dataSource.CreateCommand("""
+            SELECT id,title,artist,created_by,created_at FROM nuotti_private_catalog_entry
+            WHERE workspace_id=$1
+            ORDER BY title
+            """);
+        command.Parameters.AddWithValue(workspaceId);
+        var list = new List<PrivateCatalogEntry>();
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            list.Add(new(reader.GetString(0), workspaceId, reader.GetString(1), reader.GetString(2),
+                reader.GetString(3), reader.GetFieldValue<DateTimeOffset>(4)));
+        }
+        return list;
+    }
+
     public async Task<(PrivateAssetRevision Revision, string ObjectKey)?> CreateDraftAsync(
         string workspaceId, string catalogEntryId, string assetType, string contentType, long declaredSize,
         AssetProvenance provenance, string userId, CancellationToken cancellationToken = default)

--- a/Nuotti.Backend/Assets/PrivateAssetModel.cs
+++ b/Nuotti.Backend/Assets/PrivateAssetModel.cs
@@ -30,6 +30,8 @@ public interface IPrivateAssetMetadataStore
         CancellationToken cancellationToken = default);
     Task<PrivateCatalogEntry?> GetEntryAsync(string workspaceId, string catalogEntryId,
         CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<PrivateCatalogEntry>> ListEntriesAsync(string workspaceId,
+        CancellationToken cancellationToken = default);
     Task<(PrivateAssetRevision Revision, string ObjectKey)?> CreateDraftAsync(
         string workspaceId, string catalogEntryId, string assetType, string contentType, long declaredSize,
         AssetProvenance provenance, string userId, CancellationToken cancellationToken = default);

--- a/Nuotti.Backend/Catalog/AudienceCatalogSearch.cs
+++ b/Nuotti.Backend/Catalog/AudienceCatalogSearch.cs
@@ -1,0 +1,69 @@
+using Nuotti.Backend.Assets;
+using Nuotti.Backend.Sessions;
+using Nuotti.Contracts.V1.Model;
+
+namespace Nuotti.Backend.Catalog;
+
+public interface ISharedSongCatalog
+{
+    IReadOnlyList<SongRef> All { get; }
+    void Seed(IEnumerable<SongRef> songs);
+}
+
+public sealed class InMemorySharedSongCatalog : ISharedSongCatalog
+{
+    readonly object _gate = new();
+    List<SongRef> _songs = [];
+
+    public IReadOnlyList<SongRef> All
+    {
+        get { lock (_gate) return _songs; }
+    }
+
+    public void Seed(IEnumerable<SongRef> songs)
+    {
+        lock (_gate) _songs = songs.ToList();
+    }
+}
+
+public interface IAudienceCatalogSearch
+{
+    Task<IReadOnlyList<SongRef>> SearchAsync(string sessionCode, string query, int limit = 25,
+        CancellationToken cancellationToken = default);
+}
+
+public sealed class AudienceCatalogSearch(
+    ISharedSongCatalog shared,
+    IPrivateAssetMetadataStore privateCatalog,
+    ISessionWorkspaceBinder binder) : IAudienceCatalogSearch
+{
+    public async Task<IReadOnlyList<SongRef>> SearchAsync(string sessionCode, string query, int limit = 25,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(sessionCode)) return [];
+        limit = Math.Clamp(limit, 1, 50);
+        var needle = (query ?? string.Empty).Trim();
+        var workspaceId = binder.Resolve(sessionCode);
+        var workspaceEntries = string.IsNullOrWhiteSpace(workspaceId)
+            ? Array.Empty<PrivateCatalogEntry>()
+            : await privateCatalog.ListEntriesAsync(workspaceId, cancellationToken);
+
+        IEnumerable<SongRef> combined = shared.All;
+        if (workspaceEntries.Count > 0)
+        {
+            combined = combined.Concat(workspaceEntries.Select(e =>
+                new SongRef(new SongId(e.CatalogEntryId), e.Title, e.Artist)));
+        }
+
+        if (needle.Length == 0)
+            return combined.Take(limit).ToArray();
+
+        return combined
+            .Where(s => Contains(s.Title, needle) || Contains(s.Artist, needle) || Contains(s.Id.Value, needle))
+            .Take(limit)
+            .ToArray();
+    }
+
+    static bool Contains(string haystack, string needle) =>
+        haystack.Contains(needle, StringComparison.OrdinalIgnoreCase);
+}

--- a/Nuotti.Backend/Commands/SessionCommandProcessor.cs
+++ b/Nuotti.Backend/Commands/SessionCommandProcessor.cs
@@ -191,19 +191,40 @@ public sealed class SessionCommandProcessor(
         if (durable is not null && effects.CheckIdempotency)
         {
             var expectedSequence = persisted?.LastSequence ?? SessionSequence.None;
+            // Relays (PlayTrack, PreparePlayback, …) are at-least-once and not outbox-durable —
+            // commit only durable events, then publish relays live so Show Agent still receives them.
+            var durablePublications = publications.Where(SessionMessagePublisher.IsDurable).ToList();
+            var liveRelays = publications.Where(p => !SessionMessagePublisher.IsDurable(p)).ToList();
             var commit = await durable.CommitAsync(
-                workspaceId, session, command.CommandId, expectedSequence, next, publications,
+                workspaceId, session, command.CommandId, expectedSequence, next, durablePublications,
                 cancellationToken: ct);
             if (commit.WasDuplicate) return commit.Result;
             if (commit.WasStale)
                 throw new StaleCommitException();
             store.Set(session, next);
             if (outbox is not null) await outbox.DispatchPendingAsync(cancellationToken: ct);
+            foreach (var relay in liveRelays) await PublishAsync(relay, ct, workspaceId);
         }
         else
         {
             if (stateChanged) store.Set(session, next);
             foreach (var publication in publications) await PublishAsync(publication, ct, workspaceId);
+            // At-least-once relays that also change state (QuestionPushed → QuestionOffered) must
+            // still advance the Workspace durable snapshot; otherwise the next phase command
+            // reloads a Choices-less record and wipes memory. Use a fresh CommandId so retries
+            // remain at-least-once on the wire (docs/adr/0002).
+            if (durable is not null && stateChanged && workspaceId != "legacy")
+            {
+                var durableOnly = publications.Where(SessionMessagePublisher.IsDurable).ToList();
+                if (durableOnly.Count > 0)
+                {
+                    var latest = await durable.LoadAsync(workspaceId, session, ct);
+                    var expectedSequence = latest?.LastSequence ?? SessionSequence.None;
+                    await durable.CommitAsync(
+                        workspaceId, session, Guid.NewGuid(), expectedSequence, next, durableOnly,
+                        cancellationToken: ct);
+                }
+            }
         }
 
         Complete(activity, command, stateChanged ? next : null);
@@ -237,6 +258,33 @@ public sealed class SessionCommandProcessor(
                         CorrelationId = correlation
                     }
                 ]);
+
+            // StartPlayback must be matched before IPhaseChange: it both moves Reveal→Play and
+            // relays a cache-resolved PlayTrack so the Show Agent can start backing/click.
+            case StartPlayback start:
+                if (string.IsNullOrWhiteSpace(start.AssetRevisionId))
+                {
+                    rejection = NuottiProblem.UnprocessableEntity(
+                        title: "Invalid Start",
+                        detail: "AssetRevisionId from the Session Setlist Snapshot is required.",
+                        field: "assetRevisionId",
+                        correlationId: correlation);
+                    return new Effects([]);
+                }
+                return new Effects([
+                    Phase(state.Phase, start.TargetPhase, session, command, correlation),
+                    new PlayTrack(start.AssetRevisionId)
+                    {
+                        AssetRevisionId = start.AssetRevisionId,
+                        SessionCode = session,
+                        IssuedByRole = command.IssuedByRole,
+                        IssuedById = command.IssuedById,
+                        CommandId = command.CommandId
+                    }
+                ]);
+
+            case PreparePlayback prepare:
+                return new Effects([prepare], BroadcastSnapshot: false, CheckIdempotency: false);
 
             case IPhaseChange phaseChange:
                 return new Effects([

--- a/Nuotti.Backend/Commands/SessionCommandProcessor.cs
+++ b/Nuotti.Backend/Commands/SessionCommandProcessor.cs
@@ -184,6 +184,23 @@ public sealed class SessionCommandProcessor(
         }
 
         var stateChanged = !ReferenceEquals(next, state);
+        if (command is OpenAnswers openAnswers)
+        {
+            var seconds = OpenAnswers.ClampWindowSeconds(openAnswers.WindowSeconds);
+            var openedAt = DateTime.UtcNow;
+            next = next with
+            {
+                GuessingWindowSeconds = seconds,
+                GuessingWindowOpenedAtUtc = openedAt,
+                GuessingWindowDeadlineUtc = openedAt.AddSeconds(seconds),
+                // New Window clears live answers; Lock-held answers remain for Reveal.
+                Answers = System.Collections.Frozen.FrozenDictionary<string, int>.Empty,
+                AnswerReceivedAtUtc = System.Collections.Frozen.FrozenDictionary<string, DateTime>.Empty,
+                Tallies = next.Choices.Count == 0 ? next.Tallies : new int[next.Choices.Count]
+            };
+            stateChanged = true;
+        }
+
         var publications = effects.Events.ToList();
         if (effects.BroadcastSnapshot && stateChanged)
             publications.Add(StateChanged(session, next, command, correlation));

--- a/Nuotti.Backend/Endpoints/ApiEndpoints.cs
+++ b/Nuotti.Backend/Endpoints/ApiEndpoints.cs
@@ -48,7 +48,8 @@ internal static class ApiEndpoints
         // Upload a setlist manifest and replace the session's song catalog. Manifest validation and
         // catalog construction live behind the processor with every other command effect.
         app.MapPost("/api/manifest/{session}",
-                async (HttpContext http, ISessionCommandProcessor processor, string session, SetlistManifest manifest) =>
+                async (HttpContext http, ISessionCommandProcessor processor,
+                    ISessionWorkspaceBinder workspaces, string session, SetlistManifest manifest) =>
                 {
                     var cmd = new UpdateCatalog(manifest)
                     {
@@ -62,7 +63,8 @@ internal static class ApiEndpoints
                         Actor.Claimed(cmd),
                         cmd,
                         CorrelationIdMiddleware.GetCorrelationId(http),
-                        http.RequestAborted);
+                        http.RequestAborted,
+                        workspaces.Resolve(session) ?? "legacy");
 
                     if (result.Outcome == Outcome.Rejected) return ProblemResults.From(result.Problem!);
 
@@ -91,14 +93,17 @@ internal static class ApiEndpoints
 
     static void MapRelay<T>(this WebApplication app, string route) where T : CommandBase
     {
-        app.MapPost(route, async (HttpContext http, ISessionCommandProcessor processor, string session, T cmd) =>
+        app.MapPost(route, async (HttpContext http, ISessionCommandProcessor processor,
+                ISessionWorkspaceBinder workspaces, string session, T cmd) =>
             {
+                var workspaceId = workspaces.Resolve(session) ?? "legacy";
                 var result = await processor.ApplyAsync(
                     session,
                     Actor.Claimed(cmd),
                     cmd,
                     CorrelationIdMiddleware.GetCorrelationId(http),
-                    http.RequestAborted);
+                    http.RequestAborted,
+                    workspaceId);
 
                 return result.ToHttpResult();
             })

--- a/Nuotti.Backend/Endpoints/AudienceParticipantEndpoints.cs
+++ b/Nuotti.Backend/Endpoints/AudienceParticipantEndpoints.cs
@@ -1,0 +1,84 @@
+using Nuotti.Backend.Catalog;
+using Nuotti.Backend.Participants;
+using Nuotti.Backend.Sessions;
+using Nuotti.Contracts.V1.Model;
+
+namespace Nuotti.Backend.Endpoints;
+
+public static class AudienceCatalogEndpoints
+{
+    public static void MapAudienceCatalogEndpoints(this WebApplication app)
+    {
+        app.MapGet("/api/sessions/{session}/catalog/search", async (
+            string session,
+            string? q,
+            int? limit,
+            IAudienceCatalogSearch search,
+            CancellationToken ct) =>
+        {
+            if (string.IsNullOrWhiteSpace(session))
+                return Results.BadRequest();
+            var results = await search.SearchAsync(session, q ?? string.Empty, limit ?? 25, ct);
+            return Results.Ok(results);
+        }).RequireCors("NuottiCors");
+    }
+}
+
+public static class ParticipantEndpoints
+{
+    public sealed record ModerateParticipantNameRequest(string DisplayName);
+
+    public static void MapParticipantEndpoints(this WebApplication app)
+    {
+        app.MapPost("/api/sessions/{session}/participants/{participantId}/moderate-name", (
+            string session,
+            string participantId,
+            ModerateParticipantNameRequest request,
+            IParticipantIdentityStore participants) =>
+        {
+            try
+            {
+                if (!participants.TryModerateName(session, participantId, request.DisplayName, out var moderated)
+                    || moderated is null)
+                {
+                    return Results.NotFound();
+                }
+
+                return Results.Ok(moderated);
+            }
+            catch (ArgumentException ex)
+            {
+                return Results.BadRequest(new { error = ex.Message });
+            }
+        }).RequireCors("NuottiCors");
+    }
+}
+
+public static class AudienceAnswerStatusEndpoints
+{
+    public sealed record MyAnswerResponse(int? ChoiceIndex);
+
+    public static void MapAudienceAnswerStatusEndpoints(this WebApplication app)
+    {
+        app.MapGet("/status/{session}/answer", (
+            IGameStateStore store,
+            IParticipantIdentityStore participants,
+            string session,
+            string participantId) =>
+        {
+            if (string.IsNullOrWhiteSpace(participantId)
+                || !participants.TryGet(session, participantId, out _))
+            {
+                return Results.NotFound();
+            }
+
+            if (!store.TryGet(session, out GameStateSnapshot snapshot))
+            {
+                return Results.NotFound();
+            }
+
+            snapshot.Answers.TryGetValue(participantId, out var choice);
+            return Results.Ok(new MyAnswerResponse(snapshot.Answers.ContainsKey(participantId) ? choice : null));
+        }).RequireCors("NuottiCors");
+    }
+}

--- a/Nuotti.Backend/Endpoints/PhaseEndpoints.cs
+++ b/Nuotti.Backend/Endpoints/PhaseEndpoints.cs
@@ -1,6 +1,7 @@
 using Nuotti.Backend.Commands;
 using Nuotti.Backend.Exception;
 using Nuotti.Backend.Middleware;
+using Nuotti.Backend.Sessions;
 using Nuotti.Contracts.V1.Message;
 using Nuotti.Contracts.V1.Message.Phase;
 using Nuotti.Contracts.V1.Protocol;
@@ -24,19 +25,24 @@ internal static class PhaseEndpoints
         app.MapPhaseCommand<PlaySong>("play-song");
         app.MapPhaseCommand<GiveHint>("give-hint");
         app.MapPhaseCommand<EndGame>("end-game");
+        app.MapPhaseCommand<PreparePlayback>("prepare-playback");
+        app.MapPhaseCommand<StartPlayback>("start-playback");
     }
 
     static void MapPhaseCommand<T>(this WebApplication app, string route) where T : CommandBase
     {
         app.MapPost($"/v1/message/phase/{route}/{{session}}",
-                async (HttpContext http, ISessionCommandProcessor processor, string session, T cmd) =>
+                async (HttpContext http, ISessionCommandProcessor processor,
+                    ISessionWorkspaceBinder workspaces, string session, T cmd) =>
                 {
+                    var workspaceId = workspaces.Resolve(session) ?? "legacy";
                     var result = await processor.ApplyAsync(
                         session,
                         Actor.Claimed(cmd),
                         cmd,
                         CorrelationIdMiddleware.GetCorrelationId(http),
-                        http.RequestAborted);
+                        http.RequestAborted,
+                        workspaceId);
 
                     return result.ToHttpResult();
                 })

--- a/Nuotti.Backend/Endpoints/WorkspaceEndpoints.cs
+++ b/Nuotti.Backend/Endpoints/WorkspaceEndpoints.cs
@@ -1,5 +1,6 @@
 using Nuotti.Backend.Commands;
 using Nuotti.Backend.Middleware;
+using Nuotti.Backend.Sessions;
 using Nuotti.Backend.Workspaces;
 using Nuotti.Contracts.V1.Enum;
 using Nuotti.Contracts.V1.Message.Phase;
@@ -97,7 +98,8 @@ public static class WorkspaceEndpoints
 
         app.MapPost("/v1/workspaces/{workspaceId}/sessions/{sessionCode}/create", async (
             HttpContext http, string workspaceId, string sessionCode,
-            IWorkspaceAccessStore store, ISessionCommandProcessor processor, CancellationToken ct) =>
+            IWorkspaceAccessStore store, ISessionCommandProcessor processor,
+            ISessionWorkspaceBinder sessions, CancellationToken ct) =>
         {
             var selected = await WorkspaceHttpAccess.RequireSelectedAsync(http, store, workspaceId, ct);
             if (selected.Principal is null) return Results.Unauthorized();
@@ -108,9 +110,13 @@ public static class WorkspaceEndpoints
                 IssuedByRole = Role.Performer,
                 IssuedById = selected.Principal.UserId
             };
-            return (await processor.ApplyAsync(sessionCode,
+            var result = await processor.ApplyAsync(sessionCode,
                 Actor.Verified(Role.Performer, selected.Principal.UserId), command,
-                CorrelationIdMiddleware.GetCorrelationId(http), ct, workspaceId)).ToHttpResult();
+                CorrelationIdMiddleware.GetCorrelationId(http), ct, workspaceId);
+            if (result.Outcome is Nuotti.Contracts.V1.Protocol.Outcome.Applied
+                or Nuotti.Contracts.V1.Protocol.Outcome.Duplicate)
+                sessions.Bind(sessionCode, workspaceId);
+            return result.ToHttpResult();
         });
 
         app.MapPost("/v1/workspaces/{workspaceId}/sessions/{sessionCode}/start", async (

--- a/Nuotti.Backend/Participants/InMemoryParticipantIdentityStore.cs
+++ b/Nuotti.Backend/Participants/InMemoryParticipantIdentityStore.cs
@@ -1,0 +1,116 @@
+namespace Nuotti.Backend.Participants;
+
+/// <summary>
+/// Anonymous, device-bound Audience identity scoped to one Session.
+/// </summary>
+public sealed record Participant(
+    string ParticipantId,
+    string SessionCode,
+    string DisplayName,
+    bool NameIsModerated);
+
+public interface IParticipantIdentityStore
+{
+    Participant JoinOrRestore(string sessionCode, string deviceSecret, string? displayName);
+    bool TryGet(string sessionCode, string participantId, out Participant? participant);
+    bool TryModerateName(string sessionCode, string participantId, string moderatedName, out Participant? participant);
+}
+
+public static class ParticipantNameRules
+{
+    static readonly HashSet<string> Profanity = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "damn", "hell", "crap", "stupid", "idiot", "moron", "dumb", "suck", "hate"
+    };
+
+    public static string NormalizeOrThrow(string? displayName)
+    {
+        if (string.IsNullOrWhiteSpace(displayName))
+            throw new ArgumentException("Display name is required.", nameof(displayName));
+
+        var trimmed = displayName.Trim();
+        if (trimmed.Length < 2)
+            throw new ArgumentException("Name must be at least 2 characters long.", nameof(displayName));
+        if (trimmed.Length > 20)
+            throw new ArgumentException("Name must be 20 characters or less.", nameof(displayName));
+
+        var words = trimmed.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        if (words.Any(w => Profanity.Contains(w)))
+            throw new ArgumentException("Name contains inappropriate content.", nameof(displayName));
+
+        return trimmed;
+    }
+}
+
+public sealed class InMemoryParticipantIdentityStore : IParticipantIdentityStore
+{
+    readonly object _gate = new();
+    readonly Dictionary<(string Session, string DeviceSecret), Participant> _byDevice = new();
+    readonly Dictionary<(string Session, string ParticipantId), Participant> _byId = new();
+
+    public Participant JoinOrRestore(string sessionCode, string deviceSecret, string? displayName)
+    {
+        if (string.IsNullOrWhiteSpace(sessionCode))
+            throw new ArgumentException("Session code is required.", nameof(sessionCode));
+        if (string.IsNullOrWhiteSpace(deviceSecret))
+            throw new ArgumentException("Device secret is required.", nameof(deviceSecret));
+
+        lock (_gate)
+        {
+            var key = (sessionCode, deviceSecret);
+            if (_byDevice.TryGetValue(key, out var existing))
+            {
+                if (string.IsNullOrWhiteSpace(displayName) || existing.NameIsModerated)
+                    return existing;
+
+                var renamed = existing with { DisplayName = ParticipantNameRules.NormalizeOrThrow(displayName) };
+                _byDevice[key] = renamed;
+                _byId[(sessionCode, renamed.ParticipantId)] = renamed;
+                return renamed;
+            }
+
+            var name = string.IsNullOrWhiteSpace(displayName)
+                ? "Guest"
+                : ParticipantNameRules.NormalizeOrThrow(displayName);
+            var participant = new Participant($"part_{Guid.NewGuid():N}", sessionCode, name, NameIsModerated: false);
+            _byDevice[key] = participant;
+            _byId[(sessionCode, participant.ParticipantId)] = participant;
+            return participant;
+        }
+    }
+
+    public bool TryGet(string sessionCode, string participantId, out Participant? participant)
+    {
+        lock (_gate)
+        {
+            if (_byId.TryGetValue((sessionCode, participantId), out var found))
+            {
+                participant = found;
+                return true;
+            }
+
+            participant = null;
+            return false;
+        }
+    }
+
+    public bool TryModerateName(string sessionCode, string participantId, string moderatedName, out Participant? participant)
+    {
+        lock (_gate)
+        {
+            if (!_byId.TryGetValue((sessionCode, participantId), out var existing))
+            {
+                participant = null;
+                return false;
+            }
+
+            var name = ParticipantNameRules.NormalizeOrThrow(moderatedName);
+            var updated = existing with { DisplayName = name, NameIsModerated = true };
+            _byId[(sessionCode, participantId)] = updated;
+            foreach (var kvp in _byDevice.Where(k => k.Value.ParticipantId == participantId && k.Key.Session == sessionCode).ToList())
+                _byDevice[kvp.Key] = updated;
+            participant = updated;
+            return true;
+        }
+    }
+}

--- a/Nuotti.Backend/Persistence/SessionMessagePublisher.cs
+++ b/Nuotti.Backend/Persistence/SessionMessagePublisher.cs
@@ -19,7 +19,8 @@ public static class SessionMessagePublisher
     [
         Of<GamePhaseChanged>(), Of<CorrectAnswerRevealed>(), Of<HintGiven>(),
         Of<CatalogUpdated>(), Of<QuestionOffered>(), Of<AnswerSubmitted>(), Of<GameStateChanged>(),
-        Of<QuestionPushed>(false), Of<PlayTrack>(false), Of<StopTrack>(false)
+        Of<QuestionPushed>(false), Of<PlayTrack>(false), Of<StopTrack>(false),
+        Of<PreparePlayback>(false)
     ];
 
     static readonly IReadOnlyDictionary<Type, Entry> ByType = Entries.ToDictionary(entry => entry.Type);
@@ -42,6 +43,9 @@ public static class SessionMessagePublisher
             await bus.PublishAsync(new WorkspacePublication(workspaceId, sessionCode, message), cancellationToken);
         }
     }
+
+    public static bool IsDurable(object message)
+        => ByType.TryGetValue(message.GetType(), out var entry) && entry.Durable;
 
     public static (string Type, string Payload) SerializeDurable(object message)
     {

--- a/Nuotti.Backend/Program.cs
+++ b/Nuotti.Backend/Program.cs
@@ -1,4 +1,5 @@
 using Nuotti.Backend;
+using Nuotti.Backend.Catalog;
 using Nuotti.Backend.Commands;
 using Nuotti.Backend.Endpoints;
 using Nuotti.Backend.Eventing;
@@ -8,6 +9,7 @@ using Nuotti.Backend.Idempotency;
 using Nuotti.Backend.InfrastructureProof;
 using Nuotti.Backend.Metrics;
 using Nuotti.Backend.Models;
+using Nuotti.Backend.Participants;
 using Nuotti.Backend.Persistence;
 using Nuotti.Backend.Sessions;
 using Nuotti.Backend.Workspaces;
@@ -122,6 +124,9 @@ builder.Services.AddSingleton<ISessionStore, InMemorySessionStore>();
 builder.Services.AddSingleton<IGameStateStore, InMemoryGameStateStore>();
 builder.Services.AddSingleton<IIdempotencyStore, InMemoryIdempotencyStore>();
 builder.Services.AddSingleton<ISessionWorkspaceBinder, InMemorySessionWorkspaceBinder>();
+builder.Services.AddSingleton<IParticipantIdentityStore, InMemoryParticipantIdentityStore>();
+builder.Services.AddSingleton<ISharedSongCatalog, InMemorySharedSongCatalog>();
+builder.Services.AddSingleton<IAudienceCatalogSearch, AudienceCatalogSearch>();
 if (!string.IsNullOrWhiteSpace(databaseConnection))
 {
     builder.Services.AddSingleton<IWorkspaceAccessStore, PostgresWorkspaceAccessStore>();
@@ -215,6 +220,12 @@ app.MapHub<WorkspaceHub>(app.Environment.IsDevelopment() ? "/workspace-hub" : "/
     .RequireCors("NuottiCors");
 app.MapHealthEndpoints();
 if (app.Environment.IsDevelopment()) app.MapStatusEndpoints();
+if (app.Environment.IsDevelopment())
+{
+    app.MapAudienceCatalogEndpoints();
+    app.MapParticipantEndpoints();
+    app.MapAudienceAnswerStatusEndpoints();
+}
 app.MapMetricsEndpoints();
 app.MapAboutEndpoints();
 app.MapTimeEndpoints();

--- a/Nuotti.Backend/Program.cs
+++ b/Nuotti.Backend/Program.cs
@@ -121,6 +121,7 @@ builder.Services.AddSingleton<IMagicLinkDelivery, HttpMagicLinkDelivery>();
 builder.Services.AddSingleton<ISessionStore, InMemorySessionStore>();
 builder.Services.AddSingleton<IGameStateStore, InMemoryGameStateStore>();
 builder.Services.AddSingleton<IIdempotencyStore, InMemoryIdempotencyStore>();
+builder.Services.AddSingleton<ISessionWorkspaceBinder, InMemorySessionWorkspaceBinder>();
 if (!string.IsNullOrWhiteSpace(databaseConnection))
 {
     builder.Services.AddSingleton<IWorkspaceAccessStore, PostgresWorkspaceAccessStore>();

--- a/Nuotti.Backend/QuizHub.cs
+++ b/Nuotti.Backend/QuizHub.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.SignalR;
 using Nuotti.Backend.Commands;
+using Nuotti.Backend.Participants;
 using Nuotti.Backend.RateLimiting;
 using Nuotti.Backend.Sessions;
 using Nuotti.Contracts.V1.Enum;
@@ -14,10 +15,12 @@ public class QuizHub(
     ILogStreamer log,
     ISessionStore sessions,
     ISessionCommandProcessor processor,
+    IParticipantIdentityStore participants,
     ISessionWorkspaceBinder? workspaces = null) : Hub
 {
     const string SessionKey = "session";
     const string RoleKey = "role";
+    const string ParticipantKey = "participantId";
 
     // Engine reports status changes via hub; broadcast to entire session
     public Task EngineStatusChanged(string session, EngineStatusChanged evt)
@@ -31,7 +34,7 @@ public class QuizHub(
     public Task Echo(string session, long clientTicks, long engineTicks)
         => Clients.Group($"{session}:performer").SendAsync("Echo", clientTicks, engineTicks);
 
-    public async Task Join(string session, string role, string? name = null)
+    public async Task Join(string session, string role, string? name, string? deviceSecret)
     {
         if (string.IsNullOrWhiteSpace(session))
         {
@@ -57,38 +60,80 @@ public class QuizHub(
         Context.Items[SessionKey] = session;
         Context.Items[RoleKey] = normalizedRole;
 
+        string? participantId = null;
+        string? displayName = name;
+        if (string.Equals(normalizedRole, "audience", StringComparison.OrdinalIgnoreCase))
+        {
+            if (string.IsNullOrWhiteSpace(deviceSecret))
+            {
+                await SendProblemAsync(NuottiProblem.BadRequest(
+                    title: "Device identity required",
+                    detail: "Audience joins require a device-bound secret for Session-scoped reconnect.",
+                    reason: ReasonCode.InvalidStateTransition,
+                    field: "deviceSecret"));
+                return;
+            }
+
+            try
+            {
+                var participant = participants.JoinOrRestore(session, deviceSecret, name);
+                participantId = participant.ParticipantId;
+                displayName = participant.DisplayName;
+                Context.Items[ParticipantKey] = participantId;
+            }
+            catch (ArgumentException ex)
+            {
+                await SendProblemAsync(NuottiProblem.BadRequest(
+                    title: "Invalid display name",
+                    detail: ex.Message,
+                    reason: ReasonCode.InvalidStateTransition,
+                    field: "name"));
+                return;
+            }
+        }
+
         // Join session-wide group and session+role group
         await Groups.AddToGroupAsync(Context.ConnectionId, session);
         await Groups.AddToGroupAsync(Context.ConnectionId, $"{session}:{normalizedRole.ToLowerInvariant()}");
         // Track connection by role in the session store
-        sessions.Touch(session, normalizedRole, Context.ConnectionId, name);
+        sessions.Touch(session, normalizedRole, Context.ConnectionId, displayName);
 
         // Send server time to client for time drift detection
         var serverTime = DateTimeOffset.UtcNow;
         await Clients.Caller.SendAsync("ServerTime", serverTime.Ticks, serverTime.ToString("O"));
 
-        logger.LogInformation("Join: conn={ConnectionId} session={Session} role={Role} name={Name}", Context.ConnectionId, session, role, name);
+        if (participantId is not null)
+        {
+            await Clients.Caller.SendAsync("ParticipantRestored", new
+            {
+                ParticipantId = participantId,
+                SessionCode = session,
+                DisplayName = displayName
+            });
+        }
+
+        logger.LogInformation("Join: conn={ConnectionId} session={Session} role={Role} name={Name} participant={ParticipantId}",
+            Context.ConnectionId, session, role, displayName, participantId);
         await log.BroadcastAsync(new LogEvent(
             Timestamp: DateTimeOffset.UtcNow,
             Level: "Info",
             Source: nameof(QuizHub),
-            Message: $"Join: name={name}",
+            Message: $"Join: name={displayName}",
             ConnectionId: Context.ConnectionId,
             Session: session,
             Role: role
         ));
 
-        if (!string.IsNullOrWhiteSpace(name))
+        if (!string.IsNullOrWhiteSpace(displayName) && string.Equals(normalizedRole, "audience", StringComparison.OrdinalIgnoreCase))
         {
-            await Clients.Group(session).SendAsync("JoinedAudience", new JoinedAudience(Context.ConnectionId, name));
+            await Clients.Group(session).SendAsync("JoinedAudience",
+                new JoinedAudience(participantId ?? Context.ConnectionId, displayName));
         }
     }
 
-    public Task CreateOrJoinWithName(string session, string audienceName) => Join(session, role: "audience", name: audienceName);
+    public Task CreateOrJoinWithName(string session, string audienceName, string deviceSecret)
+        => Join(session, role: "audience", name: audienceName, deviceSecret: deviceSecret);
 
-    // // Compatibility shim for older clients (e.g., AudioEngine) that invoke 'CreateOrJoin'
-    // public Task CreateOrJoin(string session) => Join(session, role: "engine");
-    //
     public async override Task OnConnectedAsync()
     {
         await base.OnConnectedAsync();
@@ -128,16 +173,13 @@ public class QuizHub(
             Session: session,
             Role: role
         ));
-        // Remove from the session store
         sessions.Remove(Context.ConnectionId);
         await base.OnDisconnectedAsync(exception);
     }
 
-    // Emit a NuottiProblem to the calling client
     Task SendProblemAsync(NuottiProblem problem)
         => Clients.Caller.SendAsync("Problem", problem);
 
-    // Audience can ask the projector to play a track. Projector will then call the REST API to actually play.
     public async Task RequestPlay(string session, PlayTrack cmd)
     {
         var role = Context.Items.TryGetValue(RoleKey, out var roleObj) ? roleObj as string : null;
@@ -151,7 +193,6 @@ public class QuizHub(
             return;
         }
 
-        // Rate limit play/stop actions to 1 per 2 seconds per connection
         if (!ConnectionRateLimiter.TryAllow(Context.ConnectionId, "PlayStop", TimeSpan.FromSeconds(2)))
         {
             await SendProblemAsync(new NuottiProblem(
@@ -178,10 +219,9 @@ public class QuizHub(
         await Clients.Group(session).SendAsync("RequestPlay", cmd);
     }
 
-    // Audience submits answer choice
-    public async Task SubmitAnswer(string session, int choiceIndex)
+    // Audience submits an answer. Pass Guid.Empty to mint a fresh CommandId; otherwise retry with the same id.
+    public async Task SubmitAnswer(string session, int choiceIndex, Guid commandId)
     {
-        // Only audience members may submit answers
         var role = Context.Items.TryGetValue(RoleKey, out var roleObj) ? roleObj as string : null;
         if (!string.Equals(role, "audience", StringComparison.OrdinalIgnoreCase))
         {
@@ -193,7 +233,6 @@ public class QuizHub(
             return;
         }
 
-        // Debounce SubmitAnswer per-connection with 500ms window
         if (!ConnectionRateLimiter.TryAllow(Context.ConnectionId, "SubmitAnswer", TimeSpan.FromMilliseconds(500)))
         {
             await SendProblemAsync(new NuottiProblem(
@@ -206,25 +245,36 @@ public class QuizHub(
             return;
         }
 
-        var audienceId = Context.ConnectionId;
+        var audienceId = Context.Items.TryGetValue(ParticipantKey, out var partObj) && partObj is string partId
+            ? partId
+            : Context.ConnectionId;
+        var resolvedCommandId = commandId == Guid.Empty ? Guid.NewGuid() : commandId;
         var cmd = new SubmitAnswer(SongId: null, ChoiceIndex: choiceIndex)
         {
             SessionCode = session,
             IssuedByRole = Role.Audience,
-            IssuedById = audienceId
+            IssuedById = audienceId,
+            CommandId = resolvedCommandId
         };
 
-        logger.LogInformation("SubmitAnswer: conn={ConnectionId} session={Session} choiceIndex={ChoiceIndex} CommandId={CommandId}",
-            Context.ConnectionId, session, choiceIndex, cmd.CommandId);
+        logger.LogInformation("SubmitAnswer: conn={ConnectionId} session={Session} choiceIndex={ChoiceIndex} CommandId={CommandId} audience={AudienceId}",
+            Context.ConnectionId, session, choiceIndex, cmd.CommandId, audienceId);
 
-        // The role came from Join, so the server established it — unlike an HTTP caller, who merely
-        // claims one in the request body. Resolve Workspace so durable state matches CreateSession.
         var workspaceId = workspaces?.Resolve(session) ?? "legacy";
         var result = await processor.ApplyAsync(session, Actor.Verified(Role.Audience, audienceId), cmd,
             workspaceId: workspaceId);
         if (result.Problem is not null)
         {
             await SendProblemAsync(result.Problem);
+        }
+        else
+        {
+            await Clients.Caller.SendAsync("AnswerAccepted", new
+            {
+                CommandId = cmd.CommandId,
+                ChoiceIndex = choiceIndex,
+                Outcome = result.Outcome.ToString()
+            });
         }
     }
 }

--- a/Nuotti.Backend/QuizHub.cs
+++ b/Nuotti.Backend/QuizHub.cs
@@ -13,7 +13,8 @@ public class QuizHub(
     ILogger<QuizHub> logger,
     ILogStreamer log,
     ISessionStore sessions,
-    ISessionCommandProcessor processor) : Hub
+    ISessionCommandProcessor processor,
+    ISessionWorkspaceBinder? workspaces = null) : Hub
 {
     const string SessionKey = "session";
     const string RoleKey = "role";
@@ -217,8 +218,10 @@ public class QuizHub(
             Context.ConnectionId, session, choiceIndex, cmd.CommandId);
 
         // The role came from Join, so the server established it — unlike an HTTP caller, who merely
-        // claims one in the request body.
-        var result = await processor.ApplyAsync(session, Actor.Verified(Role.Audience, audienceId), cmd);
+        // claims one in the request body. Resolve Workspace so durable state matches CreateSession.
+        var workspaceId = workspaces?.Resolve(session) ?? "legacy";
+        var result = await processor.ApplyAsync(session, Actor.Verified(Role.Audience, audienceId), cmd,
+            workspaceId: workspaceId);
         if (result.Problem is not null)
         {
             await SendProblemAsync(result.Problem);

--- a/Nuotti.Backend/Sessions/ISessionWorkspaceBinder.cs
+++ b/Nuotti.Backend/Sessions/ISessionWorkspaceBinder.cs
@@ -1,0 +1,31 @@
+namespace Nuotti.Backend.Sessions;
+
+/// <summary>
+/// Remembers which Workspace owns a live Session code so phase and relay endpoints can
+/// publish WorkspacePublication (Show Agent fan-out) and commit to the durable store
+/// under the same key CreateSession used.
+/// </summary>
+public interface ISessionWorkspaceBinder
+{
+    void Bind(string sessionCode, string workspaceId);
+    string? Resolve(string sessionCode);
+}
+
+public sealed class InMemorySessionWorkspaceBinder : ISessionWorkspaceBinder
+{
+    readonly Dictionary<string, string> _map = new(StringComparer.OrdinalIgnoreCase);
+    readonly object _gate = new();
+
+    public void Bind(string sessionCode, string workspaceId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(sessionCode);
+        ArgumentException.ThrowIfNullOrWhiteSpace(workspaceId);
+        lock (_gate) _map[sessionCode.Trim()] = workspaceId.Trim();
+    }
+
+    public string? Resolve(string sessionCode)
+    {
+        if (string.IsNullOrWhiteSpace(sessionCode)) return null;
+        lock (_gate) return _map.TryGetValue(sessionCode.Trim(), out var workspaceId) ? workspaceId : null;
+    }
+}

--- a/Nuotti.Backend/ShowAgents/InMemoryShowAgentAccessStore.cs
+++ b/Nuotti.Backend/ShowAgents/InMemoryShowAgentAccessStore.cs
@@ -137,7 +137,13 @@ public sealed class InMemoryShowAgentAccessStore(TimeProvider? timeProvider = nu
             list.Add(new ShowAgentCommand(sequence, messageType, payload));
             // Playback commands describe desired state. While an Agent is offline only the newest
             // Play/Stop intent is meaningful; replaying intermediate tracks would be harmful.
-            if (list.Count > 1) list.RemoveRange(0, list.Count - 1);
+            // Prepare and other control messages must survive until acknowledged.
+            if (messageType is "PlayTrack" or "StopTrack")
+            {
+                var olderPlayback = list.Where(c => c.MessageType is "PlayTrack" or "StopTrack"
+                    && c.Sequence < sequence).ToArray();
+                foreach (var stale in olderPlayback) list.Remove(stale);
+            }
             return Task.CompletedTask;
         }
     }

--- a/Nuotti.Backend/ShowAgents/PostgresShowAgentAccessStore.cs
+++ b/Nuotti.Backend/ShowAgents/PostgresShowAgentAccessStore.cs
@@ -102,7 +102,9 @@ public sealed class PostgresShowAgentAccessStore(NpgsqlDataSource dataSource, Ti
             Payload = JsonSerializer.SerializeToElement(payload, payload.GetType())
         });
         // Compact offline playback to the latest desired Play/Stop state.
-        if (commands.Count > 1) commands.RemoveRange(0, commands.Count - 1);
+        // Prepare and other control messages must survive until acknowledged.
+        if (messageType is "PlayTrack" or "StopTrack")
+            commands.RemoveAll(c => c.MessageType is "PlayTrack" or "StopTrack" && c.Sequence < sequence);
         return null;
     }, cancellationToken);
 

--- a/Nuotti.Backend/ShowAgents/ShowAgentCommandSubscriber.cs
+++ b/Nuotti.Backend/ShowAgents/ShowAgentCommandSubscriber.cs
@@ -16,6 +16,7 @@ public sealed class ShowAgentCommandSubscriber : IDisposable
             {
                 PlayTrack => "PlayTrack",
                 StopTrack => "StopTrack",
+                PreparePlayback => "Prepare",
                 _ => null
             };
             if (messageType is not null)

--- a/Nuotti.Contracts.Tests/V1/Model/ScoringAndRankingTests.cs
+++ b/Nuotti.Contracts.Tests/V1/Model/ScoringAndRankingTests.cs
@@ -1,0 +1,66 @@
+using Nuotti.Contracts.V1.Enum;
+using Nuotti.Contracts.V1.Model;
+
+namespace Nuotti.Contracts.Tests.V1.Model;
+
+public class ScoringCalculatorTests
+{
+    readonly ScoringPolicy _policy = ScoringPolicy.Standard;
+
+    [Fact]
+    public void Immediate_correct_answer_earns_ceiling()
+    {
+        var opened = DateTime.UtcNow;
+        var points = ScoringCalculator.PointsForCorrect(_policy, opened, opened);
+        Assert.Equal(1500, points);
+    }
+
+    [Fact]
+    public void Answer_after_speed_window_earns_correct_floor()
+    {
+        var opened = DateTime.UtcNow;
+        var points = ScoringCalculator.PointsForCorrect(_policy, opened, opened.AddMilliseconds(10_000));
+        Assert.Equal(1000, points);
+    }
+
+    [Fact]
+    public void Mid_window_answer_decays_bonus()
+    {
+        var opened = DateTime.UtcNow;
+        var points = ScoringCalculator.PointsForCorrect(_policy, opened, opened.AddMilliseconds(5_000));
+        Assert.Equal(1250, points);
+    }
+
+    [Fact]
+    public void Preserved_earlier_correctness_wins()
+    {
+        var opened = DateTime.UtcNow;
+        var points = ScoringCalculator.PointsForCorrect(_policy, opened, opened.AddMinutes(1), preservedPoints: 1500);
+        Assert.Equal(1500, points);
+    }
+}
+
+public class GameStateSnapshotViewsRankingTests
+{
+    [Fact]
+    public void TopPlayers_uses_shared_tie_ranks()
+    {
+        var state = new GameStateSnapshot("S", Phase.Reveal, 0, scores: new Dictionary<string, int>
+        {
+            ["a"] = 10,
+            ["b"] = 10,
+            ["c"] = 5,
+            ["d"] = 3
+        });
+
+        var top = state.TopPlayers(10);
+        Assert.Equal(4, top.Count);
+        Assert.Equal(1, top[0].Rank);
+        Assert.Equal(1, top[1].Rank);
+        Assert.Equal(3, top[2].Rank);
+        Assert.Equal(4, top[3].Rank);
+        Assert.Equal(10, top[0].Score);
+        Assert.Equal(10, top[1].Score);
+        Assert.Equal(5, top[2].Score);
+    }
+}

--- a/Nuotti.Contracts.Tests/V1/Reducer/GameReducerTests.cs
+++ b/Nuotti.Contracts.Tests/V1/Reducer/GameReducerTests.cs
@@ -296,6 +296,46 @@ public class GameReducerTests
     }
 
     [Fact]
+    public void AnswerSubmitted_revise_moves_tally_to_final_choice()
+    {
+        var state = new GameStateSnapshot(
+            sessionCode: "S",
+            phase: Phase.Guessing,
+            songIndex: 1,
+            currentSong: null,
+            choices: new[] { "A", "B", "C" },
+            hintIndex: 0,
+            tallies: new[] { 0, 0, 0 },
+            scores: null,
+            songStartedAtUtc: null);
+
+        (state, var err) = GameReducer.Reduce(state, new AnswerSubmitted("aud-1", 0)
+        {
+            AudienceId = "aud-1",
+            ChoiceIndex = 0,
+            SessionCode = state.SessionCode,
+            EmittedAtUtc = DateTime.UtcNow,
+            CorrelationId = Guid.Empty,
+            CausedByCommandId = Guid.Empty
+        });
+        Assert.Null(err);
+
+        (state, err) = GameReducer.Reduce(state, new AnswerSubmitted("aud-1", 2)
+        {
+            AudienceId = "aud-1",
+            ChoiceIndex = 2,
+            SessionCode = state.SessionCode,
+            EmittedAtUtc = DateTime.UtcNow,
+            CorrelationId = Guid.Empty,
+            CausedByCommandId = Guid.Empty
+        });
+
+        Assert.Null(err);
+        Assert.Equal(new[] { 0, 0, 1 }, state.Tallies);
+        Assert.Equal(2, state.Answers["aud-1"]);
+    }
+
+    [Fact]
     public void AnswerSubmitted_ignored_when_not_Guessing()
     {
         var state = new GameStateSnapshot(

--- a/Nuotti.Contracts.Tests/V1/Reducer/ProgressiveWindowScoringTests.cs
+++ b/Nuotti.Contracts.Tests/V1/Reducer/ProgressiveWindowScoringTests.cs
@@ -1,0 +1,122 @@
+using Nuotti.Contracts.V1.Enum;
+using Nuotti.Contracts.V1.Event;
+using Nuotti.Contracts.V1.Model;
+using Nuotti.Contracts.V1.Reducer;
+
+namespace Nuotti.Contracts.Tests.V1.Reducer;
+
+public class ProgressiveWindowScoringTests
+{
+    [Fact]
+    public void CorrectAnswerRevealed_is_idempotent_once_finalized()
+    {
+        var state = GuessingState(ScoringPolicy.Standard);
+        (state, _) = GameReducer.Reduce(state, Answer("p1", 0, state));
+        (state, _) = GameReducer.Reduce(state, Reveal(0, state));
+        Assert.True(state.ScoresFinalized);
+        Assert.Equal(1500, state.Scores["p1"]);
+
+        var (again, err) = GameReducer.Reduce(state, Reveal(0, state));
+        Assert.Null(err);
+        Assert.Equal(1500, again.Scores["p1"]);
+    }
+
+    [Fact]
+    public void Preserved_earlier_correctness_is_not_penalized_by_later_receipt()
+    {
+        var opened = DateTime.UtcNow.AddSeconds(-30);
+        var early = opened; // t=0 → ceiling
+        var state = GuessingState(ScoringPolicy.Standard) with { GuessingWindowOpenedAtUtc = opened };
+        (state, _) = GameReducer.Reduce(state, Answer("p1", 0, state, early));
+        (state, _) = GameReducer.Reduce(state, new GamePhaseChanged(Phase.Guessing, Phase.Lock)
+        {
+            CurrentPhase = Phase.Guessing,
+            NewPhase = Phase.Lock,
+            SessionCode = state.SessionCode,
+            EmittedAtUtc = DateTime.UtcNow,
+            CorrelationId = Guid.Empty,
+            CausedByCommandId = Guid.Empty
+        });
+        // Later Window: same correct choice with a late receipt — Lock keeps the early timestamp.
+        (state, _) = GameReducer.Reduce(state, new GamePhaseChanged(Phase.Lock, Phase.Guessing)
+        {
+            CurrentPhase = Phase.Lock,
+            NewPhase = Phase.Guessing,
+            SessionCode = state.SessionCode,
+            EmittedAtUtc = DateTime.UtcNow,
+            CorrelationId = Guid.Empty,
+            CausedByCommandId = Guid.Empty
+        });
+        state = state with
+        {
+            GuessingWindowOpenedAtUtc = opened,
+            Answers = System.Collections.Frozen.FrozenDictionary<string, int>.Empty,
+            AnswerReceivedAtUtc = System.Collections.Frozen.FrozenDictionary<string, DateTime>.Empty
+        };
+        (state, _) = GameReducer.Reduce(state, Answer("p1", 0, state, opened.AddSeconds(25)));
+        (state, _) = GameReducer.Reduce(state, new GamePhaseChanged(Phase.Guessing, Phase.Lock)
+        {
+            CurrentPhase = Phase.Guessing,
+            NewPhase = Phase.Lock,
+            SessionCode = state.SessionCode,
+            EmittedAtUtc = DateTime.UtcNow,
+            CorrelationId = Guid.Empty,
+            CausedByCommandId = Guid.Empty
+        });
+        (state, _) = GameReducer.Reduce(state, Reveal(0, state));
+        Assert.Equal(1500, state.Scores["p1"]);
+    }
+
+    [Fact]
+    public void Answers_outside_Guessing_do_not_count_after_Lock()
+    {
+        var state = GuessingState(null);
+        (state, _) = GameReducer.Reduce(state, Answer("p1", 0, state));
+        (state, _) = GameReducer.Reduce(state, new GamePhaseChanged(Phase.Guessing, Phase.Lock)
+        {
+            CurrentPhase = Phase.Guessing,
+            NewPhase = Phase.Lock,
+            SessionCode = state.SessionCode,
+            EmittedAtUtc = DateTime.UtcNow,
+            CorrelationId = Guid.Empty,
+            CausedByCommandId = Guid.Empty
+        });
+        var lockedChoice = state.Answers["p1"];
+        (state, _) = GameReducer.Reduce(state, Answer("p1", 1, state));
+        Assert.Equal(lockedChoice, state.Answers["p1"]);
+    }
+
+    static GameStateSnapshot GuessingState(ScoringPolicy? policy) =>
+        new GameStateSnapshot(
+            sessionCode: "S",
+            phase: Phase.Guessing,
+            songIndex: 0,
+            choices: ["A", "B"],
+            tallies: [0, 0],
+            scores: null) with
+        {
+            ScoringPolicy = policy,
+            GuessingWindowSeconds = 30,
+            GuessingWindowOpenedAtUtc = DateTime.UtcNow
+        };
+
+    static AnswerSubmitted Answer(string id, int choice, GameStateSnapshot state, DateTime? at = null) =>
+        new(id, choice)
+        {
+            AudienceId = id,
+            ChoiceIndex = choice,
+            SessionCode = state.SessionCode,
+            EmittedAtUtc = at ?? DateTime.UtcNow,
+            CorrelationId = Guid.Empty,
+            CausedByCommandId = Guid.Empty
+        };
+
+    static CorrectAnswerRevealed Reveal(int correct, GameStateSnapshot state) => new(correct)
+    {
+        CorrectChoiceIndex = correct,
+        SessionCode = state.SessionCode,
+        EmittedAtUtc = DateTime.UtcNow,
+        CorrelationId = Guid.Empty,
+        CausedByCommandId = Guid.Empty
+    };
+}

--- a/Nuotti.Contracts/V1/Message/Phase/OpenAnswers.cs
+++ b/Nuotti.Contracts/V1/Message/Phase/OpenAnswers.cs
@@ -1,20 +1,20 @@
 namespace Nuotti.Contracts.V1.Message.Phase;
 
 /// <summary>
-/// Opens the answer window, moving the session into Guessing.
-/// Allowed phases: Start, Hint.
+/// Opens a Guessing Window. Duration must be 10–120 seconds (default 30).
+/// Allowed after Start/Hint, and after Lock to open another Window in the same Round.
 /// </summary>
-/// <remarks>
-/// Without this there was no command at all that reached Guessing, so a session could be started
-/// and then never driven any further: LockAnswers, NextRound and SubmitAnswer all require Guessing,
-/// and nothing produced it.
-/// </remarks>
-public sealed record OpenAnswers : CommandBase, IPhaseRestricted, IPhaseChange
+public sealed record OpenAnswers(int WindowSeconds = 30) : CommandBase, IPhaseRestricted, IPhaseChange
 {
+    public int WindowSeconds { get; } = WindowSeconds;
+
     public IReadOnlyCollection<Enum.Phase> AllowedPhases { get; } =
-        [Enum.Phase.Start, Enum.Phase.Hint];
+        [Enum.Phase.Start, Enum.Phase.Hint, Enum.Phase.Lock];
 
     public Enum.Phase TargetPhase => Enum.Phase.Guessing;
-    public IReadOnlyCollection<Enum.Phase> AllowedSourcePhases => [Enum.Phase.Start, Enum.Phase.Hint];
+    public IReadOnlyCollection<Enum.Phase> AllowedSourcePhases =>
+        [Enum.Phase.Start, Enum.Phase.Hint, Enum.Phase.Lock];
     public bool IsPhaseChangeAllowed(Enum.Phase current) => AllowedSourcePhases.Contains(current);
+
+    public static int ClampWindowSeconds(int seconds) => Math.Clamp(seconds <= 0 ? 30 : seconds, 10, 120);
 }

--- a/Nuotti.Contracts/V1/Message/PreparePlayback.cs
+++ b/Nuotti.Contracts/V1/Message/PreparePlayback.cs
@@ -1,0 +1,13 @@
+using Nuotti.Contracts.V1.Message.Phase;
+
+namespace Nuotti.Contracts.V1.Message;
+
+/// <summary>
+/// Performer asks the paired Show Agent to verify the Session Setlist Snapshot cache
+/// (backing/click) before Start. Relay — no phase change.
+/// Allowed phases: Reveal.
+/// </summary>
+public sealed record PreparePlayback : CommandBase, IPhaseRestricted
+{
+    public IReadOnlyCollection<Enum.Phase> AllowedPhases { get; } = [Enum.Phase.Reveal];
+}

--- a/Nuotti.Contracts/V1/Message/StartPlayback.cs
+++ b/Nuotti.Contracts/V1/Message/StartPlayback.cs
@@ -1,0 +1,20 @@
+using Nuotti.Contracts.V1.Message.Phase;
+using Nuotti.Contracts.V1.Model;
+
+namespace Nuotti.Contracts.V1.Message;
+
+/// <summary>
+/// Performer starts cached venue playback: moves Reveal → Play and relays a PlayTrack
+/// resolved from the Session Setlist Snapshot asset revision.
+/// </summary>
+public sealed record StartPlayback(SongId SongId, string AssetRevisionId) : CommandBase, IPhaseRestricted, IPhaseChange
+{
+    public SongId SongId { get; } = SongId;
+    public string AssetRevisionId { get; } = AssetRevisionId;
+
+    public IReadOnlyCollection<Enum.Phase> AllowedPhases { get; } = [Enum.Phase.Reveal];
+
+    public Enum.Phase TargetPhase => Enum.Phase.Play;
+    public IReadOnlyCollection<Enum.Phase> AllowedSourcePhases => [Enum.Phase.Reveal];
+    public bool IsPhaseChangeAllowed(Enum.Phase current) => AllowedSourcePhases.Contains(current);
+}

--- a/Nuotti.Contracts/V1/Model/GameStateSnapshot.cs
+++ b/Nuotti.Contracts/V1/Model/GameStateSnapshot.cs
@@ -60,6 +60,52 @@ public sealed record GameStateSnapshot
     public IReadOnlyDictionary<string, int> Answers { get; init; } = FrozenDictionary<string, int>.Empty;
 
     /// <summary>
+    /// Receipt times for the current window's answers. Internal; not serialized.
+    /// </summary>
+    [JsonIgnore]
+    public IReadOnlyDictionary<string, DateTime> AnswerReceivedAtUtc { get; init; } =
+        FrozenDictionary<string, DateTime>.Empty;
+
+    /// <summary>
+    /// Earliest receipt times locked for the current Round (survives subsequent Windows).
+    /// </summary>
+    [JsonIgnore]
+    public IReadOnlyDictionary<string, DateTime> LockedAnswerReceivedAtUtc { get; init; } =
+        FrozenDictionary<string, DateTime>.Empty;
+
+    /// <summary>
+    /// Locked choice at the last Lock for the current Round.
+    /// </summary>
+    [JsonIgnore]
+    public IReadOnlyDictionary<string, int> LockedAnswers { get; init; } =
+        FrozenDictionary<string, int>.Empty;
+
+    /// <summary>
+    /// When true, Reveal has finalized scores for the current Round — further CorrectAnswerRevealed events are no-ops.
+    /// </summary>
+    public bool ScoresFinalized { get; init; }
+
+    /// <summary>
+    /// Configured Guessing Window length in seconds (10–120).
+    /// </summary>
+    public int GuessingWindowSeconds { get; init; } = 30;
+
+    /// <summary>
+    /// Absolute UTC deadline for the active Guessing Window, if any.
+    /// </summary>
+    public DateTime? GuessingWindowDeadlineUtc { get; init; }
+
+    /// <summary>
+    /// UTC when the active Guessing Window opened (for time-decayed scoring).
+    /// </summary>
+    public DateTime? GuessingWindowOpenedAtUtc { get; init; }
+
+    /// <summary>
+    /// Session-captured scoring policy. Null falls back to <see cref="ScoringPolicy.Standard"/>.
+    /// </summary>
+    public ScoringPolicy? ScoringPolicy { get; init; }
+
+    /// <summary>
     /// UTC timestamp when the current song started, if applicable.
     /// </summary>
     public DateTime? SongStartedAtUtc { get; init; }

--- a/Nuotti.Contracts/V1/Model/GameStateSnapshotViews.cs
+++ b/Nuotti.Contracts/V1/Model/GameStateSnapshotViews.cs
@@ -52,12 +52,26 @@ public static class GameStateSnapshotViews
         => Math.Max(1, state.HintIndex + 1);
 
     /// <summary>
-    /// The top <paramref name="count"/> players, highest score first. Ties keep dictionary order.
+    /// The top <paramref name="count"/> players, highest score first. Equal scores share a rank
+    /// (competition ranking: 10,10,5 → ranks 1,1,3).
     /// </summary>
     public static IReadOnlyList<ScoreRow> TopPlayers(this GameStateSnapshot state, int count = 10)
-        => state.Scores
+    {
+        var ordered = state.Scores
             .OrderByDescending(kvp => kvp.Value)
+            .ThenBy(kvp => kvp.Key, StringComparer.Ordinal)
             .Take(count)
-            .Select((kvp, i) => new ScoreRow(kvp.Key, kvp.Value, i + 1))
             .ToArray();
+
+        var rows = new List<ScoreRow>(ordered.Length);
+        for (var i = 0; i < ordered.Length; i++)
+        {
+            var rank = i == 0 || ordered[i].Value != ordered[i - 1].Value
+                ? i + 1
+                : rows[i - 1].Rank;
+            rows.Add(new ScoreRow(ordered[i].Key, ordered[i].Value, rank));
+        }
+
+        return rows;
+    }
 }

--- a/Nuotti.Contracts/V1/Model/ScoringPolicy.cs
+++ b/Nuotti.Contracts/V1/Model/ScoringPolicy.cs
@@ -1,0 +1,44 @@
+namespace Nuotti.Contracts.V1.Model;
+
+/// <summary>
+/// Versioned scoring parameters captured for a Session (ceilings, speed bonus, decay window).
+/// </summary>
+public sealed record ScoringPolicy(
+    string PolicyId,
+    int Version,
+    int CorrectPoints,
+    int SpeedBonusPoints,
+    long SpeedBonusWindowMs)
+{
+    public static ScoringPolicy Standard { get; } = new("standard", 1, 1000, 500, 10_000);
+}
+
+/// <summary>
+/// Pure scoring for a locked correct answer. Earlier correctness is preserved by the caller
+/// (passing a prior award skips re-calculation).
+/// </summary>
+public static class ScoringCalculator
+{
+    /// <summary>
+    /// Points for a correct answer received at <paramref name="receivedAtUtc"/> relative to the
+    /// Guessing Window open time. Decays the speed bonus over <see cref="ScoringPolicy.SpeedBonusWindowMs"/>.
+    /// </summary>
+    public static int PointsForCorrect(
+        ScoringPolicy policy,
+        DateTime windowOpenedAtUtc,
+        DateTime receivedAtUtc,
+        int? preservedPoints = null)
+    {
+        if (preservedPoints is int prior && prior > 0)
+            return prior;
+
+        var ceiling = checked(policy.CorrectPoints + policy.SpeedBonusPoints);
+        var elapsedMs = Math.Max(0d, (receivedAtUtc - windowOpenedAtUtc).TotalMilliseconds);
+        var windowMs = Math.Max(1d, policy.SpeedBonusWindowMs);
+        if (elapsedMs >= windowMs)
+            return policy.CorrectPoints;
+
+        var decayedBonus = (int)Math.Round(policy.SpeedBonusPoints * (1d - elapsedMs / windowMs));
+        return Math.Clamp(policy.CorrectPoints + decayedBonus, policy.CorrectPoints, ceiling);
+    }
+}

--- a/Nuotti.Contracts/V1/Reducer/GameReducer.cs
+++ b/Nuotti.Contracts/V1/Reducer/GameReducer.cs
@@ -38,12 +38,31 @@ public static class GameReducer
                     return (state, $"phase_mismatch: state={state.Phase}, eventCurrent={phaseChanged.CurrentPhase}");
                 }
 
-                // Apply phase change. If moving to Start (next song), reset tallies.
+                // Apply phase change. If moving to Start (next song), reset tallies and round scoring.
                 var next = state with
                 {
                     Phase = phaseChanged.NewPhase,
                     Tallies = phaseChanged.NewPhase == Phase.Start ? [] : state.Tallies,
-                    Answers = phaseChanged.NewPhase == Phase.Start ? System.Collections.Frozen.FrozenDictionary<string, int>.Empty : state.Answers
+                    Answers = phaseChanged.NewPhase == Phase.Start
+                        ? System.Collections.Frozen.FrozenDictionary<string, int>.Empty
+                        : state.Answers,
+                    AnswerReceivedAtUtc = phaseChanged.NewPhase == Phase.Start
+                        ? System.Collections.Frozen.FrozenDictionary<string, DateTime>.Empty
+                        : state.AnswerReceivedAtUtc,
+                    LockedAnswers = phaseChanged.NewPhase == Phase.Start
+                        ? System.Collections.Frozen.FrozenDictionary<string, int>.Empty
+                        : phaseChanged.NewPhase == Phase.Lock
+                            ? FreezeAnswers(state)
+                            : state.LockedAnswers,
+                    LockedAnswerReceivedAtUtc = phaseChanged.NewPhase == Phase.Start
+                        ? System.Collections.Frozen.FrozenDictionary<string, DateTime>.Empty
+                        : phaseChanged.NewPhase == Phase.Lock
+                            ? FreezeReceipts(state)
+                            : state.LockedAnswerReceivedAtUtc,
+                    ScoresFinalized = phaseChanged.NewPhase == Phase.Start ? false : state.ScoresFinalized,
+                    GuessingWindowDeadlineUtc = phaseChanged.NewPhase is Phase.Guessing
+                        ? state.GuessingWindowDeadlineUtc
+                        : null
                 };
                 return (next, null);
             }
@@ -90,46 +109,68 @@ public static class GameReducer
                 checked { tallies[idx] += 1; }
                 answers[answer.AudienceId] = idx;
 
+                var receipts = state.AnswerReceivedAtUtc.Count == 0
+                    ? new Dictionary<string, DateTime>()
+                    : new Dictionary<string, DateTime>(state.AnswerReceivedAtUtc);
+                receipts[answer.AudienceId] = answer.EmittedAtUtc;
+
                 var updated = state with
                 {
                     Tallies = tallies,
-                    Answers = answers
+                    Answers = answers,
+                    AnswerReceivedAtUtc = receipts
                 };
                 return (updated, null);
             }
             case CorrectAnswerRevealed revealed:
             {
-                // On reveal, award +1 per audience whose last submitted answer matches the correct index.
+                if (state.ScoresFinalized)
+                    return (state, null);
+
                 var correctIdx = revealed.CorrectChoiceIndex;
                 if (correctIdx < 0 || correctIdx >= state.Choices.Count)
                 {
-                    // ignore if index is invalid for current choices
                     return (state, null);
                 }
 
-                // Start from existing scores
                 var scores = state.Scores.Count == 0
                     ? new Dictionary<string, int>()
                     : new Dictionary<string, int>(state.Scores);
+                var policy = state.ScoringPolicy;
+                // Prefer Lock-held answers; fall back to live Answers when Reveal skipped Lock.
+                var heldAnswers = state.LockedAnswers.Count > 0 ? state.LockedAnswers : state.Answers;
+                var heldReceipts = state.LockedAnswerReceivedAtUtc.Count > 0
+                    ? state.LockedAnswerReceivedAtUtc
+                    : state.AnswerReceivedAtUtc;
+                var windowOpened = state.GuessingWindowOpenedAtUtc ?? revealed.EmittedAtUtc;
 
-                foreach (var kvp in state.Answers)
+                foreach (var kvp in heldAnswers)
                 {
-                    if (kvp.Value == correctIdx)
+                    if (kvp.Value != correctIdx) continue;
+
+                    int award;
+                    if (policy is null)
                     {
-                        // award +1
-                        if (scores.TryGetValue(kvp.Key, out var current))
-                        {
-                            checked { scores[kvp.Key] = current + 1; }
-                        }
-                        else
-                        {
-                            scores[kvp.Key] = 1;
-                        }
+                        award = 1;
                     }
+                    else
+                    {
+                        heldReceipts.TryGetValue(kvp.Key, out var receivedAt);
+                        if (receivedAt == default) receivedAt = revealed.EmittedAtUtc;
+                        award = ScoringCalculator.PointsForCorrect(policy, windowOpened, receivedAt);
+                    }
+
+                    if (scores.TryGetValue(kvp.Key, out var current))
+                        checked { scores[kvp.Key] = current + award; }
+                    else
+                        scores[kvp.Key] = award;
                 }
 
-                var next = state with { Scores = scores };
-                return (next, null);
+                return (state with
+                {
+                    Scores = scores,
+                    ScoresFinalized = true
+                }, null);
             }
             case HintGiven hint:
             {
@@ -176,5 +217,37 @@ public static class GameReducer
                 // Unknown events are no-ops in this reducer
                 return (state, null);
         }
+    }
+
+    static IReadOnlyDictionary<string, int> FreezeAnswers(GameStateSnapshot state)
+    {
+        var locked = state.LockedAnswers.Count == 0
+            ? new Dictionary<string, int>()
+            : new Dictionary<string, int>(state.LockedAnswers);
+        foreach (var kvp in state.Answers)
+            locked[kvp.Key] = kvp.Value;
+        return locked;
+    }
+
+    static IReadOnlyDictionary<string, DateTime> FreezeReceipts(GameStateSnapshot state)
+    {
+        var locked = state.LockedAnswerReceivedAtUtc.Count == 0
+            ? new Dictionary<string, DateTime>()
+            : new Dictionary<string, DateTime>(state.LockedAnswerReceivedAtUtc);
+        foreach (var kvp in state.Answers)
+        {
+            if (!state.AnswerReceivedAtUtc.TryGetValue(kvp.Key, out var received))
+                continue;
+            // Unchanged choice keeps the earliest receipt so later Windows do not penalize.
+            if (state.LockedAnswers.TryGetValue(kvp.Key, out var priorChoice) && priorChoice == kvp.Value
+                && locked.TryGetValue(kvp.Key, out var priorReceived) && priorReceived < received)
+            {
+                continue;
+            }
+
+            locked[kvp.Key] = received;
+        }
+
+        return locked;
     }
 }

--- a/Nuotti.Contracts/V1/Reducer/GameReducer.cs
+++ b/Nuotti.Contracts/V1/Reducer/GameReducer.cs
@@ -70,13 +70,24 @@ public static class GameReducer
                     Array.Resize(ref tallies, needed);
                 }
 
-                // Increment selected choice tally.
-                checked { tallies[idx] += 1; }
-
-                // Upsert per-audience last answer
+                // Upsert per-audience last answer. A revise moves the tally to the final choice.
                 var answers = state.Answers.Count == 0
                     ? new Dictionary<string, int>()
                     : new Dictionary<string, int>(state.Answers);
+                if (answers.TryGetValue(answer.AudienceId, out var previousIdx))
+                {
+                    if (previousIdx == idx)
+                    {
+                        return (state, null);
+                    }
+
+                    if (previousIdx >= 0 && previousIdx < tallies.Length && tallies[previousIdx] > 0)
+                    {
+                        tallies[previousIdx] -= 1;
+                    }
+                }
+
+                checked { tallies[idx] += 1; }
                 answers[answer.AudienceId] = idx;
 
                 var updated = state with

--- a/Nuotti.Performer/PerformerClient.cs
+++ b/Nuotti.Performer/PerformerClient.cs
@@ -63,7 +63,7 @@ public sealed class PerformerClient : IAsyncDisposable
         {
             await _hub.StartAsync(cancellationToken);
             ConnectedChanged?.Invoke(IsConnected);
-            await _hub.InvokeAsync("Join", _sessionCode, "performer", null, cancellationToken);
+            await _hub.InvokeAsync("Join", _sessionCode, "performer", null, null, cancellationToken);
         }
     }
 

--- a/Nuotti.Performer/PerformerCommands.cs
+++ b/Nuotti.Performer/PerformerCommands.cs
@@ -111,6 +111,42 @@ public sealed class PerformerCommands
         await SendAsync("give-hint", cmd, ct);
     }
 
+    public async Task OpenAnswersAsync(CancellationToken ct = default)
+    {
+        EnsureSession();
+        var cmd = new OpenAnswers
+        {
+            SessionCode = _state.SessionCode!,
+            IssuedByRole = Role.Performer,
+            IssuedById = "performer-ui"
+        };
+        await SendAsync("open-answers", cmd, ct);
+    }
+
+    public async Task PreparePlaybackAsync(CancellationToken ct = default)
+    {
+        EnsureSession();
+        var cmd = new PreparePlayback
+        {
+            SessionCode = _state.SessionCode!,
+            IssuedByRole = Role.Performer,
+            IssuedById = "performer-ui"
+        };
+        await SendAsync("prepare-playback", cmd, ct);
+    }
+
+    public async Task StartPlaybackAsync(SongId songId, string assetRevisionId, CancellationToken ct = default)
+    {
+        EnsureSession();
+        var cmd = new StartPlayback(songId, assetRevisionId)
+        {
+            SessionCode = _state.SessionCode!,
+            IssuedByRole = Role.Performer,
+            IssuedById = "performer-ui"
+        };
+        await SendAsync("start-playback", cmd, ct);
+    }
+
     void EnsureSession()
     {
         if (string.IsNullOrWhiteSpace(_state.SessionCode)) throw new InvalidOperationException("Session not set");

--- a/Nuotti.Performer/PerformerUiState.cs
+++ b/Nuotti.Performer/PerformerUiState.cs
@@ -41,6 +41,8 @@ public sealed class PerformerUiState
     // Performer-local state, not part of the session snapshot
     public int? SelectedCorrectIndex { get; private set; }
     public IReadOnlyDictionary<string, int> BaselineScores { get; private set; } = new Dictionary<string, int>();
+    /// <summary>Backing/click AssetRevisionId from the Session Setlist Snapshot for Start.</summary>
+    public string? VenueAssetRevisionId { get; private set; }
 
     // Role counts
     public int ProjectorCount { get; private set; }
@@ -139,6 +141,12 @@ public sealed class PerformerUiState
     public void SetSelectedCorrectIndex(int? index)
     {
         SelectedCorrectIndex = index;
+        Changed?.Invoke();
+    }
+
+    public void SetVenueAssetRevisionId(string? assetRevisionId)
+    {
+        VenueAssetRevisionId = string.IsNullOrWhiteSpace(assetRevisionId) ? null : assetRevisionId.Trim();
         Changed?.Invoke();
     }
 

--- a/Nuotti.Performer/Shared/ControlPanel.razor
+++ b/Nuotti.Performer/Shared/ControlPanel.razor
@@ -33,6 +33,14 @@
             </MudButton>
         </MudItem>
         <MudItem xs="12" sm="6" md="4" lg="2">
+            <MudButton Variant="Variant.Filled" Color="Color.Secondary" FullWidth="true"
+                       data-testid="btn-open-window"
+                       StartIcon="@Material.Filled.Timer"
+                       OnClick="@(e => OpenWindow(e))" Disabled="@(!CanOpenWindow)">
+                Open Window (W)
+            </MudButton>
+        </MudItem>
+        <MudItem xs="12" sm="6" md="4" lg="2">
             <MudButton Variant="Variant.Filled" Color="Color.Warning" FullWidth="true" 
                        data-testid="btn-lock"
                        StartIcon="@Material.Filled.Lock" 
@@ -46,6 +54,22 @@
                        StartIcon="@Material.Filled.Visibility" 
                        OnClick="@(e => Reveal(e))" Disabled="@(!CanReveal)">
                 Reveal (R)
+            </MudButton>
+        </MudItem>
+        <MudItem xs="12" sm="6" md="4" lg="2">
+            <MudButton Variant="Variant.Filled" Color="Color.Default" FullWidth="true"
+                       data-testid="btn-prepare"
+                       StartIcon="@Material.Filled.Download"
+                       OnClick="@(e => Prepare(e))" Disabled="@(!CanPrepare)">
+                Prepare (P)
+            </MudButton>
+        </MudItem>
+        <MudItem xs="12" sm="6" md="4" lg="2">
+            <MudButton Variant="Variant.Filled" Color="Color.Primary" FullWidth="true"
+                       data-testid="btn-start-playback"
+                       StartIcon="@Material.Filled.PlayCircle"
+                       OnClick="@(e => StartPlayback(e))" Disabled="@(!CanStartPlayback)">
+                Start (A)
             </MudButton>
         </MudItem>
         <MudItem xs="12" sm="6" md="4" lg="2">
@@ -126,9 +150,12 @@
     bool HasSelection => State.SelectedCorrectIndex.HasValue;
     bool CanStartSet => State.Phase is Phase.Lobby or Phase.Finished;
     bool CanNextSong => State.Phase is Phase.Guessing && State.EngineCount > 0; // NextRound requires Engine
-    bool CanGiveHint => State.Phase is Phase.Start or Phase.Hint or Phase.Guessing;
+    bool CanGiveHint => State.Phase is Phase.Guessing;
+    bool CanOpenWindow => State.Phase is Phase.Start or Phase.Hint;
     bool CanLock => State.Phase is Phase.Guessing;
     bool CanReveal => State.Phase is Phase.Lock && HasSelection;
+    bool CanPrepare => State.Phase is Phase.Reveal;
+    bool CanStartPlayback => State.Phase is Phase.Reveal && !string.IsNullOrWhiteSpace(State.VenueAssetRevisionId);
     bool CanEndSong => State.Phase is Phase.Play && State.EngineCount > 0; // Stop requires Engine
 
     // Debounce: prevent double-triggers within 500ms for all flow buttons
@@ -191,6 +218,25 @@
         await Commands.GiveHintAsync(hint);
         // Optimistically increment; server snapshot will sync if different
         State.IncrementHintIndex();
+    }
+
+    async Task OpenWindow(MouseEventArgs _)
+    {
+        if (Debounced(nameof(OpenWindow))) return;
+        await Commands.OpenAnswersAsync();
+    }
+
+    async Task Prepare(MouseEventArgs _)
+    {
+        if (Debounced(nameof(Prepare))) return;
+        await Commands.PreparePlaybackAsync();
+    }
+
+    async Task StartPlayback(MouseEventArgs _)
+    {
+        if (Debounced(nameof(StartPlayback))) return;
+        if (State.CurrentSong is null || string.IsNullOrWhiteSpace(State.VenueAssetRevisionId)) return;
+        await Commands.StartPlaybackAsync(State.CurrentSong.Id, State.VenueAssetRevisionId);
     }
 
     async Task LockAnswers(MouseEventArgs _)
@@ -321,6 +367,10 @@
                 if (CanGiveHint)
                     _ = GiveHint(new MouseEventArgs());
                 break;
+            case "w":
+                if (CanOpenWindow)
+                    _ = OpenWindow(new MouseEventArgs());
+                break;
             case "l":
                 if (CanLock)
                     _ = LockAnswers(new MouseEventArgs());
@@ -328,6 +378,14 @@
             case "r":
                 if (CanReveal)
                     _ = Reveal(new MouseEventArgs());
+                break;
+            case "p":
+                if (CanPrepare)
+                    _ = Prepare(new MouseEventArgs());
+                break;
+            case "a":
+                if (CanStartPlayback)
+                    _ = StartPlayback(new MouseEventArgs());
                 break;
             case "e":
                 if (CanEndSong)

--- a/Nuotti.Projector.Tests/WalkingSkeletonLyricLineTests.cs
+++ b/Nuotti.Projector.Tests/WalkingSkeletonLyricLineTests.cs
@@ -1,0 +1,15 @@
+using Nuotti.Projector.Presentation.Playback;
+using Xunit;
+
+namespace Nuotti.Projector.Tests;
+
+public sealed class WalkingSkeletonLyricLineTests
+{
+    [Fact]
+    public void Captured_session_lrc_yields_one_active_line_after_start_offset()
+    {
+        const string lrc = "[00:00.00]First line of the reveal\n[00:05.00]Second line";
+        var line = LyricTimeline.Parse(lrc).ActiveLineAt(TimeSpan.FromSeconds(1), TimeSpan.Zero);
+        Assert.Equal("First line of the reveal", line?.Text);
+    }
+}

--- a/Nuotti.Projector/MainWindow.axaml.cs
+++ b/Nuotti.Projector/MainWindow.axaml.cs
@@ -379,7 +379,7 @@ public partial class MainWindow : Window
         // Update debug overlay with connection ID
         _debugOverlay.UpdateConnectionId(_connection.ConnectionId ?? "Unknown");
 
-        await _connection.InvokeAsync("Join", _sessionCode, "projector", "projector");
+        await _connection.InvokeAsync("Join", _sessionCode, "projector", "projector", null);
         AppendLocal($"[hub] joined as projector to session={_sessionCode}");
         _ = StartLogConnection();
     }
@@ -394,7 +394,7 @@ public partial class MainWindow : Window
             await _connection.StartAsync();
             AppendLocal("[hub] reconnect start ok");
 
-            await _connection.InvokeAsync("Join", _sessionCode, "projector", "projector");
+            await _connection.InvokeAsync("Join", _sessionCode, "projector", "projector", null);
             AppendLocal($"[hub] rejoined as projector to session={_sessionCode}");
 
             // Fetch latest state to resync

--- a/Nuotti.SimKit/Hub/HubConnectionFactory.cs
+++ b/Nuotti.SimKit/Hub/HubConnectionFactory.cs
@@ -42,16 +42,22 @@ internal sealed class RealHubClient : IHubClient
 
     public Task JoinAsync(string session, string role, string? name = null, CancellationToken cancellationToken = default)
     {
-        // Audience may have a display name; others pass null
-        if (!string.IsNullOrWhiteSpace(name) && string.Equals(role, "audience", StringComparison.OrdinalIgnoreCase))
+        // Audience may have a display name; others pass null. Device secret is stable per client
+        // instance so SimKit reconnects restore the same Participant within the Session.
+        if (string.Equals(role, "audience", StringComparison.OrdinalIgnoreCase))
         {
-            return _connection.InvokeAsync("CreateOrJoinWithName", session, name, cancellationToken);
+            var deviceSecret = _deviceSecret ??= Guid.NewGuid().ToString("N");
+            if (!string.IsNullOrWhiteSpace(name))
+                return _connection.InvokeAsync("CreateOrJoinWithName", session, name, deviceSecret, cancellationToken);
+            return _connection.InvokeAsync("Join", session, role, name, deviceSecret, cancellationToken);
         }
-        return _connection.InvokeAsync("Join", session, role, name, cancellationToken);
+        return _connection.InvokeAsync("Join", session, role, name, null, cancellationToken);
     }
 
+    string? _deviceSecret;
+
     public Task SubmitAnswerAsync(string session, int choiceIndex, CancellationToken cancellationToken = default)
-        => _connection.InvokeAsync("SubmitAnswer", session, choiceIndex, cancellationToken);
+        => _connection.InvokeAsync("SubmitAnswer", session, choiceIndex, Guid.Empty, cancellationToken);
 
     public IDisposable On<T>(Func<T, Task> handler)
         => _connection.On(HubWireNames.For<T>(), handler);


### PR DESCRIPTION
## Summary
- Guessing Windows are configurable 10–120s; Lock freezes the held answer (multi-Window via Lock → OpenAnswers)
- Versioned time-decayed scoring with receipt time; earlier correct receipts survive later Windows; Reveal finalizes once
- Top-ten leaderboard uses shared (competition) tie ranks

## Test plan
- [x] ScoringCalculator + shared-rank TopPlayers tests
- [x] ProgressiveWindowScoringTests (idempotent Reveal, Lock-held, preserved earlier correctness)
- [x] Existing GameReducer scoring + PhaseMachine + walking-skeleton filters green locally
- [ ] CI when Unraid runners return (disregarded)

Closes #257