### PR TITLE
feat: dark Variant B Projector with synced LRC hold (#259)

### DIFF
--- a/Nuotti.Contracts.Tests/V1/Design/ProjectorVariantBPaletteTests.cs
+++ b/Nuotti.Contracts.Tests/V1/Design/ProjectorVariantBPaletteTests.cs
@@ -1,0 +1,28 @@
+using FluentAssertions;
+using Nuotti.Contracts.V1.Design;
+using Xunit;
+
+namespace Nuotti.Contracts.Tests.V1.Design;
+
+public class ProjectorVariantBPaletteTests
+{
+    [Fact]
+    public void Variant_B_uses_accessible_cyan_primary_on_dark_stage()
+    {
+        var palette = DesignTokens.ProjectorVariantBPalette;
+        palette.Primary.Should().Be("#00FFF5");
+        palette.Background.Should().Be("#05090B");
+        palette.Surface.Should().Be("#091115");
+        palette.OnPrimary.Should().Be("#001413");
+
+        ContrastCalculator.MeetsWCAGAA(
+            ContrastCalculator.CalculateContrastRatio(palette.TextPrimary, palette.Background))
+            .Should().BeTrue();
+        ContrastCalculator.MeetsWCAGAA(
+            ContrastCalculator.CalculateContrastRatio(palette.Primary, palette.Background))
+            .Should().BeTrue("cyan accent on dark stage must remain accessible");
+        ContrastCalculator.MeetsWCAGAA(
+            ContrastCalculator.CalculateContrastRatio(palette.OnPrimary, palette.Primary))
+            .Should().BeTrue("button label on cyan must meet AA (dark ink, not white)");
+    }
+}

--- a/Nuotti.Contracts/V1/Design/ColorPalette.cs
+++ b/Nuotti.Contracts/V1/Design/ColorPalette.cs
@@ -75,4 +75,9 @@ public class ColorPalette
     /// Optional option/choice background color.
     /// </summary>
     public string? OptionBackground { get; set; }
+
+    /// <summary>
+    /// Ink color for text drawn on <see cref="Primary"/> (e.g. cyan buttons use dark ink).
+    /// </summary>
+    public string OnPrimary { get; set; } = "#FFFFFF";
 }

--- a/Nuotti.Contracts/V1/Design/DesignTokens.cs
+++ b/Nuotti.Contracts/V1/Design/DesignTokens.cs
@@ -91,6 +91,29 @@ public static class DesignTokens
     };
     
     /// <summary>
+    /// Projector Variant B — dark stage with accessible cyan (#00FFF5). Selected for venue display.
+    /// Button labels use <see cref="ColorPalette.OnPrimary"/> (dark ink); white-on-cyan fails WCAG.
+    /// </summary>
+    public static ColorPalette ProjectorVariantBPalette => new()
+    {
+        Primary = "#00FFF5",
+        Secondary = "#17363A",
+        Tertiary = "#48C9B0",
+        Info = "#00FFF5",
+        Success = "#5EC99D",
+        Warning = "#FFA040",
+        Error = "#FF6B93",
+        Background = "#05090B",
+        Surface = "#091115",
+        TextPrimary = "#ECFFFF",
+        TextSecondary = "#91A5AA",
+        Divider = "#17363A",
+        Header = "#091115",
+        OptionBackground = "#0C181D",
+        OnPrimary = "#001413"
+    };
+
+    /// <summary>
     /// Border radius for rounded corners (12px).
     /// </summary>
     public const int DefaultBorderRadius = 12;

--- a/Nuotti.Projector.Presentation/PhasePresenter.cs
+++ b/Nuotti.Projector.Presentation/PhasePresenter.cs
@@ -1,6 +1,7 @@
 using Nuotti.Contracts.V1.Enum;
 using Nuotti.Contracts.V1.Model;
 using Nuotti.Projector.Models;
+using Nuotti.Projector.Presentation.Playback;
 using Nuotti.Projector.Services;
 using System;
 using System.Collections.Generic;
@@ -28,11 +29,18 @@ public sealed class PhasePresenter(
     /// <summary>Option slots the Projector renders.</summary>
     public const int ChoiceSlots = 4;
 
-    public ViewSpec Present(GameStateSnapshot state, ProjectorSettings settings, WindowSize windowSize)
+    public ViewSpec Present(
+        GameStateSnapshot state,
+        ProjectorSettings settings,
+        WindowSize windowSize,
+        ProjectorPlaybackFrame? playback = null)
     {
         var showTallies = !(settings.HideTalliesUntilReveal && state.Phase == Phase.Guessing);
         var songTitle = safety.SanitizeSongTitle(state.SongTitle()).SafeContent;
         var songArtist = safety.SanitizeArtistName(state.SongArtist()).SafeContent;
+        var lyricLine = playback?.ActiveLine?.Text;
+        if (state.Phase == Phase.Play && playback?.Connection == ProjectorConnectionVisual.Holding)
+            lyricLine ??= playback.FallbackMessage;
 
         return new ViewSpec(
             View: ViewFor(state.Phase),
@@ -52,9 +60,12 @@ public sealed class PhasePresenter(
             ScoreboardFooter: state.SongIndex + 1 >= state.Catalog.Count
                 ? "Final Results!"
                 : "Get ready for the next song!",
-            Simple: SimpleFor(state),
+            Simple: SimpleFor(state, lyricLine),
             HasSong: state.CurrentSong is not null,
-            Typography: TypographyFor(windowSize));
+            Typography: TypographyFor(windowSize),
+            ActiveLyricLine: lyricLine,
+            ConnectionDegraded: playback?.Connection == ProjectorConnectionVisual.Holding,
+            EmitsAudio: false);
     }
 
     /// <summary>
@@ -158,14 +169,15 @@ public sealed class PhasePresenter(
 
     /// <summary>
     /// The icon-and-title screen, previously derived inside SimplePhaseView.GetPhaseInfo.
+    /// During Play, the active lyric (or holding fallback) replaces the empty detail line.
     /// </summary>
-    static SimpleSpec SimpleFor(GameStateSnapshot state) => state.Phase switch
+    static SimpleSpec SimpleFor(GameStateSnapshot state, string? lyricLine) => state.Phase switch
     {
         Phase.Start => new("\U0001F680", "Get Ready!", true, $"Song {state.SongIndex + 1}"),
         Phase.Hint => new("\U0001F4A1", "Hint Time", true, $"Hint {state.CurrentHintNumber()}"),
         Phase.Lock => new("\U0001F512", "Time's Up!", true, "No more answers!"),
         Phase.Reveal => new("\U0001F389", "The Answer Is...", true, string.Empty),
-        Phase.Play => new("\U0001F3B5", "Now Playing", true, string.Empty),
+        Phase.Play => new("\U0001F3B5", "Now Playing", true, lyricLine ?? string.Empty),
         Phase.Intermission => new("\U0001F4CA", "Scoreboard", false, "Check your score!"),
         Phase.Finished => new("\U0001F3C6", "Game Over!", false, "Thanks for playing!"),
         _ => new("\U0001F3B5", state.Phase.ToString(), false, string.Empty)

--- a/Nuotti.Projector.Presentation/Playback/PlaybackTimelineSynchronizer.cs
+++ b/Nuotti.Projector.Presentation/Playback/PlaybackTimelineSynchronizer.cs
@@ -111,6 +111,19 @@ public sealed class PlaybackTimelineSynchronizer
             + Scale(_pendingCorrection, correctionProgress);
     }
 
+    /// <summary>
+    /// Re-bases the local clock at a known position after a hold, without requiring a new network anchor.
+    /// </summary>
+    public void ForcePosition(TimeSpan position, TimeSpan localTime, double rate = 1)
+    {
+        _hasAnchor = true;
+        _basePosition = position;
+        _baseLocalTime = localTime;
+        _rate = rate;
+        _pendingCorrection = TimeSpan.Zero;
+        _correctionStartedAt = localTime;
+    }
+
     void SnapTo(PlaybackAnchor anchor, TimeSpan receivedAt, TimeSpan position)
     {
         _hasAnchor = true;

--- a/Nuotti.Projector.Presentation/Playback/ProjectorPlaybackPresenter.cs
+++ b/Nuotti.Projector.Presentation/Playback/ProjectorPlaybackPresenter.cs
@@ -1,0 +1,82 @@
+namespace Nuotti.Projector.Presentation.Playback;
+
+public enum ProjectorConnectionVisual
+{
+    Live,
+    Holding
+}
+
+public sealed record ProjectorPlaybackFrame(
+    TimeSpan Position,
+    LyricLine? ActiveLine,
+    ProjectorConnectionVisual Connection,
+    bool EmitsAudio,
+    string? FallbackMessage = null);
+
+/// <summary>
+/// Composes sparse playback anchors with unchanged LRC. The Projector never emits audio;
+/// lyrics activate using the package <c>songStartOffset</c> only.
+/// </summary>
+public sealed class ProjectorPlaybackPresenter
+{
+    readonly PlaybackTimelineSynchronizer _sync = new();
+    LyricTimeline? _lyrics;
+    TimeSpan _songStartOffset;
+    bool _frozen;
+    TimeSpan _frozenPosition;
+
+    public bool EmitsAudio => false;
+
+    public void LoadLyrics(string lrc, TimeSpan songStartOffset)
+    {
+        _lyrics = LyricTimeline.Parse(lrc);
+        _songStartOffset = songStartOffset;
+    }
+
+    public AnchorApplication ApplyAnchor(PlaybackAnchor anchor, TimeSpan receivedAt, DateTimeOffset receivedUtc)
+        => _sync.ApplyAnchor(anchor, receivedAt, receivedUtc);
+
+    public void Freeze(TimeSpan localTime)
+    {
+        _frozenPosition = _sync.PositionAt(localTime);
+        _frozen = true;
+    }
+
+    public AnchorApplication Reconcile(PlaybackAnchor anchor, TimeSpan receivedAt, DateTimeOffset receivedUtc)
+    {
+        _frozen = false;
+        return _sync.ApplyAnchor(anchor, receivedAt, receivedUtc);
+    }
+
+    /// <summary>
+    /// Clears the holding pattern after reconnect when no fresh anchor has arrived yet.
+    /// Continues from the frozen lyric position on the local clock.
+    /// </summary>
+    public void ResumeFromHold(TimeSpan localTime)
+    {
+        if (!_frozen) return;
+        _frozen = false;
+        _sync.ForcePosition(_frozenPosition, localTime);
+    }
+
+    public ProjectorPlaybackFrame Present(TimeSpan localTime)
+    {
+        if (_frozen)
+        {
+            var heldLine = _lyrics?.ActiveLineAt(_frozenPosition, _songStartOffset);
+            return new(
+                _frozenPosition,
+                heldLine,
+                ProjectorConnectionVisual.Holding,
+                EmitsAudio: false,
+                FallbackMessage: heldLine is null ? "Reconnecting…" : null);
+        }
+
+        var position = _sync.PositionAt(localTime);
+        return new(
+            position,
+            _lyrics?.ActiveLineAt(position, _songStartOffset),
+            ProjectorConnectionVisual.Live,
+            EmitsAudio: false);
+    }
+}

--- a/Nuotti.Projector.Presentation/ViewSpec.cs
+++ b/Nuotti.Projector.Presentation/ViewSpec.cs
@@ -75,4 +75,7 @@ public sealed record ViewSpec(
     string ScoreboardFooter,
     SimpleSpec Simple,
     bool HasSong,
-    TypographySpec Typography);
+    TypographySpec Typography,
+    string? ActiveLyricLine = null,
+    bool ConnectionDegraded = false,
+    bool EmitsAudio = false);

--- a/Nuotti.Projector.Tests/PhasePresenterTests.cs
+++ b/Nuotti.Projector.Tests/PhasePresenterTests.cs
@@ -316,4 +316,38 @@ public class PhasePresenterTests
         spec.Question.Should().Be("What song is this?");
         spec.Question.Should().NotStartWith("[");
     }
+
+    [Fact]
+    public void Projector_never_emits_audio_and_Play_shows_offset_LRC_line()
+    {
+        var playback = new Projector.Presentation.Playback.ProjectorPlaybackFrame(
+            TimeSpan.FromSeconds(3.5),
+            new Projector.Presentation.Playback.LyricLine(TimeSpan.FromSeconds(1.5), "First sung line"),
+            Projector.Presentation.Playback.ProjectorConnectionVisual.Live,
+            EmitsAudio: false);
+
+        var spec = Presenter().Present(State(PhaseEnum.Play), Settings(), Hd, playback);
+
+        spec.EmitsAudio.Should().BeFalse();
+        spec.ActiveLyricLine.Should().Be("First sung line");
+        spec.Simple.Detail.Should().Be("First sung line");
+        spec.Typography.Headline.Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public void Disconnect_holding_shows_neutral_fallback_on_Play()
+    {
+        var playback = new Projector.Presentation.Playback.ProjectorPlaybackFrame(
+            TimeSpan.Zero,
+            null,
+            Projector.Presentation.Playback.ProjectorConnectionVisual.Holding,
+            EmitsAudio: false,
+            FallbackMessage: "Reconnecting…");
+
+        var spec = Presenter().Present(State(PhaseEnum.Play), Settings(), Uhd, playback);
+
+        spec.ConnectionDegraded.Should().BeTrue();
+        spec.ActiveLyricLine.Should().Be("Reconnecting…");
+        spec.EmitsAudio.Should().BeFalse();
+    }
 }

--- a/Nuotti.Projector.Tests/ProjectorPlaybackPresenterTests.cs
+++ b/Nuotti.Projector.Tests/ProjectorPlaybackPresenterTests.cs
@@ -1,0 +1,79 @@
+using FluentAssertions;
+using Nuotti.Projector.Presentation.Playback;
+using Xunit;
+
+namespace Nuotti.Projector.Tests;
+
+public sealed class ProjectorPlaybackPresenterTests
+{
+    static PlaybackAnchor Anchor(
+        long sequence = 1,
+        long frame = 0,
+        double rate = 1,
+        PlaybackAnchorState state = PlaybackAnchorState.Playing)
+        => new(
+            "play-1",
+            "rev-1",
+            SampleRate: 48_000,
+            Frame: frame,
+            EngineMonotonicTimestamp: TimeSpan.FromMilliseconds(frame / 48.0),
+            BackendUtcCorrelation: DateTimeOffset.Parse("2026-08-01T12:00:00Z"),
+            state,
+            rate,
+            sequence,
+            ControlGeneration: 1);
+
+    [Fact]
+    public void Activates_unchanged_LRC_using_songStartOffset_and_emits_no_audio()
+    {
+        var presenter = new ProjectorPlaybackPresenter();
+        presenter.LoadLyrics(
+            "[00:00.00]Count-in\n[00:01.50]First line",
+            TimeSpan.FromSeconds(2));
+        presenter.ApplyAnchor(Anchor(frame: 0), TimeSpan.Zero, DateTimeOffset.Parse("2026-08-01T12:00:00Z"));
+
+        var before = presenter.Present(TimeSpan.FromMilliseconds(1_999));
+        before.EmitsAudio.Should().BeFalse();
+        before.ActiveLine.Should().BeNull();
+
+        var after = presenter.Present(TimeSpan.FromMilliseconds(3_500));
+        after.EmitsAudio.Should().BeFalse();
+        after.ActiveLine!.Text.Should().Be("First line");
+        after.Connection.Should().Be(ProjectorConnectionVisual.Live);
+    }
+
+    [Fact]
+    public void Disconnect_freezes_safe_visual_then_reconcile_snaps_to_new_anchor()
+    {
+        var presenter = new ProjectorPlaybackPresenter();
+        presenter.LoadLyrics("[00:00.00]Hold\n[00:05.00]After", TimeSpan.Zero);
+        presenter.ApplyAnchor(Anchor(frame: 0), TimeSpan.Zero, DateTimeOffset.Parse("2026-08-01T12:00:00Z"));
+
+        var live = presenter.Present(TimeSpan.FromSeconds(1));
+        live.ActiveLine!.Text.Should().Be("Hold");
+
+        presenter.Freeze(TimeSpan.FromSeconds(1));
+        var frozen = presenter.Present(TimeSpan.FromSeconds(10));
+        frozen.Connection.Should().Be(ProjectorConnectionVisual.Holding);
+        frozen.ActiveLine!.Text.Should().Be("Hold");
+        frozen.Position.Should().Be(live.Position);
+
+        var receivedUtc = DateTimeOffset.Parse("2026-08-01T12:00:05Z");
+        presenter.Reconcile(Anchor(sequence: 2, frame: 48_000 * 5), TimeSpan.FromSeconds(10), receivedUtc);
+        var resumed = presenter.Present(TimeSpan.FromSeconds(10));
+        resumed.Connection.Should().Be(ProjectorConnectionVisual.Live);
+        resumed.ActiveLine!.Text.Should().Be("After");
+    }
+
+    [Fact]
+    public void Without_lyrics_holding_pattern_is_neutral_fallback()
+    {
+        var presenter = new ProjectorPlaybackPresenter();
+        presenter.Freeze(TimeSpan.Zero);
+        var frame = presenter.Present(TimeSpan.FromSeconds(1));
+        frame.Connection.Should().Be(ProjectorConnectionVisual.Holding);
+        frame.ActiveLine.Should().BeNull();
+        frame.FallbackMessage.Should().Be("Reconnecting…");
+        frame.EmitsAudio.Should().BeFalse();
+    }
+}

--- a/Nuotti.Projector/App.axaml
+++ b/Nuotti.Projector/App.axaml
@@ -1,16 +1,15 @@
 <Application xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              x:Class="Nuotti.Projector.App"
-             RequestedThemeVariant="Default">
-             <!-- "Default" ThemeVariant follows system theme variant. "Dark" or "Light" are other available options. -->
+             RequestedThemeVariant="Dark">
+             <!-- Projector venue display uses Variant B dark/cyan hierarchy at 1080p and 4K. -->
 
     <Application.Styles>
         <FluentTheme />
     </Application.Styles>
 
     <Application.Resources>
-        <!-- Theme Colors - These colors are synchronized with Nuotti.Contracts.V1.Design.DesignTokens -->
-        <!-- Light Theme Colors (Kahoot/Bandle inspired) -->
+        <!-- Theme Colors - synchronized with DesignTokens.ProjectorVariantBPalette -->
         <ResourceDictionary>
             <!-- F15 - Font Resources -->
             <FontFamily x:Key="PrimaryFont">Inter, Segoe UI, SF Pro Display, Ubuntu, Arial, sans-serif</FontFamily>
@@ -18,13 +17,13 @@
             <FontFamily x:Key="DisplayFont">Inter, Segoe UI, SF Pro Display, Ubuntu, Helvetica Neue, Arial, sans-serif</FontFamily>
 
             <ResourceDictionary.ThemeDictionaries>
-                <!-- Light Theme -->
+                <!-- Light Theme (unused on Projector; kept for FluentTheme completeness) -->
                 <ResourceDictionary x:Key="Light">
-                    <Color x:Key="PrimaryColor">#FF6B35</Color>
+                    <Color x:Key="PrimaryColor">#DB3B00</Color>
                     <Color x:Key="SecondaryColor">#004E89</Color>
                     <Color x:Key="TertiaryColor">#1B9AAA</Color>
                     <Color x:Key="InfoColor">#06BEE1</Color>
-                    <Color x:Key="SuccessColor">#46B283</Color>
+                    <Color x:Key="SuccessColor">#40A277</Color>
                     <Color x:Key="WarningColor">#F77F00</Color>
                     <Color x:Key="ErrorColor">#EF476F</Color>
                     <Color x:Key="BackgroundColor">#FAFAFA</Color>
@@ -32,6 +31,7 @@
                     <Color x:Key="TextPrimaryColor">#1A1A1A</Color>
                     <Color x:Key="TextSecondaryColor">#666666</Color>
                     <Color x:Key="DividerColor">#E0E0E0</Color>
+                    <Color x:Key="OnPrimaryColor">#FFFFFF</Color>
 
                     <SolidColorBrush x:Key="PrimaryBrush" Color="{StaticResource PrimaryColor}" />
                     <SolidColorBrush x:Key="SecondaryBrush" Color="{StaticResource SecondaryColor}" />
@@ -44,22 +44,24 @@
                     <SolidColorBrush x:Key="DividerBrush" Color="{StaticResource DividerColor}" />
                     <SolidColorBrush x:Key="HeaderBrush" Color="{StaticResource SurfaceColor}" />
                     <SolidColorBrush x:Key="OptionBackgroundBrush" Color="#F5F5F5" />
+                    <SolidColorBrush x:Key="OnPrimaryBrush" Color="{StaticResource OnPrimaryColor}" />
                 </ResourceDictionary>
 
-                <!-- Dark Theme -->
+                <!-- Dark Theme = Projector Variant B -->
                 <ResourceDictionary x:Key="Dark">
-                    <Color x:Key="PrimaryColor">#FF8C61</Color>
-                    <Color x:Key="SecondaryColor">#2E7DAF</Color>
+                    <Color x:Key="PrimaryColor">#00FFF5</Color>
+                    <Color x:Key="SecondaryColor">#17363A</Color>
                     <Color x:Key="TertiaryColor">#48C9B0</Color>
-                    <Color x:Key="InfoColor">#3DD9FF</Color>
+                    <Color x:Key="InfoColor">#00FFF5</Color>
                     <Color x:Key="SuccessColor">#5EC99D</Color>
                     <Color x:Key="WarningColor">#FFA040</Color>
                     <Color x:Key="ErrorColor">#FF6B93</Color>
-                    <Color x:Key="BackgroundColor">#0A0E27</Color>
-                    <Color x:Key="SurfaceColor">#151B3B</Color>
-                    <Color x:Key="TextPrimaryColor">#E8E8E8</Color>
-                    <Color x:Key="TextSecondaryColor">#B0B0B0</Color>
-                    <Color x:Key="DividerColor">#2A2F4F</Color>
+                    <Color x:Key="BackgroundColor">#05090B</Color>
+                    <Color x:Key="SurfaceColor">#091115</Color>
+                    <Color x:Key="TextPrimaryColor">#ECFFFF</Color>
+                    <Color x:Key="TextSecondaryColor">#91A5AA</Color>
+                    <Color x:Key="DividerColor">#17363A</Color>
+                    <Color x:Key="OnPrimaryColor">#001413</Color>
 
                     <SolidColorBrush x:Key="PrimaryBrush" Color="{StaticResource PrimaryColor}" />
                     <SolidColorBrush x:Key="SecondaryBrush" Color="{StaticResource SecondaryColor}" />
@@ -71,7 +73,8 @@
                     <SolidColorBrush x:Key="TextSecondaryBrush" Color="{StaticResource TextSecondaryColor}" />
                     <SolidColorBrush x:Key="DividerBrush" Color="{StaticResource DividerColor}" />
                     <SolidColorBrush x:Key="HeaderBrush" Color="{StaticResource SurfaceColor}" />
-                    <SolidColorBrush x:Key="OptionBackgroundBrush" Color="#1F2544" />
+                    <SolidColorBrush x:Key="OptionBackgroundBrush" Color="#0C181D" />
+                    <SolidColorBrush x:Key="OnPrimaryBrush" Color="{StaticResource OnPrimaryColor}" />
                 </ResourceDictionary>
             </ResourceDictionary.ThemeDictionaries>
         </ResourceDictionary>

--- a/Nuotti.Projector/MainWindow.axaml.cs
+++ b/Nuotti.Projector/MainWindow.axaml.cs
@@ -15,6 +15,7 @@ using Nuotti.Contracts.V1.Model;
 using Nuotti.Projector.Controls;
 using Nuotti.Projector.Models;
 using Nuotti.Projector.Presentation;
+using Nuotti.Projector.Presentation.Playback;
 using Nuotti.Projector.Services;
 using Nuotti.Projector.Views;
 using System;
@@ -72,6 +73,8 @@ public partial class MainWindow : Window
     private CursorService? _cursorService;
     private ProjectorSettings _settings;
     private readonly PhasePresenter _presenter;
+    private readonly ProjectorPlaybackPresenter _playbackPresenter = new();
+    private readonly Stopwatch _playbackClock = Stopwatch.StartNew();
 
     // F5 - Phase views
     private readonly Dictionary<PhaseView, PhaseViewBase> _phaseViews = new();
@@ -361,7 +364,16 @@ public partial class MainWindow : Window
         _connection.Closed += async (_) =>
         {
             _connectionTextBlock.Text = "Disconnected";
+            _playbackPresenter.Freeze(_playbackClock.Elapsed);
             _reconnectOverlay.Show("Connection Lost", "Attempting to reconnect...");
+            try
+            {
+                RenderCurrent();
+            }
+            catch (Exception renderEx)
+            {
+                AppendLocal($"[hub] holding render failed: {renderEx.Message}");
+            }
 
             var delayMs = Random.Shared.Next(0, 5) * 1000;
             AppendLocal($"[hub] disconnected; reconnecting in {delayMs} ms");
@@ -411,8 +423,10 @@ public partial class MainWindow : Window
                 AppendLocal("[hub] state resync failed, continuing with current state");
             }
 
+            _playbackPresenter.ResumeFromHold(_playbackClock.Elapsed);
             _connectionTextBlock.Text = "Connected";
             _reconnectOverlay.Hide();
+            RenderCurrent();
 
             _ = StartLogConnection();
             AppendLocal("[hub] reconnected successfully");
@@ -849,13 +863,20 @@ public partial class MainWindow : Window
     {
         try
         {
-            Render(_presenter.Present(state, _settings, new WindowSize(Bounds.Width, Bounds.Height)));
+            RenderCurrent(state);
             AppendLocal($"[gamestate] Phase: {state.Phase}, Song: {state.SongTitle()}");
         }
         catch (Exception ex)
         {
             AppendLocal($"[gamestate] Error: {ex.Message}");
         }
+    }
+
+    void RenderCurrent(GameStateSnapshot? state = null)
+    {
+        state ??= _gameStateService.CurrentState;
+        var playback = _playbackPresenter.Present(_playbackClock.Elapsed);
+        Render(_presenter.Present(state, _settings, new WindowSize(Bounds.Width, Bounds.Height), playback));
     }
 
     /// <summary>
@@ -904,7 +925,7 @@ public partial class MainWindow : Window
         // Update button appearance
         _tallyToggleButton.Content = _settings.HideTalliesUntilReveal ? "🙈" : "👁️";
 
-        Render(_presenter.Present(_gameStateService.CurrentState, _settings, new WindowSize(Bounds.Width, Bounds.Height)));
+        RenderCurrent();
 
         var status = _settings.HideTalliesUntilReveal ? "hidden" : "visible";
         AppendLocal($"[tallies] Tallies during guessing: {status}");

--- a/Nuotti.Projector/Views/ErrorStateView.axaml
+++ b/Nuotti.Projector/Views/ErrorStateView.axaml
@@ -72,7 +72,7 @@
                         FontFamily="{StaticResource PrimaryFont}"
                         Padding="20,12"
                         Background="{DynamicResource PrimaryBrush}"
-                        Foreground="White"
+                        Foreground="{DynamicResource OnPrimaryBrush}"
                         CornerRadius="8"
                         Click="OnRetryClick"/>
                 
@@ -82,7 +82,7 @@
                         FontFamily="{StaticResource PrimaryFont}"
                         Padding="20,12"
                         Background="{DynamicResource SecondaryBrush}"
-                        Foreground="White"
+                        Foreground="{DynamicResource TextPrimaryBrush}"
                         CornerRadius="8"
                         Click="OnBackClick"/>
                 

--- a/Nuotti.Projector/Views/SimplePhaseView.axaml.cs
+++ b/Nuotti.Projector/Views/SimplePhaseView.axaml.cs
@@ -85,6 +85,22 @@ public partial class SimplePhaseView : PhaseViewBase
 
         _additionalInfoText.IsVisible = !string.IsNullOrEmpty(spec.Simple.Detail);
         _additionalInfoText.Text = spec.Simple.Detail;
+        if (!string.IsNullOrEmpty(spec.ActiveLyricLine))
+        {
+            if (this.TryGetResource("PrimaryBrush", out var brush) && brush is Avalonia.Media.IBrush primary)
+                _additionalInfoText.Foreground = primary;
+            _additionalInfoText.FontWeight = Avalonia.Media.FontWeight.Bold;
+            _additionalInfoText.FontSize = TypographyService.CalculateFontSizeFromWindow(
+                ResponsiveTypographyService.FontSizes.HeadlineMin,
+                ResponsiveTypographyService.FontSizes.HeadlineMax,
+                GetWindowSize(),
+                0.05);
+        }
+        else
+        {
+            _additionalInfoText.ClearValue(TextBlock.ForegroundProperty);
+            _additionalInfoText.FontWeight = Avalonia.Media.FontWeight.Normal;
+        }
     }
 
     protected override void InitializeComponent()


### PR DESCRIPTION
## Summary
- Projector dark theme is Variant B (`#00FFF5` / `#05090B`) with WCAG-tested `OnPrimary` ink for cyan buttons.
- `ProjectorPlaybackPresenter` activates unchanged LRC via `songStartOffset`, never emits audio, and freezes a safe lyric/neutral holding frame on disconnect before resume/reconcile.
- Play-phase `ViewSpec` surfaces the active lyric; MainWindow freezes on hub loss and resumes after state resync.

Closes #259

## Test plan
- [x] `dotnet test Nuotti.Projector.Tests`
- [x] `dotnet test Nuotti.Contracts.Tests --filter ProjectorVariantB|ContrastAudit`
- [ ] Visual check at 1080p and 4K: Join/Hint/Guess/Lock/Reveal/leaderboard/error use cyan hierarchy
- [ ] Disconnect mid-Play: last lyric or “Reconnecting…” holds; reconnect resumes