### PR TITLE
feat: multi-Round show advancement and 30-day results (#260)

### DIFF
--- a/Nuotti.Backend.Tests/MultiRoundShowProcessorTests.cs
+++ b/Nuotti.Backend.Tests/MultiRoundShowProcessorTests.cs
@@ -1,0 +1,140 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Nuotti.Backend.Commands;
+using Nuotti.Backend.Retention;
+using Nuotti.Backend.Sessions;
+using Nuotti.Backend.Tests.TestSupport;
+using Nuotti.Contracts.V1.Enum;
+using Nuotti.Contracts.V1.Event;
+using Nuotti.Contracts.V1.Message.Phase;
+using Nuotti.Contracts.V1.Model;
+using Nuotti.Contracts.V1.Protocol;
+using Nuotti.Contracts.V1.Reducer;
+using Xunit;
+using PhaseEnum = Nuotti.Contracts.V1.Enum.Phase;
+
+namespace Nuotti.Backend.Tests;
+
+/// <summary>
+/// Issue #260 — multi-Round show at the processor seam: NextRound advances SongIndex,
+/// only Performers advance the flow, and EndGame retains identifiable scores for 30 days.
+/// </summary>
+public class MultiRoundShowProcessorTests
+{
+    const string Session = "MULTI1";
+
+    static Actor Performer => Actor.Verified(Role.Performer, "perf-1");
+    static Actor Audience => Actor.Verified(Role.Audience, "aud-1");
+
+    static SongRef Song(string id, string title) => new(new SongId(id), title, "Artist");
+
+    static void SeededIntermission(IGameStateStore store, IReadOnlyList<SongRef> catalog, int songIndex = 0)
+    {
+        store.Set(Session, GameReducer.Initial(Session) with
+        {
+            Phase = PhaseEnum.Intermission,
+            Catalog = catalog,
+            SongIndex = songIndex,
+            CurrentSong = catalog[songIndex],
+            Scores = new Dictionary<string, int> { ["aud-1"] = 10 }
+        });
+    }
+
+    static SessionCommandProcessor CreateProcessor(
+        out IGameStateStore store,
+        out CapturingEventBus bus,
+        ISessionResultsStore? results = null)
+    {
+        store = new InMemoryGameStateStore();
+        bus = new CapturingEventBus();
+        return new SessionCommandProcessor(
+            store,
+            Harness.IdempotencyStore(),
+            bus,
+            NullLogger<SessionCommandProcessor>.Instance,
+            results: results);
+    }
+
+    [Fact]
+    public async Task NextRound_from_Intermission_advances_SongIndex_and_CurrentSong()
+    {
+        var processor = CreateProcessor(out var store, out var bus);
+        var catalog = new[] { Song("s1", "One"), Song("s2", "Two") };
+        SeededIntermission(store, catalog, songIndex: 0);
+
+        var result = await processor.ApplyAsync(Session, Performer,
+            new NextRound(new SongId("s2"))
+            {
+                SessionCode = Session,
+                IssuedByRole = Role.Performer,
+                IssuedById = "perf-1"
+            });
+
+        Assert.Equal(Outcome.Applied, result.Outcome);
+        Assert.True(store.TryGet(Session, out var next));
+        Assert.Equal(PhaseEnum.Start, next!.Phase);
+        Assert.Equal(1, next.SongIndex);
+        Assert.Equal("s2", next.CurrentSong!.Id.Value);
+        Assert.Equal("Two", next.CurrentSong.Title);
+        Assert.Contains(bus.Published.OfType<CurrentSongSet>(), e => e.SongIndex == 1);
+    }
+
+    [Fact]
+    public async Task Audience_cannot_advance_NextRound_or_EndGame()
+    {
+        var processor = CreateProcessor(out var store, out var bus);
+        var catalog = new[] { Song("s1", "One"), Song("s2", "Two") };
+        SeededIntermission(store, catalog);
+
+        var next = await processor.ApplyAsync(Session, Audience,
+            new NextRound(new SongId("s2"))
+            {
+                SessionCode = Session,
+                IssuedByRole = Role.Audience,
+                IssuedById = "aud-1"
+            });
+        Assert.Equal(Outcome.Rejected, next.Outcome);
+        Assert.Equal(403, next.Problem!.Status);
+
+        var end = await processor.ApplyAsync(Session, Audience,
+            new EndGame
+            {
+                SessionCode = Session,
+                IssuedByRole = Role.Audience,
+                IssuedById = "aud-1"
+            });
+        Assert.Equal(Outcome.Rejected, end.Outcome);
+        Assert.Equal(403, end.Problem!.Status);
+        Assert.Empty(bus.Published);
+    }
+
+    [Fact]
+    public async Task EndGame_moves_to_Finished_and_retains_identifiable_scores_for_30_days()
+    {
+        var results = new InMemorySessionResultsStore();
+        var processor = CreateProcessor(out var store, out _, results);
+        var catalog = new[] { Song("s1", "One"), Song("s2", "Two") };
+        SeededIntermission(store, catalog, songIndex: 1);
+
+        var cmd = new EndGame
+        {
+            SessionCode = Session,
+            IssuedByRole = Role.Performer,
+            IssuedById = "perf-1"
+        };
+        var result = await processor.ApplyAsync(Session, Performer, cmd, workspaceId: "ws-1");
+
+        Assert.Equal(Outcome.Applied, result.Outcome);
+        Assert.True(store.TryGet(Session, out var finished));
+        Assert.Equal(PhaseEnum.Finished, finished!.Phase);
+
+        var retained = await results.GetAsync("ws-1", Session);
+        Assert.NotNull(retained);
+        Assert.Equal(10, retained!.Scores["aud-1"]);
+        Assert.Equal(cmd.CommandId, retained.CausingCommandId);
+        Assert.True(retained.SongCount >= 2);
+
+        Assert.Equal(0, await results.PruneExpiredAsync(DateTimeOffset.UtcNow.AddDays(29)));
+        Assert.Equal(1, await results.PruneExpiredAsync(DateTimeOffset.UtcNow.AddDays(31)));
+        Assert.Null(await results.GetAsync("ws-1", Session));
+    }
+}

--- a/Nuotti.Backend/Commands/SessionCommandProcessor.cs
+++ b/Nuotti.Backend/Commands/SessionCommandProcessor.cs
@@ -2,6 +2,7 @@ using Nuotti.Backend.Audit;
 using Nuotti.Backend.Idempotency;
 using Nuotti.Backend.Metrics;
 using Nuotti.Backend.Persistence;
+using Nuotti.Backend.Retention;
 using Nuotti.Backend.Sessions;
 using Nuotti.Backend.Telemetry;
 using Nuotti.Contracts.V1.Enum;
@@ -25,7 +26,8 @@ public sealed class SessionCommandProcessor(
     BackendMetrics? metrics = null,
     AuditLogService? audit = null,
     IDurableSessionCommitStore? durable = null,
-    DurableOutboxDispatcher? outbox = null) : ISessionCommandProcessor
+    DurableOutboxDispatcher? outbox = null,
+    ISessionResultsStore? results = null) : ISessionCommandProcessor
 {
     /// <summary>
     /// What a Command does. Events are reduced in order; the reducer ignores types it does not know,
@@ -245,6 +247,20 @@ public sealed class SessionCommandProcessor(
         }
 
         Complete(activity, command, stateChanged ? next : null);
+        if (command is EndGame && results is not null && stateChanged)
+        {
+            var sequence = durable is null
+                ? 0L
+                : (await durable.LoadAsync(workspaceId, session, ct))?.LastSequence.Value ?? 0L;
+            await results.SaveAsync(new SessionShowResult(
+                workspaceId,
+                session,
+                DateTimeOffset.UtcNow,
+                next.Scores,
+                sequence,
+                command.CommandId,
+                SongCount: Math.Max(next.SongIndex + 1, next.Catalog.Count)), ct);
+        }
         return CommandResult.Applied(stateChanged ? next : null);
     }
 
@@ -304,6 +320,21 @@ public sealed class SessionCommandProcessor(
 
             case PreparePlayback prepare:
                 return new Effects([prepare], BroadcastSnapshot: false, CheckIdempotency: false);
+
+            // NextRound must set CurrentSong/SongIndex before the generic IPhaseChange arm.
+            case NextRound nextRound:
+            {
+                var (song, index) = ResolveSong(state, nextRound.SongId);
+                return new Effects([
+                    Phase(state.Phase, nextRound.TargetPhase, session, command, correlation),
+                    new CurrentSongSet(song, index)
+                    {
+                        SessionCode = session,
+                        CausedByCommandId = command.CommandId,
+                        CorrelationId = correlation
+                    }
+                ]);
+            }
 
             case IPhaseChange phaseChange:
                 return new Effects([
@@ -403,6 +434,17 @@ public sealed class SessionCommandProcessor(
             CausedByCommandId = command.CommandId,
             CorrelationId = correlation
         };
+
+    static (SongRef Song, int Index) ResolveSong(GameStateSnapshot state, SongId songId)
+    {
+        for (var i = 0; i < state.Catalog.Count; i++)
+        {
+            if (state.Catalog[i].Id.Value == songId.Value)
+                return (state.Catalog[i], i);
+        }
+
+        return (new SongRef(songId, songId.Value, string.Empty), state.SongIndex + 1);
+    }
 
     static Role RequiredRole(CommandBase command)
         => command is SubmitAnswer ? Role.Audience : Role.Performer;

--- a/Nuotti.Backend/Persistence/SessionMessagePublisher.cs
+++ b/Nuotti.Backend/Persistence/SessionMessagePublisher.cs
@@ -19,6 +19,7 @@ public static class SessionMessagePublisher
     [
         Of<GamePhaseChanged>(), Of<CorrectAnswerRevealed>(), Of<HintGiven>(),
         Of<CatalogUpdated>(), Of<QuestionOffered>(), Of<AnswerSubmitted>(), Of<GameStateChanged>(),
+        Of<CurrentSongSet>(),
         Of<QuestionPushed>(false), Of<PlayTrack>(false), Of<StopTrack>(false),
         Of<PreparePlayback>(false)
     ];

--- a/Nuotti.Backend/Program.cs
+++ b/Nuotti.Backend/Program.cs
@@ -190,6 +190,7 @@ var auditLogger = new Serilog.LoggerConfiguration()
     .CreateLogger();
 builder.Services.AddSingleton<Serilog.ILogger>(provider => auditLogger);
 builder.Services.AddSingleton<Nuotti.Backend.Audit.AuditLogService>();
+builder.Services.AddSingleton<Nuotti.Backend.Retention.ISessionResultsStore, Nuotti.Backend.Retention.InMemorySessionResultsStore>();
 
 // Command processing: the only path by which a session's state changes.
 builder.Services.AddSingleton<ISessionCommandProcessor, SessionCommandProcessor>();

--- a/Nuotti.Backend/Retention/SessionResultsStore.cs
+++ b/Nuotti.Backend/Retention/SessionResultsStore.cs
@@ -1,0 +1,51 @@
+namespace Nuotti.Backend.Retention;
+
+/// <summary>
+/// Retained, reproducible Session results after EndGame. Identifiable scores are kept for 30 days.
+/// </summary>
+public sealed record SessionShowResult(
+    string WorkspaceId,
+    string SessionCode,
+    DateTimeOffset CompletedAtUtc,
+    IReadOnlyDictionary<string, int> Scores,
+    long LastSequence,
+    Guid CausingCommandId,
+    int SongCount);
+
+public interface ISessionResultsStore
+{
+    static readonly TimeSpan Retention = TimeSpan.FromDays(30);
+
+    Task SaveAsync(SessionShowResult result, CancellationToken cancellationToken = default);
+    Task<SessionShowResult?> GetAsync(string workspaceId, string sessionCode, CancellationToken cancellationToken = default);
+    Task<int> PruneExpiredAsync(DateTimeOffset nowUtc, CancellationToken cancellationToken = default);
+}
+
+public sealed class InMemorySessionResultsStore : ISessionResultsStore
+{
+    readonly Dictionary<(string Workspace, string Session), SessionShowResult> _results = new();
+    readonly object _gate = new();
+
+    public Task SaveAsync(SessionShowResult result, CancellationToken cancellationToken = default)
+    {
+        lock (_gate) _results[(result.WorkspaceId, result.SessionCode)] = result;
+        return Task.CompletedTask;
+    }
+
+    public Task<SessionShowResult?> GetAsync(string workspaceId, string sessionCode, CancellationToken cancellationToken = default)
+    {
+        lock (_gate)
+            return Task.FromResult(_results.TryGetValue((workspaceId, sessionCode), out var r) ? r : null);
+    }
+
+    public Task<int> PruneExpiredAsync(DateTimeOffset nowUtc, CancellationToken cancellationToken = default)
+    {
+        lock (_gate)
+        {
+            var cutoff = nowUtc - ISessionResultsStore.Retention;
+            var expired = _results.Where(kv => kv.Value.CompletedAtUtc < cutoff).Select(kv => kv.Key).ToList();
+            foreach (var key in expired) _results.Remove(key);
+            return Task.FromResult(expired.Count);
+        }
+    }
+}

--- a/Nuotti.Contracts.Tests/V1/Reducer/CurrentSongSetReducerTests.cs
+++ b/Nuotti.Contracts.Tests/V1/Reducer/CurrentSongSetReducerTests.cs
@@ -1,0 +1,34 @@
+using FluentAssertions;
+using Nuotti.Contracts.V1.Event;
+using Nuotti.Contracts.V1.Model;
+using Nuotti.Contracts.V1.Reducer;
+using Xunit;
+
+namespace Nuotti.Contracts.Tests.V1.Reducer;
+
+public class CurrentSongSetReducerTests
+{
+    [Fact]
+    public void CurrentSongSet_updates_SongIndex_CurrentSong_and_resets_HintIndex()
+    {
+        var song = new SongRef(new SongId("s2"), "Two", "Band");
+        var state = GameReducer.Initial("S") with
+        {
+            SongIndex = 0,
+            HintIndex = 2,
+            CurrentSong = new SongRef(new SongId("s1"), "One", "Band")
+        };
+
+        var (next, error) = GameReducer.Reduce(state, new CurrentSongSet(song, 1)
+        {
+            SessionCode = "S",
+            CausedByCommandId = Guid.NewGuid(),
+            CorrelationId = Guid.NewGuid()
+        });
+
+        error.Should().BeNull();
+        next.SongIndex.Should().Be(1);
+        next.CurrentSong.Should().Be(song);
+        next.HintIndex.Should().Be(0);
+    }
+}

--- a/Nuotti.Contracts/V1/Event/CurrentSongSet.cs
+++ b/Nuotti.Contracts/V1/Event/CurrentSongSet.cs
@@ -1,0 +1,13 @@
+using Nuotti.Contracts.V1.Message;
+using Nuotti.Contracts.V1.Model;
+
+namespace Nuotti.Contracts.V1.Event;
+
+/// <summary>
+/// Selects the CurrentSong and SongIndex for the next Round. Emitted with NextRound (and optionally Start).
+/// </summary>
+public sealed record CurrentSongSet(SongRef Song, int SongIndex) : EventBase
+{
+    public SongRef Song { get; } = Song;
+    public int SongIndex { get; } = SongIndex;
+}

--- a/Nuotti.Contracts/V1/Reducer/GameReducer.cs
+++ b/Nuotti.Contracts/V1/Reducer/GameReducer.cs
@@ -182,6 +182,15 @@ public static class GameReducer
             {
                 return (state with { Catalog = catalogUpdated.Catalog }, null);
             }
+            case CurrentSongSet songSet:
+            {
+                return (state with
+                {
+                    CurrentSong = songSet.Song,
+                    SongIndex = songSet.SongIndex,
+                    HintIndex = 0
+                }, null);
+            }
             case QuestionOffered offered:
             {
                 // Re-offering the same choices is a no-op. QuestionPushed skips idempotency by

--- a/Nuotti.Performer/PerformerCommands.cs
+++ b/Nuotti.Performer/PerformerCommands.cs
@@ -87,6 +87,18 @@ public sealed class PerformerCommands
         await SendAsync("next-round", cmd, ct);
     }
 
+    public async Task EndGameAsync(CancellationToken ct = default)
+    {
+        EnsureSession();
+        var cmd = new EndGame
+        {
+            SessionCode = _state.SessionCode!,
+            IssuedByRole = Role.Performer,
+            IssuedById = "performer-ui"
+        };
+        await SendAsync("end-game", cmd, ct);
+    }
+
     public async Task PlaySongAsync(SongId songId, CancellationToken ct = default)
     {
         EnsureSession();

--- a/Nuotti.Performer/Shared/CommandPalette.razor
+++ b/Nuotti.Performer/Shared/CommandPalette.razor
@@ -48,10 +48,11 @@
         _all = new List<PaletteAction>
         {
             new("start", "Start Set", async () => await StartSetAsync(), () => State.Phase is Phase.Lobby or Phase.Finished, "S"),
-            new("next", "Next Song", async () => await NextSongAsync(), () => State.Phase is Phase.Guessing && State.EngineCount > 0, "N"),
+            new("next", "Next Song", async () => await NextSongAsync(), () => State.Phase is Phase.Intermission or Phase.Guessing, "N"),
             new("hint", "Give Hint", async () => await GiveHintAsync(), () => State.Phase is Phase.Start or Phase.Hint or Phase.Guessing, "H"),
             new("lock", "Lock Answers", async () => await LockAnswersAsync(), () => State.Phase is Phase.Guessing, "L"),
             new("reveal", "Reveal", async () => await RevealAsync(), () => State.Phase is Phase.Lock && State.SelectedCorrectIndex.HasValue, "R"),
+            new("endgame", "End Game", async () => await Commands.EndGameAsync(), () => State.Phase is Phase.Intermission, "G"),
             new("end", "End Song", async () => await EndSongAsync(), () => State.Phase is Phase.Play && State.EngineCount > 0, "E"),
         };
         Filter();

--- a/Nuotti.Performer/Shared/ControlPanel.razor
+++ b/Nuotti.Performer/Shared/ControlPanel.razor
@@ -80,6 +80,14 @@
                 End Song (E)
             </MudButton>
         </MudItem>
+        <MudItem xs="12" sm="6" md="4" lg="2">
+            <MudButton Variant="Variant.Outlined" Color="Color.Error" FullWidth="true"
+                       data-testid="btn-end-game"
+                       StartIcon="@Material.Filled.Flag"
+                       OnClick="@(e => EndGame(e))" Disabled="@(!CanEndGame)">
+                End Game
+            </MudButton>
+        </MudItem>
     </MudGrid>
 </MudPaper>
 
@@ -149,7 +157,7 @@
     // State helpers
     bool HasSelection => State.SelectedCorrectIndex.HasValue;
     bool CanStartSet => State.Phase is Phase.Lobby or Phase.Finished;
-    bool CanNextSong => State.Phase is Phase.Guessing && State.EngineCount > 0; // NextRound requires Engine
+    bool CanNextSong => State.Phase is Phase.Intermission or Phase.Guessing;
     bool CanGiveHint => State.Phase is Phase.Guessing;
     bool CanOpenWindow => State.Phase is Phase.Start or Phase.Hint;
     bool CanLock => State.Phase is Phase.Guessing;
@@ -157,6 +165,7 @@
     bool CanPrepare => State.Phase is Phase.Reveal;
     bool CanStartPlayback => State.Phase is Phase.Reveal && !string.IsNullOrWhiteSpace(State.VenueAssetRevisionId);
     bool CanEndSong => State.Phase is Phase.Play && State.EngineCount > 0; // Stop requires Engine
+    bool CanEndGame => State.Phase is Phase.Intermission;
 
     // Debounce: prevent double-triggers within 500ms for all flow buttons
     readonly Dictionary<string, DateTime> _lastInvoke = new();
@@ -207,6 +216,12 @@
         {
             await Commands.NextSongAsync(songId);
         }
+    }
+
+    async Task EndGame(MouseEventArgs _)
+    {
+        if (Debounced(nameof(EndGame))) return;
+        await Commands.EndGameAsync();
     }
 
     async Task GiveHint(MouseEventArgs _)


### PR DESCRIPTION
## Summary
- `NextRound` emits `CurrentSongSet` so SongIndex/CurrentSong advance with the catalog song; only Performers may drive NextRound/EndGame.
- `EndGame` moves to Finished and stores identifiable scores in `ISessionResultsStore` with 30-day prune.
- Performer Control Panel / palette: Next Song from Intermission, End Game action.

Closes #260

## Test plan
- [x] `dotnet test` MultiRoundShow + CurrentSongSet + SessionCommandProcessorTests
- [x] Performer builds
- [ ] Manual: two-song Intermission → Next → End Game; verify Finished + retained scores