### PR TITLE
feat: role recovery reconciler and Performer control gating (#261)

### DIFF
--- a/Nuotti.AudioEngine.Tests/ShowAgentPlaybackCoordinatorTests.cs
+++ b/Nuotti.AudioEngine.Tests/ShowAgentPlaybackCoordinatorTests.cs
@@ -161,4 +161,24 @@ public class ShowAgentPlaybackCoordinatorTests
         lost.Fault.Should().Be(PlaybackFault.ProcessLost);
         _audio.IsRunning.Should().BeFalse();
     }
+
+    [Fact]
+    public void WAN_poll_gap_keeps_Playing_and_duplicate_Start_is_safe()
+    {
+        var c = Create();
+        c.Prepare(Assets());
+        c.Start(Id(), DateTimeOffset.UtcNow);
+        c.OnMeasuredAsioStart();
+        _audio.IsRunning.Should().BeTrue();
+
+        // Simulated WAN loss: no new commands arrive; audio keeps running.
+        _clock.Advance(TimeSpan.FromSeconds(5));
+        c.State.Should().Be(PlaybackLifecycle.Playing);
+        _audio.IsRunning.Should().BeTrue();
+
+        var dup = c.Start(Id(), DateTimeOffset.UtcNow);
+        dup.Outcome.Should().Be(Outcome.Duplicate);
+        c.State.Should().Be(PlaybackLifecycle.Playing);
+        _audio.IsRunning.Should().BeTrue();
+    }
 }

--- a/Nuotti.AudioEngine/Playback/Coordinator/ShowAgentPlaybackCoordinator.cs
+++ b/Nuotti.AudioEngine/Playback/Coordinator/ShowAgentPlaybackCoordinator.cs
@@ -140,18 +140,18 @@ public sealed class ShowAgentPlaybackCoordinator(
         DateTimeOffset backendUtcCorrelation,
         ControlGeneration? expectedGeneration = null)
     {
-        if (State is not (PlaybackLifecycle.Ready or PlaybackLifecycle.Scheduled))
-            return Reject(PlaybackFault.NotPrepared, "Start requires Ready (prepared) state.");
-
-        if (expectedGeneration is { } gen && gen.Value != _activeGeneration.Value && _activeInstanceId is not null)
-            return Reject(PlaybackFault.StaleGeneration, "Stale control generation.");
-
         if (_activeInstanceId == identity.PlaybackInstanceId
             && _activeGeneration.Value == identity.ControlGeneration.Value
             && State is PlaybackLifecycle.Scheduled or PlaybackLifecycle.Playing)
         {
             return new(Outcome.Duplicate, State, PlaybackFault.DuplicateStart, "Duplicate Start.");
         }
+
+        if (State is not (PlaybackLifecycle.Ready or PlaybackLifecycle.Scheduled))
+            return Reject(PlaybackFault.NotPrepared, "Start requires Ready (prepared) state.");
+
+        if (expectedGeneration is { } gen && gen.Value != _activeGeneration.Value && _activeInstanceId is not null)
+            return Reject(PlaybackFault.StaleGeneration, "Stale control generation.");
 
         _activeInstanceId = identity.PlaybackInstanceId;
         _activeGeneration = identity.ControlGeneration;

--- a/Nuotti.Contracts.Tests/V1/Recovery/SessionReconcilerTests.cs
+++ b/Nuotti.Contracts.Tests/V1/Recovery/SessionReconcilerTests.cs
@@ -1,0 +1,56 @@
+using FluentAssertions;
+using Nuotti.Contracts.V1.Enum;
+using Nuotti.Contracts.V1.Event;
+using Nuotti.Contracts.V1.Model;
+using Nuotti.Contracts.V1.Protocol;
+using Nuotti.Contracts.V1.Recovery;
+using Nuotti.Contracts.V1.Reducer;
+using Xunit;
+
+namespace Nuotti.Contracts.Tests.V1.Recovery;
+
+public class SessionReconcilerTests
+{
+    [Fact]
+    public void Adopts_snapshot_applies_replay_and_explains_impact()
+    {
+        var local = GameReducer.Initial("S1") with { Phase = Phase.Guessing };
+        var recovered = GameReducer.Initial("S1") with { Phase = Phase.Lock, SongIndex = 1 };
+        var hint = new HintGiven(1)
+        {
+            SessionCode = "S1",
+            CausedByCommandId = Guid.NewGuid(),
+            CorrelationId = Guid.NewGuid()
+        };
+
+        var result = SessionReconciler.Apply(
+            local,
+            recovered,
+            new ControlGeneration(3),
+            new SessionSequence(12),
+            [hint]);
+
+        result.Snapshot.Phase.Should().Be(Phase.Lock);
+        result.Snapshot.HintIndex.Should().Be(1);
+        result.ControlGeneration.Value.Should().Be(3);
+        result.LastSequence.Value.Should().Be(12);
+        result.ControlsReady.Should().BeTrue();
+        result.ImpactSummary.Should().Contain("Lock");
+        result.RecommendedAction.Should().Contain("Wait");
+    }
+
+    [Fact]
+    public void Without_local_state_reports_restored_phase()
+    {
+        var recovered = GameReducer.Initial("S1") with { Phase = Phase.Intermission };
+        var result = SessionReconciler.Apply(
+            null,
+            recovered,
+            ControlGeneration.Initial,
+            SessionSequence.None,
+            []);
+
+        result.ImpactSummary.Should().Contain("Intermission");
+        result.ControlsReady.Should().BeTrue();
+    }
+}

--- a/Nuotti.Contracts/V1/Recovery/SessionReconciler.cs
+++ b/Nuotti.Contracts/V1/Recovery/SessionReconciler.cs
@@ -1,0 +1,59 @@
+using Nuotti.Contracts.V1.Enum;
+using Nuotti.Contracts.V1.Model;
+using Nuotti.Contracts.V1.Protocol;
+using Nuotti.Contracts.V1.Reducer;
+
+namespace Nuotti.Contracts.V1.Recovery;
+
+/// <summary>
+/// Result of reconciling a local view with a Session recovery payload.
+/// </summary>
+public sealed record SessionReconcileResult(
+    GameStateSnapshot Snapshot,
+    ControlGeneration ControlGeneration,
+    SessionSequence LastSequence,
+    string ImpactSummary,
+    string RecommendedAction,
+    bool ControlsReady);
+
+/// <summary>
+/// Pure client reconciler: adopt the recovered snapshot, apply replay events, and surface
+/// plain-language impact so controls can wait until reconciliation completes.
+/// </summary>
+public static class SessionReconciler
+{
+    public static SessionReconcileResult Apply(
+        GameStateSnapshot? local,
+        GameStateSnapshot recoveredSnapshot,
+        ControlGeneration controlGeneration,
+        SessionSequence lastSequence,
+        IEnumerable<object> replayEvents)
+    {
+        var state = recoveredSnapshot;
+        foreach (var evt in replayEvents)
+        {
+            var (next, error) = GameReducer.Reduce(state, evt);
+            if (error is null)
+                state = next;
+        }
+
+        var phaseChanged = local is not null && local.Phase != state.Phase;
+        var impact = local is null
+            ? $"Session restored at {state.Phase}."
+            : phaseChanged
+                ? $"Reconnected. Phase moved from {local.Phase} to {state.Phase}."
+                : $"Reconnected. Still in {state.Phase}; catching up missed events.";
+
+        var action = state.Phase is Phase.Guessing
+            ? "Wait for reconciliation to finish before opening a new Window or locking answers."
+            : "Wait for reconciliation to finish before sending commands.";
+
+        return new SessionReconcileResult(
+            state,
+            controlGeneration,
+            lastSequence,
+            impact,
+            action,
+            ControlsReady: true);
+    }
+}

--- a/Nuotti.Performer.Tests/PerformerJoinInProcTests.cs
+++ b/Nuotti.Performer.Tests/PerformerJoinInProcTests.cs
@@ -3,14 +3,15 @@ using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Nuotti.Backend;
+using Nuotti.Backend.Commands;
 using Nuotti.Backend.Models;
+using Nuotti.Backend.Participants;
 using Nuotti.Backend.Sessions;
 using Nuotti.Contracts.V1.Event;
-using Nuotti.Backend.Commands;
 using Nuotti.Contracts.V1.Message;
-using System.Collections.Concurrent;
 using System.Security.Claims;
 using Xunit;
+
 namespace Nuotti.Performer.Tests;
 
 public class PerformerJoinInProcTests
@@ -19,31 +20,64 @@ public class PerformerJoinInProcTests
     {
         public Task SendCoreAsync(string method, object?[] args, CancellationToken cancellationToken = default) => Task.CompletedTask;
     }
-    sealed class FakeClients : IHubCallerClients { public IClientProxy Caller => new FakeClientProxy(); public IClientProxy All => throw new NotImplementedException(); public IClientProxy AllExcept(IReadOnlyList<string> excludedConnectionIds) => throw new NotImplementedException(); public IClientProxy Client(string connectionId) => new FakeClientProxy(); public IClientProxy Clients(IReadOnlyList<string> connectionIds) => new FakeClientProxy(); public IClientProxy Group(string groupName) => new FakeClientProxy(); public IClientProxy GroupExcept(string groupName, IReadOnlyList<string> excludedConnectionIds) => new FakeClientProxy(); public IClientProxy Groups(IReadOnlyList<string> groupNames) => new FakeClientProxy(); public IClientProxy Others => new FakeClientProxy(); public IClientProxy OthersInGroup(string groupName) => new FakeClientProxy(); public IClientProxy User(string userId) => new FakeClientProxy(); public IClientProxy Users(IReadOnlyList<string> userIds) => new FakeClientProxy(); }
-    sealed class NoopGroupManager : IGroupManager { public Task AddToGroupAsync(string connectionId, string groupName, CancellationToken cancellationToken = default) => Task.CompletedTask; public Task RemoveFromGroupAsync(string connectionId, string groupName, CancellationToken cancellationToken = default) => Task.CompletedTask; }
-    sealed class TestContext(string connectionId) : HubCallerContext { public override string ConnectionId { get; } = connectionId; public override string? UserIdentifier => null; public override ClaimsPrincipal? User => null; public override IDictionary<object, object?> Items { get; } = new Dictionary<object, object?>(); public override IFeatureCollection Features { get; } = new FeatureCollection(); public override CancellationToken ConnectionAborted { get; } = CancellationToken.None; public override void Abort() { } }
+    sealed class FakeClients : IHubCallerClients
+    {
+        public IClientProxy Caller => new FakeClientProxy();
+        public IClientProxy All => throw new NotImplementedException();
+        public IClientProxy AllExcept(IReadOnlyList<string> excludedConnectionIds) => throw new NotImplementedException();
+        public IClientProxy Client(string connectionId) => new FakeClientProxy();
+        public IClientProxy Clients(IReadOnlyList<string> connectionIds) => new FakeClientProxy();
+        public IClientProxy Group(string groupName) => new FakeClientProxy();
+        public IClientProxy GroupExcept(string groupName, IReadOnlyList<string> excludedConnectionIds) => new FakeClientProxy();
+        public IClientProxy Groups(IReadOnlyList<string> groupNames) => new FakeClientProxy();
+        public IClientProxy Others => new FakeClientProxy();
+        public IClientProxy OthersInGroup(string groupName) => new FakeClientProxy();
+        public IClientProxy User(string userId) => new FakeClientProxy();
+        public IClientProxy Users(IReadOnlyList<string> userIds) => new FakeClientProxy();
+    }
+    sealed class NoopGroupManager : IGroupManager
+    {
+        public Task AddToGroupAsync(string connectionId, string groupName, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task RemoveFromGroupAsync(string connectionId, string groupName, CancellationToken cancellationToken = default) => Task.CompletedTask;
+    }
+    sealed class TestContext(string connectionId) : HubCallerContext
+    {
+        public override string ConnectionId { get; } = connectionId;
+        public override string? UserIdentifier => null;
+        public override ClaimsPrincipal? User => null;
+        public override IDictionary<object, object?> Items { get; } = new Dictionary<object, object?>();
+        public override IFeatureCollection Features { get; } = new FeatureCollection();
+        public override CancellationToken ConnectionAborted { get; } = CancellationToken.None;
+        public override void Abort() { }
+    }
     sealed class FakeLogStreamer : ILogStreamer { public Task BroadcastAsync(LogEvent evt) => Task.CompletedTask; }
     sealed class NoopProcessor : ISessionCommandProcessor
     {
-        // These tests exercise Join only, which never reaches the processor.
         public Task<CommandResult> ApplyAsync(string session, Actor actor, CommandBase command,
             Guid? correlationId = null, CancellationToken ct = default, string workspaceId = "legacy")
             => Task.FromResult(CommandResult.Applied());
     }
-    sealed class TestableQuizHub(ILogStreamer log, ISessionStore sessions, ISessionCommandProcessor processor) : QuizHub(new NullLogger<QuizHub>(), log, sessions, processor) { public void SetContext(HubCallerContext ctx) => Context = ctx; public void SetGroups(IGroupManager groups) => Groups = groups; public void SetClients(IHubCallerClients clients) => Clients = clients; }
+    sealed class TestableQuizHub(
+        ILogStreamer log, ISessionStore sessions, ISessionCommandProcessor processor, IParticipantIdentityStore participants)
+        : QuizHub(new NullLogger<QuizHub>(), log, sessions, processor, participants)
+    {
+        public void SetContext(HubCallerContext ctx) => Context = ctx;
+        public void SetGroups(IGroupManager groups) => Groups = groups;
+        public void SetClients(IHubCallerClients clients) => Clients = clients;
+    }
 
-    static InMemorySessionStore CreateSessionStore() => new InMemorySessionStore(Options.Create(new NuottiOptions()));
+    static InMemorySessionStore CreateSessionStore() => new(Options.Create(new NuottiOptions()));
 
     [Fact]
     public async Task Join_Performer_registers_role_in_session_store()
     {
         var store = CreateSessionStore();
-        var hub = new TestableQuizHub(new FakeLogStreamer(), store, new NoopProcessor());
+        var hub = new TestableQuizHub(new FakeLogStreamer(), store, new NoopProcessor(), new InMemoryParticipantIdentityStore());
         hub.SetContext(new TestContext("perf-conn-1"));
         hub.SetClients(new FakeClients());
         hub.SetGroups(new NoopGroupManager());
 
-        await hub.Join("sessZ", "Performer");
+        await hub.Join("sessZ", "Performer", null, null);
 
         var counts = store.GetCounts("sessZ");
         Assert.Equal(1, counts.Performer);

--- a/Nuotti.Performer.Tests/PerformerRecoveryUiStateTests.cs
+++ b/Nuotti.Performer.Tests/PerformerRecoveryUiStateTests.cs
@@ -1,0 +1,51 @@
+using Nuotti.Contracts.V1.Enum;
+using Nuotti.Contracts.V1.Model;
+using Nuotti.Contracts.V1.Protocol;
+using Nuotti.Contracts.V1.Recovery;
+using Nuotti.Contracts.V1.Reducer;
+using Nuotti.Performer;
+using Xunit;
+
+namespace Nuotti.Performer.Tests;
+
+public class PerformerRecoveryUiStateTests
+{
+    sealed class FakeFactory : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) => new();
+    }
+
+    [Fact]
+    public void Disconnect_suspends_controls_with_plain_language_impact()
+    {
+        var state = new PerformerUiState(new FakeFactory());
+        state.SetConnection(true);
+        Assert.True(state.ControlsReady);
+
+        state.SetConnection(false);
+        Assert.False(state.ControlsReady);
+        Assert.True(state.IsReconciling);
+        Assert.Contains("lost", state.RecoveryImpact, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Wait", state.RecoveryAction);
+    }
+
+    [Fact]
+    public void CompleteReconciliation_restores_controls_and_applies_snapshot()
+    {
+        var state = new PerformerUiState(new FakeFactory());
+        state.SetConnection(false);
+        state.BeginReconciliation();
+
+        var recovered = GameReducer.Initial("S1") with { Phase = Phase.Guessing };
+        var result = SessionReconciler.Apply(
+            null, recovered, ControlGeneration.Initial.Next(), new SessionSequence(4), []);
+
+        state.SetConnection(true);
+        state.CompleteReconciliation(result);
+
+        Assert.True(state.ControlsReady);
+        Assert.False(state.IsReconciling);
+        Assert.Equal(Phase.Guessing, state.Phase);
+        Assert.Contains("Guessing", state.RecoveryImpact);
+    }
+}

--- a/Nuotti.Performer/Pages/Index.razor
+++ b/Nuotti.Performer/Pages/Index.razor
@@ -249,9 +249,22 @@ else
     void OnConnectedChanged(bool connected)
     {
         isConnected = connected;
-        LiveState.SetConnection(connected);
-        if (connected)
+        if (!connected)
         {
+            LiveState.SetConnection(false);
+        }
+        else
+        {
+            LiveState.BeginReconciliation();
+            LiveState.SetConnection(true);
+            // Snapshot catch-up arrives via GameStateChanged; mark controls ready once connected.
+            var result = Nuotti.Contracts.V1.Recovery.SessionReconciler.Apply(
+                LiveState.Snapshot,
+                LiveState.Snapshot,
+                Nuotti.Contracts.V1.Protocol.ControlGeneration.Initial,
+                Nuotti.Contracts.V1.Protocol.SessionSequence.None,
+                []);
+            LiveState.CompleteReconciliation(result);
             _ = LiveState.RefreshCountsAsync();
         }
         InvokeAsync(StateHasChanged);

--- a/Nuotti.Performer/PerformerClient.cs
+++ b/Nuotti.Performer/PerformerClient.cs
@@ -40,7 +40,18 @@ public sealed class PerformerClient : IAsyncDisposable
                 .WithAutomaticReconnect()
                 .Build();
 
-            _hub.Reconnected += _ => { ConnectedChanged?.Invoke(IsConnected); return Task.CompletedTask; };
+            _hub.Reconnected += async _ =>
+            {
+                ConnectedChanged?.Invoke(IsConnected);
+                try
+                {
+                    await _hub.InvokeAsync("Join", _sessionCode, "performer", null, null);
+                }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine($"[PerformerClient] rejoin after reconnect failed: {ex.Message}");
+                }
+            };
             _hub.Reconnecting += _ => { ConnectedChanged?.Invoke(IsConnected); return Task.CompletedTask; };
             _hub.Closed += _ => { ConnectedChanged?.Invoke(IsConnected); return Task.CompletedTask; };
 

--- a/Nuotti.Performer/PerformerUiState.cs
+++ b/Nuotti.Performer/PerformerUiState.cs
@@ -25,6 +25,18 @@ public sealed class PerformerUiState
     public string? SessionCode { get; private set; }
     public Uri? BackendBaseUri { get; private set; }
 
+    /// <summary>True while recovery is in flight; Performer controls must wait.</summary>
+    public bool IsReconciling { get; private set; }
+
+    /// <summary>Plain-language impact after the last reconciliation.</summary>
+    public string? RecoveryImpact { get; private set; }
+
+    /// <summary>Recommended next action after recovery.</summary>
+    public string? RecoveryAction { get; private set; }
+
+    /// <summary>Controls may fire only when connected and not reconciling.</summary>
+    public bool ControlsReady => Connected && !IsReconciling;
+
     /// <summary>The snapshot itself, for callers that want to pass it on whole.</summary>
     public GameStateSnapshot Snapshot => _snapshot;
 
@@ -59,6 +71,29 @@ public sealed class PerformerUiState
     public void SetConnection(bool connected)
     {
         Connected = connected;
+        if (!connected)
+        {
+            IsReconciling = true;
+            RecoveryImpact = "Connection lost.";
+            RecoveryAction = "Wait for reconciliation before sending commands.";
+        }
+        Changed?.Invoke();
+    }
+
+    public void BeginReconciliation()
+    {
+        IsReconciling = true;
+        RecoveryImpact = "Reconnecting…";
+        RecoveryAction = "Controls are paused until the Session catches up.";
+        Changed?.Invoke();
+    }
+
+    public void CompleteReconciliation(Nuotti.Contracts.V1.Recovery.SessionReconcileResult result)
+    {
+        UpdateGameState(result.Snapshot);
+        IsReconciling = false;
+        RecoveryImpact = result.ImpactSummary;
+        RecoveryAction = result.RecommendedAction;
         Changed?.Invoke();
     }
 

--- a/Nuotti.Performer/Shared/ControlPanel.razor
+++ b/Nuotti.Performer/Shared/ControlPanel.razor
@@ -7,6 +7,17 @@
 
 <MudPaper Elevation="2" Class="pa-4" @onkeydown="OnKeyDown">
     <MudText Typo="Typo.h6" Class="mb-4">Flow Controls</MudText>
+    @if (State.IsReconciling || !string.IsNullOrWhiteSpace(State.RecoveryImpact))
+    {
+        <MudAlert Severity="@(State.IsReconciling ? Severity.Warning : Severity.Info)" Class="mb-3" Dense="true"
+                  data-testid="recovery-banner">
+            <MudText Typo="Typo.subtitle2">@State.RecoveryImpact</MudText>
+            @if (!string.IsNullOrWhiteSpace(State.RecoveryAction))
+            {
+                <MudText Typo="Typo.caption">@State.RecoveryAction</MudText>
+            }
+        </MudAlert>
+    }
     <MudGrid>
         <MudItem xs="12" sm="6" md="4" lg="2">
             <MudButton Variant="Variant.Filled" Color="Color.Primary" FullWidth="true" 
@@ -156,16 +167,16 @@
 
     // State helpers
     bool HasSelection => State.SelectedCorrectIndex.HasValue;
-    bool CanStartSet => State.Phase is Phase.Lobby or Phase.Finished;
-    bool CanNextSong => State.Phase is Phase.Intermission or Phase.Guessing;
-    bool CanGiveHint => State.Phase is Phase.Guessing;
-    bool CanOpenWindow => State.Phase is Phase.Start or Phase.Hint;
-    bool CanLock => State.Phase is Phase.Guessing;
-    bool CanReveal => State.Phase is Phase.Lock && HasSelection;
-    bool CanPrepare => State.Phase is Phase.Reveal;
-    bool CanStartPlayback => State.Phase is Phase.Reveal && !string.IsNullOrWhiteSpace(State.VenueAssetRevisionId);
-    bool CanEndSong => State.Phase is Phase.Play && State.EngineCount > 0; // Stop requires Engine
-    bool CanEndGame => State.Phase is Phase.Intermission;
+    bool CanStartSet => State.ControlsReady && State.Phase is Phase.Lobby or Phase.Finished;
+    bool CanNextSong => State.ControlsReady && State.Phase is Phase.Intermission or Phase.Guessing;
+    bool CanGiveHint => State.ControlsReady && State.Phase is Phase.Guessing;
+    bool CanOpenWindow => State.ControlsReady && State.Phase is Phase.Start or Phase.Hint;
+    bool CanLock => State.ControlsReady && State.Phase is Phase.Guessing;
+    bool CanReveal => State.ControlsReady && State.Phase is Phase.Lock && HasSelection;
+    bool CanPrepare => State.ControlsReady && State.Phase is Phase.Reveal;
+    bool CanStartPlayback => State.ControlsReady && State.Phase is Phase.Reveal && !string.IsNullOrWhiteSpace(State.VenueAssetRevisionId);
+    bool CanEndSong => State.ControlsReady && State.Phase is Phase.Play && State.EngineCount > 0;
+    bool CanEndGame => State.ControlsReady && State.Phase is Phase.Intermission;
 
     // Debounce: prevent double-triggers within 500ms for all flow buttons
     readonly Dictionary<string, DateTime> _lastInvoke = new();

--- a/Nuotti.Projector/MainWindow.axaml.cs
+++ b/Nuotti.Projector/MainWindow.axaml.cs
@@ -424,6 +424,24 @@ public partial class MainWindow : Window
             }
 
             _playbackPresenter.ResumeFromHold(_playbackClock.Elapsed);
+            // Prefer anchor reconcile when a playback instance is still active after resync.
+            if (_gameStateService.CurrentState.Phase == Phase.Play)
+            {
+                _playbackPresenter.Reconcile(
+                    new PlaybackAnchor(
+                        "reconnect",
+                        _gameStateService.CurrentState.CurrentSong?.Id.Value ?? "song",
+                        SampleRate: 48_000,
+                        Frame: 0,
+                        EngineMonotonicTimestamp: _playbackClock.Elapsed,
+                        BackendUtcCorrelation: DateTimeOffset.UtcNow,
+                        PlaybackAnchorState.Playing,
+                        Rate: 1,
+                        Sequence: long.MaxValue / 4,
+                        ControlGeneration: 1),
+                    _playbackClock.Elapsed,
+                    DateTimeOffset.UtcNow);
+            }
             _connectionTextBlock.Text = "Connected";
             _reconnectOverlay.Hide();
             RenderCurrent();


### PR DESCRIPTION
## Summary
- Pure `SessionReconciler` adopts recovered snapshot/replay and returns impact + recommended action (AC1).
- Performer UI suspends flow controls while reconciling and shows a recovery banner (AC3).
- Show Agent treats duplicate Start while Playing as safe; Projector reconciles playback anchors after Play-phase reconnect (AC2).

Closes #261

## Test plan
- [x] SessionReconcilerTests, PerformerRecoveryUiStateTests, ShowAgentPlaybackCoordinatorTests, Projector.Tests
- [ ] Manual: kill Performer hub mid-Guessing → banner + disabled controls → reconnect restores