### PR TITLE
docs: add Cursor Cloud dev environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,3 +11,49 @@ Use the five default triage labels. See `docs/agents/triage-labels.md`.
 ### Domain docs
 
 This repository uses the single-context domain-doc layout. See `docs/agents/domain.md`.
+
+## Cursor Cloud specific instructions
+
+Environment is prepared by the startup update script; the notes below are durable, non-obvious
+gotchas for developing here.
+
+### Toolchain
+
+- .NET SDK is pinned by `global.json` to `10.0.100-rc.1.25451.107` (a preview). It is installed
+  under `~/.dotnet` and put on `PATH` (and `DOTNET_ROOT`) via `~/.bashrc`, so `dotnet` works in
+  interactive shells. Node 22 / npm are preinstalled; `web/` uses **npm** (has `package-lock.json`).
+
+### Running services (run projects individually; do NOT rely on the Aspire AppHost here)
+
+- **Backend** (REST + SignalR, the core of the product): `dotnet run --project Nuotti.Backend`
+  serves `http://localhost:5240` in `Development`. With no connection strings it transparently
+  falls back to **in-memory** stores/event bus — no Postgres/Redis/Azure Storage required.
+- **Web** (SvelteKit static frontend) in `web/`: `npm run dev` (Vite; default port 5173).
+- The Aspire AppHost `Nuotti/Nuotti.csproj` orchestrates everything but requires Docker plus
+  Postgres/Redis/an Azure Storage emulator **and** an Avalonia desktop Projector, so it is not
+  suitable for headless cloud runs. Start the individual projects instead.
+- Quick end-to-end sanity check (create session → upload manifest → push question → read state):
+  see `tools/smoke-test.sh`, but note it pushes a question with `issuedByRole: 2` (Audience),
+  which the backend now rejects with `403 "Only Performer may execute this command."` Use
+  `issuedByRole: "Performer"` (Role enum: Performer=0, Projector=1, Audience=2, Engine=3).
+
+### Tests
+
+- Run test projects directly, e.g. `dotnet test tests/Nuotti.UnitTests/Nuotti.UnitTests.csproj`.
+  Do **not** pass `--settings:.runsettings`: it references a legacy `TestSettings.testsettings`
+  through an unexpanded `$(MSBuildProjectDirectory)`, which the .NET 10 RC test platform treats as
+  embedded test settings and aborts the run (0 tests). Only coverage collection is lost this way.
+
+### Known caveats (pre-existing; not environment issues)
+
+- `Nuotti.SimKit.InProc` (and `Nuotti.SimKit.InProc.Tests`) do not compile: `InProcCommandEmitter.cs`
+  and `InProcHubClient.cs` reference `Outcome` without `using Nuotti.Contracts.V1.Protocol;`. This is
+  isolated — Backend/Contracts/Audience/Performer/Projector/AudioEngine/SimKit and the CI test
+  projects all build and test fine.
+- `dotnet format --verify-no-changes` reports whitespace/line-ending diffs on Linux checkouts:
+  `.editorconfig` mandates `end_of_line = crlf` for `*.cs`, but there is no `.gitattributes`, so
+  files are checked out with LF. This is a line-ending artifact, not real formatting drift.
+- Web ESLint/Prettier are not runnable as configured: the required tools and plugins (`eslint`,
+  `prettier`, `@typescript-eslint/*`, `eslint-plugin-svelte`, `svelte-eslint-parser`,
+  `prettier-plugin-svelte`) are **not** declared in `web/package.json`, so `npx eslint`/`npx prettier`
+  pull bare latest versions and fail (flat-config / missing-plugin errors).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for the Nuotti (.NET 10 RC + SvelteKit) real-time quiz/show platform in Cursor Cloud, and records durable, non-obvious setup notes for future agents in `AGENTS.md`.

The only code change is documentation (`AGENTS.md`). The toolchain install (.NET SDK, web deps) is captured by the startup update script / VM snapshot, not committed to the repo.

## What was set up

- **.NET SDK** pinned by `global.json` (`10.0.100-rc.1.25451.107`) installed to `~/.dotnet` and put on `PATH`/`DOTNET_ROOT`.
- **Web** (`web/`) dependencies via `npm ci` (Node 22 preinstalled).
- Startup update script: guarded (idempotent) SDK install + `dotnet restore Nuotti.sln` + `npm ci` in `web/`.

## Verified working

| Service | Build | Test | Run |
| --- | --- | --- | --- |
| .NET solution | `dotnet build` (all except pre-existing `Nuotti.SimKit.InProc` break) | ~589 tests pass across 8 projects (`dotnet test <proj>`) | — |
| Backend (REST + SignalR) | ✅ | `Nuotti.Backend.Tests` 162 pass | `dotnet run --project Nuotti.Backend` → `http://localhost:5240` (in-memory stores) |
| Web (SvelteKit) | ✅ | — | `npm run dev` → `http://localhost:5173` |

**Hello-world (core flow):** created session `demo-show`, uploaded a 1-song manifest (Bohemian Rhapsody / Queen), pushed a question as `Performer` (`202`), and confirmed the live snapshot via `GET /status/demo-show` reflects the pushed choices.

[nuotti_web_and_backend_running.mp4](https://cursor.com/agents/bc-3f199451-7fde-42a3-9899-6d390bcabad5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fnuotti_web_and_backend_running.mp4)

[SvelteKit web frontend running](https://cursor.com/agents/bc-3f199451-7fde-42a3-9899-6d390bcabad5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fweb_frontend_running.webp)
[Backend live session state for demo-show](https://cursor.com/agents/bc-3f199451-7fde-42a3-9899-6d390bcabad5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbackend_status_demo_show.webp)

## Documented caveats (pre-existing; not environment issues)

- `Nuotti.SimKit.InProc` fails to compile (`Outcome` used without `using Nuotti.Contracts.V1.Protocol;`).
- `dotnet test --settings:.runsettings` aborts under .NET 10 RC (legacy `TestSettings.testsettings` reference); run test projects without it.
- `dotnet format --verify-no-changes` flags CRLF/LF diffs on Linux checkouts (`.editorconfig` mandates CRLF for `*.cs`, no `.gitattributes`).
- Web ESLint/Prettier tools/plugins are not declared in `web/package.json`, so `npx eslint`/`npx prettier` fail.
- `tools/smoke-test.sh` pushes a question as role `2` (Audience) → `403`; use `Performer`.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3f199451-7fde-42a3-9899-6d390bcabad5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3f199451-7fde-42a3-9899-6d390bcabad5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

