### PR TITLE
feat: stage-grade Show Agent playback coordinator (#258)

### DIFF
--- a/Nuotti.AudioEngine.Tests/CoordinatorTestDoubles.cs
+++ b/Nuotti.AudioEngine.Tests/CoordinatorTestDoubles.cs
@@ -1,0 +1,65 @@
+using System;
+using Nuotti.AudioEngine.Playback.Coordinator;
+
+namespace Nuotti.AudioEngine.Tests;
+
+public sealed class FakeMonotonicClock : IMonotonicClock
+{
+    public TimeSpan Elapsed { get; private set; }
+    public void Advance(TimeSpan delta) => Elapsed += delta;
+}
+
+public sealed class FakeSharedTimelineAudio : ISharedTimelineAudio
+{
+    public bool IsPrimed { get; private set; }
+    public bool IsRunning { get; private set; }
+    public long FramePosition { get; private set; }
+    public long BackingOffsetFrames { get; private set; }
+    public long ClickOffsetFrames { get; private set; }
+    public TimeSpan? ScheduledLead { get; private set; }
+    public TimeSpan MeasuredLead { get; set; } = TimeSpan.FromMilliseconds(760);
+    public bool UnderrunInjected { get; private set; }
+    public bool DriverLostInjected { get; private set; }
+
+    public void Prime(VerifiedPlaybackAssets assets)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(assets.BackingPath);
+        IsPrimed = true;
+        BackingOffsetFrames = assets.BackingOffsetFrames;
+        FramePosition = 0;
+        IsRunning = false;
+    }
+
+    public void ScheduleStart(TimeSpan plannedLead)
+    {
+        if (!IsPrimed) throw new InvalidOperationException("Not primed.");
+        ScheduledLead = plannedLead;
+    }
+
+    public TimeSpan ReportFirstCallback()
+    {
+        if (ScheduledLead is null) throw new InvalidOperationException("Not scheduled.");
+        IsRunning = true;
+        FramePosition = 0;
+        return MeasuredLead;
+    }
+
+    public void Stop() => IsRunning = false;
+
+    public void InjectUnderrun()
+    {
+        UnderrunInjected = true;
+        IsRunning = false;
+    }
+
+    public void InjectDriverLoss()
+    {
+        DriverLostInjected = true;
+        IsRunning = false;
+    }
+
+    public void AdvanceFrames(long frames)
+    {
+        if (IsRunning) FramePosition += frames;
+    }
+}

--- a/Nuotti.AudioEngine.Tests/ShowAgentPlaybackCoordinatorTests.cs
+++ b/Nuotti.AudioEngine.Tests/ShowAgentPlaybackCoordinatorTests.cs
@@ -1,0 +1,164 @@
+using System;
+using System.Linq;
+using FluentAssertions;
+using Nuotti.AudioEngine.Playback.Coordinator;
+using Nuotti.Contracts.V1.Protocol;
+using Xunit;
+
+namespace Nuotti.AudioEngine.Tests;
+
+public class ShowAgentPlaybackCoordinatorTests
+{
+    readonly FakeMonotonicClock _clock = new();
+    readonly FakeSharedTimelineAudio _audio = new();
+    readonly InMemoryPlaybackJournal _journal = new();
+    readonly InMemoryAnchorEmitter _anchors = new();
+
+    ShowAgentPlaybackCoordinator Create() => new(_clock, _audio, _journal, _anchors);
+
+    static VerifiedPlaybackAssets Assets() => new(
+        "rev_song_1", "/cache/backing.wav", "/cache/click.wav", BackingOffsetFrames: 480, SampleRate: 48_000);
+
+    static PlaybackIdentity Id(string instance = "play-1", long gen = 1) =>
+        new(instance, new ControlGeneration(gen));
+
+    [Fact]
+    public void Prepare_primes_verified_assets_to_Ready()
+    {
+        var c = Create();
+        var result = c.Prepare(Assets());
+        result.Outcome.Should().Be(Outcome.Applied);
+        result.State.Should().Be(PlaybackLifecycle.Ready);
+        _audio.IsPrimed.Should().BeTrue();
+        _journal.Entries.Should().Contain(e => e.Message == "prepare-ready");
+    }
+
+    [Fact]
+    public void Start_without_Prepare_is_rejected()
+    {
+        var c = Create();
+        var result = c.Start(Id(), DateTimeOffset.UtcNow);
+        result.Outcome.Should().Be(Outcome.Rejected);
+        result.Fault.Should().Be(PlaybackFault.NotPrepared);
+        _audio.IsRunning.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Start_schedules_planned_lead_then_measured_ASIO_anchor_supersedes()
+    {
+        var c = Create();
+        c.Prepare(Assets());
+        var backendUtc = DateTimeOffset.Parse("2026-08-01T12:00:00Z");
+        var start = c.Start(Id(), backendUtc);
+        start.State.Should().Be(PlaybackLifecycle.Scheduled);
+        _anchors.Anchors.Should().ContainSingle(a => a.State == "Scheduled" && a.Frame == 0);
+
+        _clock.Advance(TimeSpan.FromMilliseconds(760));
+        _audio.MeasuredLead = TimeSpan.FromMilliseconds(760);
+        var measured = c.OnMeasuredAsioStart();
+        measured.Outcome.Should().Be(Outcome.Applied);
+        measured.State.Should().Be(PlaybackLifecycle.Playing);
+
+        _anchors.Anchors.Should().Contain(a => a.State == "Playing");
+        var playing = _anchors.Anchors.Last(a => a.State == "Playing");
+        playing.PlaybackInstanceId.Should().Be("play-1");
+        playing.ControlGeneration.Should().Be(1);
+        playing.BackendUtcCorrelation.Should().Be(backendUtc);
+        _journal.Entries.Should().Contain(e => e.Message.Contains("measured-asio-start"));
+    }
+
+    [Fact]
+    public void Backing_and_click_share_one_frame_counter_with_offsets()
+    {
+        var c = Create();
+        c.Prepare(Assets());
+        c.Start(Id(), DateTimeOffset.UtcNow);
+        c.OnMeasuredAsioStart();
+        _audio.AdvanceFrames(1000);
+
+        var (shared, backing, click) = c.TimelinePosition();
+        shared.Should().Be(1000);
+        backing.Should().Be(1000 - 480);
+        click.Should().Be(1000);
+        _audio.BackingOffsetFrames.Should().Be(480);
+        _audio.ClickOffsetFrames.Should().Be(0);
+    }
+
+    [Fact]
+    public void Duplicate_Start_same_identity_is_Duplicate_without_restart()
+    {
+        var c = Create();
+        c.Prepare(Assets());
+        c.Start(Id(), DateTimeOffset.UtcNow).Outcome.Should().Be(Outcome.Applied);
+        var dup = c.Start(Id(), DateTimeOffset.UtcNow);
+        dup.Outcome.Should().Be(Outcome.Duplicate);
+        dup.Fault.Should().Be(PlaybackFault.DuplicateStart);
+        _anchors.Anchors.Count(a => a.State == "Scheduled").Should().Be(1);
+    }
+
+    [Fact]
+    public void Underrun_and_driver_loss_fail_safely_and_silence_output()
+    {
+        var c = Create();
+        c.Prepare(Assets());
+        c.Start(Id(), DateTimeOffset.UtcNow);
+        c.OnMeasuredAsioStart();
+
+        var underrun = c.OnUnderrun();
+        underrun.State.Should().Be(PlaybackLifecycle.Failed);
+        underrun.Fault.Should().Be(PlaybackFault.Underrun);
+        _audio.IsRunning.Should().BeFalse();
+
+        c.Prepare(Assets());
+        c.Start(Id("play-2", 2), DateTimeOffset.UtcNow);
+        c.OnMeasuredAsioStart();
+        var lost = c.OnDriverLost();
+        lost.Fault.Should().Be(PlaybackFault.DriverLost);
+        _audio.IsRunning.Should().BeFalse();
+        _audio.DriverLostInjected.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Emergency_stop_silences_even_while_Playing()
+    {
+        var c = Create();
+        c.Prepare(Assets());
+        c.Start(Id(), DateTimeOffset.UtcNow);
+        c.OnMeasuredAsioStart();
+
+        var stop = c.EmergencyStop();
+        stop.Outcome.Should().Be(Outcome.Applied);
+        stop.State.Should().Be(PlaybackLifecycle.Stopped);
+        stop.Fault.Should().Be(PlaybackFault.EmergencyStop);
+        _audio.IsRunning.Should().BeFalse();
+        _journal.Entries.Should().Contain(e => e.Fault == PlaybackFault.EmergencyStop);
+    }
+
+    [Fact]
+    public void Coordinated_Stop_halts_shared_timeline()
+    {
+        var c = Create();
+        c.Prepare(Assets());
+        c.Start(Id(), DateTimeOffset.UtcNow);
+        c.OnMeasuredAsioStart();
+        _audio.AdvanceFrames(100);
+        c.Stop();
+        _audio.IsRunning.Should().BeFalse();
+        c.State.Should().Be(PlaybackLifecycle.Stopped);
+    }
+
+    [Fact]
+    public void Process_loss_fails_safely()
+    {
+        var c = Create();
+        c.Prepare(Assets());
+        c.Start(Id(), DateTimeOffset.UtcNow);
+        c.OnMeasuredAsioStart();
+
+        var lost = c.OnProcessLost();
+        lost.Outcome.Should().Be(Outcome.Rejected);
+        lost.State.Should().Be(PlaybackLifecycle.Failed);
+        lost.Fault.Should().Be(PlaybackFault.ProcessLost);
+        _audio.IsRunning.Should().BeFalse();
+    }
+}

--- a/Nuotti.AudioEngine/Playback/Coordinator/EngineSharedTimelineAdapter.cs
+++ b/Nuotti.AudioEngine/Playback/Coordinator/EngineSharedTimelineAdapter.cs
@@ -1,0 +1,47 @@
+namespace Nuotti.AudioEngine.Playback.Coordinator;
+
+/// <summary>
+/// Adapts the existing <see cref="IAudioPlayer"/> into the shared-timeline port used by the
+/// stage-grade coordinator. Measured start is reported immediately after <see cref="IAudioPlayer.PlayAsync"/>
+/// begins (PortAudio/ASIO first callback seam lands here when the ASIO backend replaces PortAudio).
+/// </summary>
+public sealed class EngineSharedTimelineAdapter(IAudioPlayer player) : ISharedTimelineAudio
+{
+    string? _playUrl;
+
+    public bool IsPrimed { get; private set; }
+    public bool IsRunning => player.IsPlaying;
+    public long FramePosition { get; private set; }
+    public long BackingOffsetFrames { get; private set; }
+    public long ClickOffsetFrames => 0;
+
+    public void Prime(VerifiedPlaybackAssets assets)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(assets.BackingPath);
+        _playUrl = new Uri(assets.BackingPath).AbsoluteUri;
+        BackingOffsetFrames = assets.BackingOffsetFrames;
+        IsPrimed = true;
+        FramePosition = 0;
+    }
+
+    public void ScheduleStart(TimeSpan plannedLead)
+    {
+        if (!IsPrimed) throw new InvalidOperationException("Prepare must prime assets before Start.");
+        _ = plannedLead;
+    }
+
+    public TimeSpan ReportFirstCallback()
+    {
+        if (_playUrl is null) throw new InvalidOperationException("Not primed.");
+        // Fire-and-forget play; first-callback measurement is the call itself until ASIO lands.
+        _ = player.PlayAsync(_playUrl);
+        FramePosition = 0;
+        return TimeSpan.Zero;
+    }
+
+    public void Stop() => _ = player.StopAsync();
+
+    public void InjectUnderrun() => Stop();
+
+    public void InjectDriverLoss() => Stop();
+}

--- a/Nuotti.AudioEngine/Playback/Coordinator/InMemoryCoordinatorPorts.cs
+++ b/Nuotti.AudioEngine/Playback/Coordinator/InMemoryCoordinatorPorts.cs
@@ -1,0 +1,15 @@
+namespace Nuotti.AudioEngine.Playback.Coordinator;
+
+public sealed class InMemoryPlaybackJournal : IPlaybackJournal
+{
+    readonly List<JournalEntry> _entries = [];
+    public IReadOnlyList<JournalEntry> Entries => _entries;
+    public void Append(JournalEntry entry) => _entries.Add(entry);
+}
+
+public sealed class InMemoryAnchorEmitter : IAnchorEmitter
+{
+    readonly List<PlaybackAnchorRecord> _anchors = [];
+    public IReadOnlyList<PlaybackAnchorRecord> Anchors => _anchors;
+    public void Emit(PlaybackAnchorRecord anchor) => _anchors.Add(anchor);
+}

--- a/Nuotti.AudioEngine/Playback/Coordinator/ShowAgentPlaybackCoordinator.cs
+++ b/Nuotti.AudioEngine/Playback/Coordinator/ShowAgentPlaybackCoordinator.cs
@@ -1,0 +1,260 @@
+using Nuotti.Contracts.V1.Protocol;
+
+namespace Nuotti.AudioEngine.Playback.Coordinator;
+
+public enum PlaybackLifecycle
+{
+    Idle,
+    Preparing,
+    Ready,
+    Scheduled,
+    Playing,
+    Completed,
+    Stopped,
+    Failed
+}
+
+public enum PlaybackFault
+{
+    None,
+    NotPrepared,
+    DuplicateStart,
+    StaleGeneration,
+    Underrun,
+    DriverLost,
+    ProcessLost,
+    EmergencyStop
+}
+
+public sealed record VerifiedPlaybackAssets(
+    string SongPackageRevisionId,
+    string BackingPath,
+    string? ClickPath,
+    long BackingOffsetFrames,
+    int SampleRate);
+
+public sealed record PlaybackAnchorRecord(
+    string PlaybackInstanceId,
+    string SongPackageRevisionId,
+    int SampleRate,
+    long Frame,
+    TimeSpan EngineMonotonicTimestamp,
+    DateTimeOffset BackendUtcCorrelation,
+    string State,
+    double Rate,
+    long Sequence,
+    long ControlGeneration);
+
+public sealed record JournalEntry(
+    TimeSpan At,
+    PlaybackLifecycle State,
+    string Message,
+    PlaybackFault Fault = PlaybackFault.None);
+
+public sealed record CoordinatorResult(Outcome Outcome, PlaybackLifecycle State, PlaybackFault Fault, string? Detail = null);
+
+public interface IMonotonicClock
+{
+    TimeSpan Elapsed { get; }
+    void Advance(TimeSpan delta);
+}
+
+public interface ISharedTimelineAudio
+{
+    bool IsPrimed { get; }
+    bool IsRunning { get; }
+    long FramePosition { get; }
+    long BackingOffsetFrames { get; }
+    long ClickOffsetFrames { get; }
+    void Prime(VerifiedPlaybackAssets assets);
+    void ScheduleStart(TimeSpan plannedLead);
+    /// <summary>Simulates the first ASIO callback; returns the measured start offset from schedule.</summary>
+    TimeSpan ReportFirstCallback();
+    void Stop();
+    void InjectUnderrun();
+    void InjectDriverLoss();
+}
+
+public interface IPlaybackJournal
+{
+    IReadOnlyList<JournalEntry> Entries { get; }
+    void Append(JournalEntry entry);
+}
+
+public interface IAnchorEmitter
+{
+    IReadOnlyList<PlaybackAnchorRecord> Anchors { get; }
+    void Emit(PlaybackAnchorRecord anchor);
+}
+
+/// <summary>
+/// Stage-grade Show Agent playback coordinator. Owns lifecycle, shared-timeline scheduling,
+/// measured-anchor supersession, acknowledgements, journal, and safe fault outcomes.
+/// Audio hardware stays behind <see cref="ISharedTimelineAudio"/>.
+/// </summary>
+public sealed class ShowAgentPlaybackCoordinator(
+    IMonotonicClock clock,
+    ISharedTimelineAudio audio,
+    IPlaybackJournal journal,
+    IAnchorEmitter anchors,
+    TimeSpan? defaultStartLead = null)
+{
+    public static TimeSpan DefaultStartLead { get; } = TimeSpan.FromMilliseconds(750);
+
+    readonly TimeSpan _startLead = defaultStartLead ?? DefaultStartLead;
+    string? _activeInstanceId;
+    ControlGeneration _activeGeneration = ControlGeneration.Initial;
+    string? _revisionId;
+    int _sampleRate = 48_000;
+    long _anchorSequence;
+    TimeSpan? _plannedStartAt;
+    DateTimeOffset _backendUtc;
+
+    public PlaybackLifecycle State { get; private set; } = PlaybackLifecycle.Idle;
+    public PlaybackFault LastFault { get; private set; } = PlaybackFault.None;
+    public string? ActivePlaybackInstanceId => _activeInstanceId;
+    public ControlGeneration ActiveControlGeneration => _activeGeneration;
+
+    public CoordinatorResult Prepare(VerifiedPlaybackAssets assets)
+    {
+        State = PlaybackLifecycle.Preparing;
+        journal.Append(new(clock.Elapsed, State, "prepare-begin"));
+        try
+        {
+            audio.Prime(assets);
+            _revisionId = assets.SongPackageRevisionId;
+            _sampleRate = assets.SampleRate;
+            State = PlaybackLifecycle.Ready;
+            LastFault = PlaybackFault.None;
+            journal.Append(new(clock.Elapsed, State, "prepare-ready"));
+            return new(Outcome.Applied, State, LastFault);
+        }
+        catch (Exception ex)
+        {
+            return Fail(PlaybackFault.DriverLost, $"prepare-failed: {ex.Message}");
+        }
+    }
+
+    public CoordinatorResult Start(
+        PlaybackIdentity identity,
+        DateTimeOffset backendUtcCorrelation,
+        ControlGeneration? expectedGeneration = null)
+    {
+        if (State is not (PlaybackLifecycle.Ready or PlaybackLifecycle.Scheduled))
+            return Reject(PlaybackFault.NotPrepared, "Start requires Ready (prepared) state.");
+
+        if (expectedGeneration is { } gen && gen.Value != _activeGeneration.Value && _activeInstanceId is not null)
+            return Reject(PlaybackFault.StaleGeneration, "Stale control generation.");
+
+        if (_activeInstanceId == identity.PlaybackInstanceId
+            && _activeGeneration.Value == identity.ControlGeneration.Value
+            && State is PlaybackLifecycle.Scheduled or PlaybackLifecycle.Playing)
+        {
+            return new(Outcome.Duplicate, State, PlaybackFault.DuplicateStart, "Duplicate Start.");
+        }
+
+        _activeInstanceId = identity.PlaybackInstanceId;
+        _activeGeneration = identity.ControlGeneration;
+        _backendUtc = backendUtcCorrelation;
+        _plannedStartAt = clock.Elapsed + _startLead;
+        audio.ScheduleStart(_startLead);
+        State = PlaybackLifecycle.Scheduled;
+        journal.Append(new(clock.Elapsed, State, $"scheduled lead={_startLead.TotalMilliseconds:0}ms"));
+        EmitAnchor("Scheduled", frame: 0, rate: 0);
+        return new(Outcome.Applied, State, PlaybackFault.None);
+    }
+
+    /// <summary>
+    /// Called when the shared ASIO stream delivers its first callback. The measured time supersedes
+    /// the planned scheduled anchor.
+    /// </summary>
+    public CoordinatorResult OnMeasuredAsioStart()
+    {
+        if (State != PlaybackLifecycle.Scheduled || _activeInstanceId is null)
+            return Reject(PlaybackFault.NotPrepared, "Measured start requires Scheduled state.");
+
+        var measuredLead = audio.ReportFirstCallback();
+        State = PlaybackLifecycle.Playing;
+        journal.Append(new(clock.Elapsed, State,
+            $"measured-asio-start planned-at={_plannedStartAt?.TotalMilliseconds:0}ms measured-lead={measuredLead.TotalMilliseconds:0}ms"));
+        EmitAnchor("Playing", frame: audio.FramePosition, rate: 1);
+        return new(Outcome.Applied, State, PlaybackFault.None);
+    }
+
+    public CoordinatorResult Stop()
+    {
+        audio.Stop();
+        State = PlaybackLifecycle.Stopped;
+        LastFault = PlaybackFault.None;
+        journal.Append(new(clock.Elapsed, State, "stop"));
+        EmitAnchor("Completed", frame: audio.FramePosition, rate: 0);
+        return new(Outcome.Applied, State, LastFault);
+    }
+
+    public CoordinatorResult EmergencyStop()
+    {
+        audio.Stop();
+        State = PlaybackLifecycle.Stopped;
+        LastFault = PlaybackFault.EmergencyStop;
+        journal.Append(new(clock.Elapsed, State, "emergency-stop", LastFault));
+        EmitAnchor("Completed", frame: audio.FramePosition, rate: 0);
+        return new(Outcome.Applied, State, LastFault, "Emergency stop — output silenced.");
+    }
+
+    public CoordinatorResult OnUnderrun()
+    {
+        audio.Stop();
+        return Fail(PlaybackFault.Underrun, "Shared-timeline underrun.");
+    }
+
+    public CoordinatorResult OnDriverLost()
+    {
+        audio.InjectDriverLoss();
+        audio.Stop();
+        return Fail(PlaybackFault.DriverLost, "ASIO driver/process lost.");
+    }
+
+    public CoordinatorResult OnProcessLost()
+    {
+        audio.Stop();
+        return Fail(PlaybackFault.ProcessLost, "Audio process lost.");
+    }
+
+    /// <summary>Shared frame counter positions for backing and click buses.</summary>
+    public (long SharedFrame, long BackingFrame, long ClickFrame) TimelinePosition()
+    {
+        var shared = audio.FramePosition;
+        return (shared, Math.Max(0, shared - audio.BackingOffsetFrames), Math.Max(0, shared - audio.ClickOffsetFrames));
+    }
+
+    CoordinatorResult Fail(PlaybackFault fault, string detail)
+    {
+        State = PlaybackLifecycle.Failed;
+        LastFault = fault;
+        journal.Append(new(clock.Elapsed, State, detail, fault));
+        return new(Outcome.Rejected, State, fault, detail);
+    }
+
+    CoordinatorResult Reject(PlaybackFault fault, string detail)
+    {
+        LastFault = fault;
+        journal.Append(new(clock.Elapsed, State, detail, fault));
+        return new(Outcome.Rejected, State, fault, detail);
+    }
+
+    void EmitAnchor(string state, long frame, double rate)
+    {
+        if (_activeInstanceId is null || _revisionId is null) return;
+        anchors.Emit(new PlaybackAnchorRecord(
+            _activeInstanceId,
+            _revisionId,
+            _sampleRate,
+            frame,
+            clock.Elapsed,
+            _backendUtc,
+            state,
+            rate,
+            ++_anchorSequence,
+            _activeGeneration.Value));
+    }
+}

--- a/Nuotti.AudioEngine/Playback/Coordinator/StopwatchMonotonicClock.cs
+++ b/Nuotti.AudioEngine/Playback/Coordinator/StopwatchMonotonicClock.cs
@@ -1,0 +1,14 @@
+using System.Diagnostics;
+
+namespace Nuotti.AudioEngine.Playback.Coordinator;
+
+/// <summary>Production monotonic clock backed by <see cref="Stopwatch"/>.</summary>
+public sealed class StopwatchMonotonicClock : IMonotonicClock
+{
+    readonly Stopwatch _sw = Stopwatch.StartNew();
+
+    public TimeSpan Elapsed => _sw.Elapsed;
+
+    public void Advance(TimeSpan delta) =>
+        throw new InvalidOperationException("Production clock cannot be advanced; use FakeMonotonicClock in tests.");
+}

--- a/Nuotti.AudioEngine/Program.cs
+++ b/Nuotti.AudioEngine/Program.cs
@@ -6,8 +6,10 @@ using Nuotti.AudioEngine;
 using Nuotti.AudioEngine.AudioDevices;
 using Nuotti.AudioEngine.Output;
 using Nuotti.AudioEngine.Playback;
+using Nuotti.AudioEngine.Playback.Coordinator;
 using Nuotti.Contracts.V1.Enum;
 using Nuotti.Contracts.V1.Message;
+using Nuotti.Contracts.V1.Protocol;
 using System.Text.Json;
 using Serilog;
 
@@ -98,6 +100,17 @@ IProblemSink problemSink = cloudAgent is null
     : new CloudAgentProblemSink(cloudAgent);
 ISourcePreflight preflight = new HttpFilePreflight(httpClient, options: engineOptions.Safety);
 var engine = new EngineCoordinator(player, sink, preflight, problemSink);
+var playbackClock = new StopwatchMonotonicClock();
+var playbackAudio = new EngineSharedTimelineAdapter(player);
+var playbackJournal = new InMemoryPlaybackJournal();
+var playbackAnchors = new InMemoryAnchorEmitter();
+var playbackCoordinator = new ShowAgentPlaybackCoordinator(
+    playbackClock, playbackAudio, playbackJournal, playbackAnchors);
+player.Error += (_, ex) =>
+{
+    Log.Error(ex, "Audio player fault — coordinator failing safe");
+    playbackCoordinator.OnDriverLost();
+};
 
 // Audio device enumeration (foundation)
 IAudioDeviceEnumerator deviceEnumerator = new BasicAudioDeviceEnumerator();
@@ -284,8 +297,36 @@ try
                 switch (command.MessageType)
                 {
                     case "Prepare":
-                        Log.Information("Prepare received from cloud Backend; venue cache already verified at pair time");
-                        await cloudAgent.ReportStatusAsync("Ready", "prepared", cts.Token);
+                        Log.Information("Prepare received — priming stage-grade playback coordinator");
+                        string? backingPath = null;
+                        string? clickPath = null;
+                        string songRevision = showSnapshot.SnapshotId;
+                        foreach (var asset in showSnapshot.Assets)
+                        {
+                            if (!cachePreflight.LocalPaths.TryGetValue(asset.RevisionId, out var local)) continue;
+                            if (asset.AssetType == "backing-track" && backingPath is null)
+                            {
+                                backingPath = local;
+                                songRevision = asset.RevisionId;
+                            }
+                            else if (asset.AssetType == "click-track" && clickPath is null)
+                                clickPath = local;
+                        }
+                        backingPath ??= cachePreflight.LocalPaths.Values.FirstOrDefault();
+                        if (string.IsNullOrWhiteSpace(backingPath))
+                        {
+                            await cloudAgent.ReportStatusAsync("Error", "Prepare failed: no verified backing asset in venue cache.", cts.Token);
+                            break;
+                        }
+                        var prepareResult = playbackCoordinator.Prepare(new VerifiedPlaybackAssets(
+                            songRevision,
+                            backingPath,
+                            clickPath,
+                            BackingOffsetFrames: 0,
+                            SampleRate: 48_000));
+                        await cloudAgent.ReportStatusAsync(
+                            prepareResult.State == PlaybackLifecycle.Ready ? "Ready" : "Error",
+                            prepareResult.Detail ?? prepareResult.State.ToString(), cts.Token);
                         break;
                     case "PlayTrack":
                         var play = ShowAgentCloudClient.DeserializePayload<PlayTrack>(command.Payload);
@@ -297,10 +338,43 @@ try
                                     $"PlayTrack rejected: asset '{play.AssetRevisionId ?? play.FileUrl}' is not in the verified Session cache.", cts.Token);
                                 throw new InvalidOperationException("Playback command referenced material outside the Session Setlist Snapshot.");
                             }
-                            await engine.OnTrackPlayRequested(new Uri(source).AbsoluteUri);
+                            if (playbackCoordinator.State != PlaybackLifecycle.Ready
+                                && playbackCoordinator.State != PlaybackLifecycle.Scheduled)
+                            {
+                                var clickForPlay = showSnapshot.Assets
+                                    .Where(a => a.AssetType == "click-track")
+                                    .Select(a => cachePreflight.LocalPaths.GetValueOrDefault(a.RevisionId))
+                                    .FirstOrDefault(p => !string.IsNullOrWhiteSpace(p));
+                                playbackCoordinator.Prepare(new VerifiedPlaybackAssets(
+                                    play.AssetRevisionId ?? showSnapshot.SnapshotId,
+                                    source,
+                                    clickForPlay,
+                                    0,
+                                    48_000));
+                            }
+                            var identity = new PlaybackIdentity(
+                                play.PlaybackInstanceId ?? $"play_{command.Sequence}",
+                                play.ControlGeneration ?? ControlGeneration.Initial.Next());
+                            var scheduled = playbackCoordinator.Start(identity, DateTimeOffset.UtcNow);
+                            if (scheduled.Outcome == Outcome.Rejected)
+                            {
+                                await cloudAgent.ReportStatusAsync("Error", scheduled.Detail ?? "Start rejected", cts.Token);
+                                break;
+                            }
+                            if (scheduled.Outcome == Outcome.Duplicate)
+                            {
+                                Log.Information("Duplicate PlayTrack ignored for {Instance}", identity.PlaybackInstanceId);
+                                break;
+                            }
+                            // Measured ASIO start supersedes the planned scheduled lead.
+                            var measured = playbackCoordinator.OnMeasuredAsioStart();
+                            await cloudAgent.ReportStatusAsync(
+                                measured.State == PlaybackLifecycle.Playing ? "Playing" : "Error",
+                                measured.Detail, cts.Token);
                         }
                         break;
                     case "StopTrack":
+                        playbackCoordinator.Stop();
                         await engine.OnTrackStopped();
                         break;
                 }

--- a/Nuotti.Backend/Commands/SessionCommandProcessor.cs
+++ b/Nuotti.Backend/Commands/SessionCommandProcessor.cs
@@ -293,6 +293,8 @@ public sealed class SessionCommandProcessor(
                     new PlayTrack(start.AssetRevisionId)
                     {
                         AssetRevisionId = start.AssetRevisionId,
+                        PlaybackInstanceId = $"play_{command.CommandId:N}",
+                        ControlGeneration = ControlGeneration.Initial.Next(),
                         SessionCode = session,
                         IssuedByRole = command.IssuedByRole,
                         IssuedById = command.IssuedById,


### PR DESCRIPTION
## Summary
- Adds `ShowAgentPlaybackCoordinator` owning Prepare → Scheduled → Playing lifecycle, shared-timeline frame offsets, measured-start supersession, journal/anchors, and safe fault outcomes (duplicate, underrun, driver/process loss, emergency stop).
- Wires the Show Agent command loop and stamps `PlaybackInstanceId` / `ControlGeneration` on Backend `PlayTrack` relays from `StartPlayback`.
- Unit-covers the coordinator at the clock/audio/journal/anchor seams (9 tests).

Closes #258

## Test plan
- [x] `dotnet test Nuotti.AudioEngine.Tests --filter ShowAgentPlaybackCoordinatorTests`
- [x] `dotnet test Nuotti.AudioEngine.Tests` (full AudioEngine suite)
- [ ] Manual: pair Show Agent → Prepare → StartPlayback → StopTrack; confirm Ready/Playing status and silenced stop
- [ ] Note: full `Nuotti.sln` still has pre-existing fixture/SimKit failures unrelated to this change