### PR TITLE
feat: production diagnostics, governance, and entitlement seams (#262)

### DIFF
--- a/Nuotti.Backend.Tests/GovernanceJourneyTests.cs
+++ b/Nuotti.Backend.Tests/GovernanceJourneyTests.cs
@@ -1,0 +1,128 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Security.Cryptography;
+using System.Text.Json;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Nuotti.Backend;
+using Nuotti.Backend.Assets;
+using Nuotti.Backend.ShowAgents;
+using Nuotti.Backend.Workspaces;
+using Nuotti.Contracts.V1.Governance;
+
+namespace Nuotti.Backend.Tests;
+
+public sealed class GovernanceJourneyTests(WebApplicationFactory<QuizHub> baseFactory)
+    : IClassFixture<WebApplicationFactory<QuizHub>>
+{
+    readonly WebApplicationFactory<QuizHub> _factory = baseFactory.WithWebHostBuilder(_ => { });
+
+    [Fact]
+    public async Task Verbose_export_requires_entitlement_and_takedown_blocks_download()
+    {
+        using var client = _factory.CreateClient();
+        var owner = await SignInAsync(client, "gov-owner");
+        var workspace = await PostAsync<WorkspaceAccess>(client, "/v1/workspaces", owner.SessionToken, new { name = "Gov band" });
+        await SelectAsync(client, owner.SessionToken, workspace.WorkspaceId);
+
+        var deniedExport = await SendAsync(client, HttpMethod.Post,
+            $"/v1/workspaces/{workspace.WorkspaceId}/diagnostics/export", owner.SessionToken);
+        Assert.Equal(HttpStatusCode.Forbidden, deniedExport.StatusCode);
+
+        var elevated = await PostAsync<JsonElement>(client,
+            $"/v1/workspaces/{workspace.WorkspaceId}/diagnostics/verbose", owner.SessionToken,
+            new { minutes = 10, verbose = true });
+        Assert.Equal("Verbose", elevated.GetProperty("level").GetString());
+
+        var export = await SendAsync(client, HttpMethod.Post,
+            $"/v1/workspaces/{workspace.WorkspaceId}/diagnostics/export", owner.SessionToken);
+        Assert.Equal(HttpStatusCode.OK, export.StatusCode);
+        Assert.Equal("application/zip", export.Content.Headers.ContentType?.MediaType);
+        Assert.True((await export.Content.ReadAsByteArrayAsync()).Length > 20);
+
+        var entry = await PostAsync<PrivateCatalogEntry>(client,
+            $"/v1/workspaces/{workspace.WorkspaceId}/catalog", owner.SessionToken,
+            new { title = "Restricted", artist = "Band" });
+        var bytes = "gov-audio"u8.ToArray();
+        var upload = await PostAsync<PrivateAssetUploadGrant>(client,
+            $"/v1/workspaces/{workspace.WorkspaceId}/catalog/{entry.CatalogEntryId}/asset-uploads", owner.SessionToken,
+            new
+            {
+                assetType = "backing-track", contentType = "audio/wav", size = bytes.LongLength,
+                provenance = new
+                {
+                    source = "owned", rightsBasis = "original", territory = "NO",
+                    permittedUses = new[] { "backing-track" }, rightsExpiresAt = (DateTimeOffset?)null,
+                    supportingDocumentReference = "gov-case"
+                }
+            });
+        var metadata = _factory.Services.GetRequiredService<IPrivateAssetMetadataStore>();
+        var objects = Assert.IsType<InMemoryPrivateAssetObjectStore>(_factory.Services.GetRequiredService<IPrivateAssetObjectStore>());
+        var objectKey = await metadata.GetObjectKeyAsync(workspace.WorkspaceId, upload.Revision.RevisionId);
+        objects.PutDirect(objectKey!, bytes, "audio/wav");
+        var sha256 = Convert.ToHexString(SHA256.HashData(bytes)).ToLowerInvariant();
+        var published = await PostAsync<PrivateAssetRevision>(client,
+            $"/v1/workspaces/{workspace.WorkspaceId}/revisions/{upload.Revision.RevisionId}/publish", owner.SessionToken,
+            new { sha256 });
+
+        await PostAsync<TakedownCase>(client,
+            $"/v1/workspaces/{workspace.WorkspaceId}/assets/{published.RevisionId}/takedown", owner.SessionToken,
+            new { reason = "rights dispute" });
+        var blocked = await SendAsync(client, HttpMethod.Post,
+            $"/v1/workspaces/{workspace.WorkspaceId}/revisions/{published.RevisionId}/download", owner.SessionToken);
+        Assert.Equal(HttpStatusCode.Forbidden, blocked.StatusCode);
+    }
+
+    [Fact]
+    public async Task Show_agent_token_includes_verifiable_signed_lease()
+    {
+        using var client = _factory.CreateClient();
+        var owner = await SignInAsync(client, "lease-owner");
+        var workspace = await PostAsync<WorkspaceAccess>(client, "/v1/workspaces", owner.SessionToken, new { name = "Lease band" });
+        await SelectAsync(client, owner.SessionToken, workspace.WorkspaceId);
+        (await SendAsync(client, HttpMethod.Post,
+            $"/v1/workspaces/{workspace.WorkspaceId}/sessions/LEASE1/create", owner.SessionToken)).EnsureSuccessStatusCode();
+
+        var pairing = await PostAsync<ShowAgentPairingCode>(client,
+            $"/v1/workspaces/{workspace.WorkspaceId}/sessions/LEASE1/show-agent/pairings", owner.SessionToken, null);
+        var paired = await PostAsync<PairedShowAgent>(client, "/v1/show-agent/pair", null,
+            new { code = pairing.Code, name = "Lease laptop" });
+        var tokenResponse = await PostAsync<JsonElement>(client, "/v1/show-agent/token", null,
+            new { credential = paired.Credential });
+        var signed = tokenResponse.GetProperty("signedLease");
+        Assert.False(string.IsNullOrWhiteSpace(signed.GetProperty("signature").GetString()));
+
+        var lease = JsonSerializer.Deserialize<SignedLease>(signed.GetRawText(), new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true
+        })!;
+        var governance = _factory.Services.GetRequiredService<Nuotti.Backend.Governance.ProductionGovernance>();
+        Assert.True(governance.LeaseIssuer.TryVerify(lease, DateTimeOffset.UtcNow, out _));
+    }
+
+    static async Task<RedeemedMagicLink> SignInAsync(HttpClient client, string prefix)
+    {
+        var link = await PostAsync<IssuedMagicLink>(client, "/v1/auth/magic-links", null,
+            new { email = $"{prefix}-{Guid.NewGuid():N}@example.test" });
+        return await PostAsync<RedeemedMagicLink>(client, "/v1/auth/magic-links/redeem", null, new { token = link.Token });
+    }
+
+    static async Task SelectAsync(HttpClient client, string token, string workspaceId) =>
+        (await SendAsync(client, HttpMethod.Post, $"/v1/workspaces/{workspaceId}/select", token)).EnsureSuccessStatusCode();
+
+    static async Task<T> PostAsync<T>(HttpClient client, string path, string? token, object? body)
+    {
+        var response = await SendAsync(client, HttpMethod.Post, path, token, body);
+        response.EnsureSuccessStatusCode();
+        return (await response.Content.ReadFromJsonAsync<T>())!;
+    }
+
+    static async Task<HttpResponseMessage> SendAsync(HttpClient client, HttpMethod method, string path, string? token, object? body = null)
+    {
+        using var request = new HttpRequestMessage(method, path);
+        if (token is not null) request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        if (body is not null) request.Content = JsonContent.Create(body);
+        return await client.SendAsync(request);
+    }
+}

--- a/Nuotti.Backend/Audit/AuditLogService.cs
+++ b/Nuotti.Backend/Audit/AuditLogService.cs
@@ -49,6 +49,32 @@ public class AuditLogService
     }
 
     /// <summary>
+    /// Logs a governance / entitlement / diagnostics boundary action.
+    /// </summary>
+    public void LogGovernanceAction(string action, string workspaceId, string actorId, string detail)
+    {
+        using (LogContext.PushProperty("audit.type", "governance_action"))
+        using (LogContext.PushProperty("audit.action", action))
+        using (LogContext.PushProperty("audit.workspace_id", SafeWorkspace(workspaceId)))
+        using (LogContext.PushProperty("audit.actor_id", SafeActor(actorId)))
+        using (LogContext.PushProperty("audit.detail", detail))
+        {
+            _auditLogger.Information(
+                "Governance action: Action={Action}, Workspace={WorkspaceId}, Actor={ActorId}, Detail={Detail}",
+                action,
+                SafeWorkspace(workspaceId),
+                SafeActor(actorId),
+                detail);
+        }
+    }
+
+    static string SafeWorkspace(string workspaceId)
+        => Nuotti.Contracts.V1.Governance.SafeTelemetryIdentifiers.CorrelateWorkspace(workspaceId);
+
+    static string SafeActor(string actorId)
+        => Nuotti.Contracts.V1.Governance.SafeTelemetryIdentifiers.CorrelateActor(actorId);
+
+    /// <summary>
     /// Logs an event being published.
     /// </summary>
     public void LogEventPublished<TEvent>(TEvent evt)

--- a/Nuotti.Backend/Diagnostics/DiagnosticsBundleService.cs
+++ b/Nuotti.Backend/Diagnostics/DiagnosticsBundleService.cs
@@ -1,5 +1,6 @@
 using System.IO.Compression;
 using System.Text.Json;
+using Nuotti.Contracts.V1.Governance;
 using ServiceDefaults;
 
 namespace Nuotti.Backend.Diagnostics;
@@ -253,6 +254,46 @@ public class DiagnosticsBundleService
         }
 
         return Path.Combine(Path.GetTempPath(), fileName);
+    }
+
+    /// <summary>
+    /// Creates a support ZIP from bounded, redacted evidence (production diagnostics seam).
+    /// </summary>
+    public async Task<string> CreateBoundedBundleAsync(
+        BoundedSupportEvidence evidence,
+        string? workspaceId,
+        CancellationToken cancellationToken = default)
+    {
+        var timestamp = DateTimeOffset.UtcNow.ToString("yyyyMMdd-HHmmss");
+        var safeWorkspace = string.IsNullOrWhiteSpace(workspaceId)
+            ? "workspace"
+            : SafeTelemetryIdentifiers.CorrelateWorkspace(workspaceId).Replace(':', '-');
+        var fileName = $"nuotti-support-{safeWorkspace}-{timestamp}.zip";
+        var zipPath = Path.Combine(Path.GetTempPath(), fileName);
+
+        await using var zipStream = File.Create(zipPath);
+        using var archive = new ZipArchive(zipStream, ZipArchiveMode.Create);
+
+        var manifest = archive.CreateEntry("manifest.txt");
+        await using (var stream = manifest.Open())
+        await using (var writer = new StreamWriter(stream))
+            await writer.WriteAsync(evidence.RenderManifest(workspaceId ?? "anon"));
+
+        foreach (var item in evidence.Items)
+        {
+            var entry = archive.CreateEntry($"evidence/{SanitizeEntryName(item.Name)}.txt");
+            await using var stream = entry.Open();
+            await using var writer = new StreamWriter(stream);
+            await writer.WriteAsync(item.Content);
+        }
+
+        return zipPath;
+    }
+
+    static string SanitizeEntryName(string name)
+    {
+        var cleaned = new string(name.Select(c => char.IsLetterOrDigit(c) || c is '-' or '_' ? c : '_').ToArray());
+        return string.IsNullOrWhiteSpace(cleaned) ? "item" : cleaned;
     }
 }
 

--- a/Nuotti.Backend/Endpoints/GovernanceEndpoints.cs
+++ b/Nuotti.Backend/Endpoints/GovernanceEndpoints.cs
@@ -1,0 +1,146 @@
+using Microsoft.AspNetCore.Mvc;
+using Nuotti.Backend.Audit;
+using Nuotti.Backend.Governance;
+using Nuotti.Backend.Workspaces;
+using Nuotti.Contracts.V1.Governance;
+
+namespace Nuotti.Backend.Endpoints;
+
+internal static class GovernanceEndpoints
+{
+    public static void MapGovernanceEndpoints(this WebApplication app)
+    {
+        app.MapPost("/v1/workspaces/{workspaceId}/diagnostics/verbose", async (
+            HttpContext http,
+            string workspaceId,
+            ProductionGovernance governance,
+            IWorkspaceAccessStore access,
+            AuditLogService audit,
+            [FromBody] ElevateVerboseRequest? body,
+            CancellationToken ct) =>
+        {
+            var selected = await WorkspaceHttpAccess.RequireSelectedAsync(http, access, workspaceId, ct);
+            if (selected.Principal is null) return Results.Unauthorized();
+            if (selected.Access is null) return Results.NotFound();
+            if (selected.Access.Role != WorkspaceRole.Owner)
+                return Results.Forbid();
+
+            governance.Entitlements.Grant(workspaceId, EntitlementKind.DiagnosticsExport);
+            var ttl = TimeSpan.FromMinutes(Math.Clamp(body?.Minutes ?? 15, 1, 120));
+            var level = body?.Verbose == true ? DiagnosticVerbosity.Verbose : DiagnosticVerbosity.Debug;
+            var now = DateTimeOffset.UtcNow;
+            var scopeId = governance.VerboseCapture.Elevate(level, ttl, now, body?.ScopeId);
+            governance.ApplyVerboseLevel(now);
+            audit.LogGovernanceAction(
+                "diagnostics.verbose.elevate",
+                workspaceId,
+                selected.Principal.UserId,
+                $"scope={scopeId};level={level};ttlMinutes={ttl.TotalMinutes}");
+            return Results.Ok(new
+            {
+                scopeId,
+                level = level.ToString(),
+                expiresAt = now.Add(ttl)
+            });
+        });
+
+        app.MapPost("/v1/workspaces/{workspaceId}/diagnostics/export", async (
+            HttpContext http,
+            string workspaceId,
+            ProductionGovernance governance,
+            IWorkspaceAccessStore access,
+            Nuotti.Backend.Diagnostics.DiagnosticsBundleService bundles,
+            AuditLogService audit,
+            CancellationToken ct) =>
+        {
+            var selected = await WorkspaceHttpAccess.RequireSelectedAsync(http, access, workspaceId, ct);
+            if (selected.Principal is null) return Results.Unauthorized();
+            if (selected.Access is null) return Results.NotFound();
+            if (!governance.Entitlements.IsAllowed(workspaceId, EntitlementKind.DiagnosticsExport))
+                return Results.Json(new { title = "Not entitled", detail = "Diagnostics export requires an active entitlement." },
+                    statusCode: StatusCodes.Status403Forbidden);
+
+            var evidence = new BoundedSupportEvidence();
+            evidence.TryAdd("workspace", SafeTelemetryIdentifiers.CorrelateWorkspace(workspaceId));
+            evidence.TryAdd("verbose-scope", governance.VerboseCapture.ActiveScopeId(DateTimeOffset.UtcNow) ?? "none");
+            evidence.TryAdd("config", string.Join('\n',
+                bundles.RedactConfiguration().Select(kv => $"{kv.Key}={kv.Value}")));
+
+            var path = await bundles.CreateBoundedBundleAsync(evidence, workspaceId, ct);
+            try
+            {
+                var bytes = await File.ReadAllBytesAsync(path, ct);
+                audit.LogGovernanceAction(
+                    "diagnostics.export",
+                    workspaceId,
+                    selected.Principal.UserId,
+                    $"bytes={bytes.Length};truncated={evidence.Truncated}");
+                return Results.File(bytes, "application/zip", Path.GetFileName(path));
+            }
+            finally
+            {
+                try { File.Delete(path); } catch { /* best-effort temp cleanup */ }
+            }
+        });
+
+        app.MapPost("/v1/workspaces/{workspaceId}/entitlements/{kind}", async (
+            HttpContext http,
+            string workspaceId,
+            string kind,
+            ProductionGovernance governance,
+            IWorkspaceAccessStore access,
+            AuditLogService audit,
+            CancellationToken ct) =>
+        {
+            var selected = await WorkspaceHttpAccess.RequireSelectedAsync(http, access, workspaceId, ct);
+            if (selected.Principal is null) return Results.Unauthorized();
+            if (selected.Access is null) return Results.NotFound();
+            if (selected.Access.Role != WorkspaceRole.Owner)
+                return Results.Forbid();
+            if (!Enum.TryParse<EntitlementKind>(kind, ignoreCase: true, out var entitlement))
+                return Results.ValidationProblem(new Dictionary<string, string[]>
+                {
+                    ["kind"] = ["Unknown entitlement kind."]
+                });
+
+            governance.Entitlements.Grant(workspaceId, entitlement);
+            audit.LogGovernanceAction("entitlement.grant", workspaceId, selected.Principal.UserId, entitlement.ToString());
+            return Results.Ok(new { workspaceId, kind = entitlement.ToString(), granted = true });
+        });
+
+        app.MapPost("/v1/workspaces/{workspaceId}/assets/{revisionId}/takedown", async (
+            HttpContext http,
+            string workspaceId,
+            string revisionId,
+            ProductionGovernance governance,
+            IWorkspaceAccessStore access,
+            AuditLogService audit,
+            [FromBody] TakedownRequest? body,
+            CancellationToken ct) =>
+        {
+            var selected = await WorkspaceHttpAccess.RequireSelectedAsync(http, access, workspaceId, ct);
+            if (selected.Principal is null) return Results.Unauthorized();
+            if (selected.Access is null) return Results.NotFound();
+            if (selected.Access.Role != WorkspaceRole.Owner)
+                return Results.Forbid();
+
+            var opened = governance.Takedowns.Open(workspaceId, revisionId, body?.Reason ?? "takedown", DateTimeOffset.UtcNow);
+            var enforced = governance.Takedowns.Enforce(opened.CaseId, DateTimeOffset.UtcNow);
+            audit.LogGovernanceAction(
+                "asset.takedown.enforce",
+                workspaceId,
+                selected.Principal.UserId,
+                $"revision={revisionId};case={enforced.CaseId}");
+            return Results.Ok(enforced);
+        });
+
+        app.MapGet("/v1/workspaces/{workspaceId}/assets/{revisionId}/takedown-status", (
+            string workspaceId,
+            string revisionId,
+            ProductionGovernance governance) =>
+            Results.Ok(new { blocked = governance.Takedowns.IsBlocked(workspaceId, revisionId) }));
+    }
+
+    public sealed record ElevateVerboseRequest(int? Minutes, bool? Verbose, string? ScopeId);
+    public sealed record TakedownRequest(string? Reason);
+}

--- a/Nuotti.Backend/Endpoints/PrivateAssetEndpoints.cs
+++ b/Nuotti.Backend/Endpoints/PrivateAssetEndpoints.cs
@@ -1,6 +1,8 @@
 using Nuotti.Backend.Assets;
 using Nuotti.Backend.Exception;
+using Nuotti.Backend.Governance;
 using Nuotti.Backend.Workspaces;
+using Nuotti.Contracts.V1.Governance;
 using Nuotti.Contracts.V1.Enum;
 
 namespace Nuotti.Backend.Endpoints;
@@ -121,11 +123,18 @@ public static class PrivateAssetEndpoints
 
         app.MapPost("/v1/workspaces/{workspaceId}/revisions/{revisionId}/download", async (
             HttpContext http, string workspaceId, string revisionId, IWorkspaceAccessStore access,
-            IPrivateAssetMetadataStore metadata, IPrivateAssetObjectStore objects, CancellationToken ct) =>
+            IPrivateAssetMetadataStore metadata, IPrivateAssetObjectStore objects,
+            ProductionGovernance governance, CancellationToken ct) =>
         {
             var selected = await WorkspaceHttpAccess.RequireSelectedAsync(http, access, workspaceId, ct);
             if (selected.Principal is null) return Results.Unauthorized();
             if (selected.Access is null) return Results.NotFound();
+            if (governance.Takedowns.IsBlocked(workspaceId, revisionId))
+                return Results.Json(new { title = "Takedown enforced", detail = "Asset download is blocked by an enforced takedown." },
+                    statusCode: StatusCodes.Status403Forbidden);
+            if (!governance.Entitlements.IsAllowed(workspaceId, EntitlementKind.AssetDownload))
+                return Results.Json(new { title = "Not entitled", detail = "Asset download requires an active entitlement." },
+                    statusCode: StatusCodes.Status403Forbidden);
             var revision = await metadata.GetAsync(workspaceId, revisionId, ct);
             if (revision?.Status != AssetRevisionStatus.Published || RightsExpired(revision.Provenance)) return Results.NotFound();
             var key = await metadata.GetObjectKeyAsync(workspaceId, revisionId, ct);

--- a/Nuotti.Backend/Endpoints/ShowAgentEndpoints.cs
+++ b/Nuotti.Backend/Endpoints/ShowAgentEndpoints.cs
@@ -1,6 +1,8 @@
+using Nuotti.Backend.Governance;
 using Nuotti.Backend.ShowAgents;
 using Nuotti.Backend.Workspaces;
 using Nuotti.Backend.Persistence;
+using Nuotti.Contracts.V1.Governance;
 
 namespace Nuotti.Backend.Endpoints;
 
@@ -10,15 +12,24 @@ public sealed record ShowAgentStatusRequest(ShowAgentConnectionState State, stri
 
 public static class ShowAgentEndpoints
 {
+    static readonly System.Text.Json.JsonSerializerOptions LeaseJson = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
     public static void MapShowAgentEndpoints(this WebApplication app)
     {
         app.MapPost("/v1/workspaces/{workspaceId}/sessions/{sessionCode}/show-agent/pairings", async (
             HttpContext http, string workspaceId, string sessionCode, IWorkspaceAccessStore workspaceStore,
-            IShowAgentAccessStore agentStore, IDurableSessionCommitStore sessions, CancellationToken ct) =>
+            IShowAgentAccessStore agentStore, IDurableSessionCommitStore sessions,
+            ProductionGovernance governance, CancellationToken ct) =>
         {
             var selected = await WorkspaceHttpAccess.RequireSelectedAsync(http, workspaceStore, workspaceId, ct);
             if (selected.Principal is null) return Results.Unauthorized();
             if (selected.Access is null) return Results.NotFound();
+            if (!governance.Entitlements.IsAllowed(workspaceId, EntitlementKind.ShowAgentPairing))
+                return Results.Json(new { title = "Not entitled", detail = "Show Agent pairing requires an active entitlement." },
+                    statusCode: StatusCodes.Status403Forbidden);
             if (await sessions.LoadAsync(workspaceId, sessionCode, ct) is null) return Results.NotFound();
             return Results.Ok(await agentStore.IssuePairingCodeAsync(
                 workspaceId, sessionCode, selected.Principal.UserId, ct));
@@ -42,33 +53,43 @@ public static class ShowAgentEndpoints
         }).RequireRateLimiting("show-agent-pairing");
 
         app.MapPost("/v1/show-agent/token", async (
-            ShowAgentCredentialRequest request, IShowAgentAccessStore store, CancellationToken ct) =>
+            ShowAgentCredentialRequest request, IShowAgentAccessStore store,
+            ProductionGovernance governance, CancellationToken ct) =>
         {
             if (string.IsNullOrWhiteSpace(request.Credential))
                 return Results.ValidationProblem(new Dictionary<string, string[]> { ["credential"] = ["Credential is required."] });
             var issued = await store.IssueAccessTokenAsync(request.Credential, ct);
-            return issued is null ? Results.Unauthorized() : Results.Ok(new
+            if (issued is null) return Results.Unauthorized();
+            var signed = governance.LeaseIssuer.Issue(
+                issued.Value.Lease.AgentId,
+                issued.Value.Lease.WorkspaceId,
+                issued.Value.Lease.SessionCode,
+                issued.Value.Lease.ExpiresAt);
+            return Results.Ok(new
             {
                 accessToken = issued.Value.Token,
                 expiresAt = issued.Value.Lease.ExpiresAt,
                 workspaceId = issued.Value.Lease.WorkspaceId,
-                sessionCode = issued.Value.Lease.SessionCode
+                sessionCode = issued.Value.Lease.SessionCode,
+                signedLease = signed
             });
         });
 
         app.MapPut("/v1/show-agent/status", async (
-            HttpContext http, ShowAgentStatusRequest request, IShowAgentAccessStore store, CancellationToken ct) =>
+            HttpContext http, ShowAgentStatusRequest request, IShowAgentAccessStore store,
+            ProductionGovernance governance, CancellationToken ct) =>
         {
-            var lease = await AuthenticateAgentAsync(http, store, ct);
+            var lease = await AuthenticateAgentAsync(http, store, governance, ct);
             if (lease is null) return Results.Unauthorized();
             return await store.ReportStatusAsync(lease, request.State, request.Detail, ct)
                 ? Results.NoContent() : Results.Unauthorized();
         });
 
         app.MapGet("/v1/show-agent/commands", async (
-            HttpContext http, long? after, IShowAgentAccessStore store, CancellationToken ct) =>
+            HttpContext http, long? after, IShowAgentAccessStore store,
+            ProductionGovernance governance, CancellationToken ct) =>
         {
-            var lease = await AuthenticateAgentAsync(http, store, ct);
+            var lease = await AuthenticateAgentAsync(http, store, governance, ct);
             if (lease is null) return Results.Unauthorized();
             var commands = await store.ReadCommandsAsync(lease, Math.Max(0, after ?? 0), ct);
             return commands is null ? Results.Unauthorized() : Results.Ok(commands);
@@ -98,12 +119,34 @@ public static class ShowAgentEndpoints
     }
 
     static async Task<ShowAgentLease?> AuthenticateAgentAsync(
-        HttpContext http, IShowAgentAccessStore store, CancellationToken ct)
+        HttpContext http, IShowAgentAccessStore store, ProductionGovernance governance, CancellationToken ct)
     {
         var authorization = http.Request.Headers.Authorization.ToString();
         const string prefix = "Bearer ";
         if (!authorization.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)) return null;
         var token = authorization[prefix.Length..].Trim();
-        return token.Length == 0 ? null : await store.AuthenticateAsync(token, ct);
+        if (token.Length == 0) return null;
+        var lease = await store.AuthenticateAsync(token, ct);
+        if (lease is null) return null;
+
+        // Optional signed-lease header: when present, integrity + expiry must verify.
+        var signedHeader = http.Request.Headers["X-Nuotti-Signed-Lease"].ToString();
+        if (string.IsNullOrWhiteSpace(signedHeader)) return lease;
+
+        try
+        {
+            var signed = System.Text.Json.JsonSerializer.Deserialize<SignedLease>(signedHeader, LeaseJson);
+            if (signed is null
+                || !string.Equals(signed.AgentId, lease.AgentId, StringComparison.Ordinal)
+                || !string.Equals(signed.WorkspaceId, lease.WorkspaceId, StringComparison.Ordinal)
+                || !string.Equals(signed.SessionCode, lease.SessionCode, StringComparison.Ordinal)
+                || !governance.LeaseIssuer.TryVerify(signed, DateTimeOffset.UtcNow, out _))
+                return null;
+            return lease;
+        }
+        catch (System.Text.Json.JsonException)
+        {
+            return null;
+        }
     }
 }

--- a/Nuotti.Backend/Endpoints/WorkspaceEndpoints.cs
+++ b/Nuotti.Backend/Endpoints/WorkspaceEndpoints.cs
@@ -42,13 +42,16 @@ public static class WorkspaceEndpoints
         });
 
         app.MapPost("/v1/workspaces", async (
-            HttpContext http, CreateWorkspaceRequest request, IWorkspaceAccessStore store, CancellationToken ct) =>
+            HttpContext http, CreateWorkspaceRequest request, IWorkspaceAccessStore store,
+            Nuotti.Backend.Governance.ProductionGovernance governance, CancellationToken ct) =>
         {
             var principal = await WorkspaceHttpAccess.AuthenticateAsync(http, store, ct);
             if (principal is null) return Results.Unauthorized();
             if (string.IsNullOrWhiteSpace(request.Name) || request.Name.Trim().Length > 120)
                 return Invalid("name", "Workspace name must be between 1 and 120 characters.");
-            return Results.Ok(await store.CreateWorkspaceAsync(principal, request.Name, ct));
+            var created = await store.CreateWorkspaceAsync(principal, request.Name, ct);
+            governance.GrantLaunchEntitlements(created.WorkspaceId);
+            return Results.Ok(created);
         });
 
         app.MapPost("/v1/workspaces/{workspaceId}/select", async (

--- a/Nuotti.Backend/Governance/ProductionGovernance.cs
+++ b/Nuotti.Backend/Governance/ProductionGovernance.cs
@@ -1,0 +1,43 @@
+using Nuotti.Contracts.V1.Governance;
+using ServiceDefaults;
+using Serilog.Events;
+
+namespace Nuotti.Backend.Governance;
+
+/// <summary>
+/// Process-wide production governance seams registered in DI.
+/// </summary>
+public sealed class ProductionGovernance
+{
+    public ScopedVerboseCapture VerboseCapture { get; } = new();
+    public EntitlementGate Entitlements { get; } = new();
+    public TakedownCaseStore Takedowns { get; } = new();
+    public SignedLeaseIssuer LeaseIssuer { get; } = new(SignedLeaseIssuer.CreateKey());
+    public LogLevelSwitchService? LogLevelSwitch { get; set; }
+
+    public DiagnosticVerbosity ApplyVerboseLevel(DateTimeOffset nowUtc)
+    {
+        var level = VerboseCapture.EffectiveLevel(nowUtc);
+        if (LogLevelSwitch is not null)
+        {
+            LogLevelSwitch.SetLevel(level switch
+            {
+                DiagnosticVerbosity.Verbose => LogEventLevel.Verbose,
+                DiagnosticVerbosity.Debug => LogEventLevel.Debug,
+                _ => LogEventLevel.Information
+            });
+        }
+        return level;
+    }
+
+    /// <summary>
+    /// Default entitlements for a newly created private-show workspace.
+    /// Owners can revoke individual kinds via the entitlement gate.
+    /// </summary>
+    public void GrantLaunchEntitlements(string workspaceId)
+    {
+        Entitlements.Grant(workspaceId, EntitlementKind.AssetDownload);
+        Entitlements.Grant(workspaceId, EntitlementKind.ShowAgentPairing);
+        Entitlements.Grant(workspaceId, EntitlementKind.PublishPackage);
+    }
+}

--- a/Nuotti.Backend/Program.cs
+++ b/Nuotti.Backend/Program.cs
@@ -164,6 +164,7 @@ builder.Services.AddSingleton<BackendMetrics>();
 
 // Diagnostics
 builder.Services.AddSingleton<Nuotti.Backend.Diagnostics.DiagnosticsBundleService>();
+builder.Services.AddSingleton<Nuotti.Backend.Governance.ProductionGovernance>();
 
 // Alerting
 builder.Services.AddHttpClient("Alerting");
@@ -239,6 +240,7 @@ app.MapPrivateAssetEndpoints();
 app.MapSongPackageEndpoints();
 app.MapSessionSnapshotEndpoints();
 app.MapRecoveryEndpoints();
+app.MapGovernanceEndpoints();
 app.MapNuottiEndpoints("Nuotti.Backend");
 
 // Force creation of subscribers so they can attach to the bus
@@ -246,6 +248,9 @@ _ = app.Services.GetRequiredService<HubBroadcastSubscriber>();
 _ = app.Services.GetRequiredService<MetricsSubscriber>();
 _ = app.Services.GetRequiredService<LogStreamSubscriber>();
 _ = app.Services.GetRequiredService<ShowAgentCommandSubscriber>();
+
+var productionGovernance = app.Services.GetRequiredService<Nuotti.Backend.Governance.ProductionGovernance>();
+productionGovernance.LogLevelSwitch = app.Services.GetService<LogLevelSwitchService>();
 
 var logger = app.Services.GetRequiredService<ILogger<Program>>();
 

--- a/Nuotti.Backend/Retention/SessionResultsStore.cs
+++ b/Nuotti.Backend/Retention/SessionResultsStore.cs
@@ -14,7 +14,7 @@ public sealed record SessionShowResult(
 
 public interface ISessionResultsStore
 {
-    static readonly TimeSpan Retention = TimeSpan.FromDays(30);
+    static readonly TimeSpan Retention = Nuotti.Contracts.V1.Governance.RetentionBoundary.SessionResults;
 
     Task SaveAsync(SessionShowResult result, CancellationToken cancellationToken = default);
     Task<SessionShowResult?> GetAsync(string workspaceId, string sessionCode, CancellationToken cancellationToken = default);

--- a/Nuotti.Backend/Telemetry/BackendActivitySource.cs
+++ b/Nuotti.Backend/Telemetry/BackendActivitySource.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using Nuotti.Contracts.V1.Governance;
 
 namespace Nuotti.Backend.Telemetry;
 
@@ -22,7 +23,7 @@ public static class BackendActivitySource
         {
             activity.SetTag("command.name", commandName);
             activity.SetTag("command.id", commandId.ToString());
-            activity.SetTag("session.code", session);
+            activity.SetTag("session.code", SafeTelemetryIdentifiers.CorrelateSession(session));
             activity.SetTag("nuotti.command_type", "phase_change");
         }
         return activity;
@@ -37,7 +38,7 @@ public static class BackendActivitySource
         if (activity != null)
         {
             activity.SetTag("event.type", eventType);
-            activity.SetTag("session.code", session);
+            activity.SetTag("session.code", SafeTelemetryIdentifiers.CorrelateSession(session));
             if (correlationId.HasValue)
             {
                 activity.SetTag("correlation.id", correlationId.Value.ToString());
@@ -57,9 +58,8 @@ public static class BackendActivitySource
         {
             activity.SetTag("event.type", eventType);
             activity.SetTag("subscriber.name", subscriberName);
-            activity.SetTag("session.code", session);
+            activity.SetTag("session.code", SafeTelemetryIdentifiers.CorrelateSession(session));
         }
         return activity;
     }
 }
-

--- a/Nuotti.Contracts.Tests/V1/Governance/ProductionGovernanceSeamsTests.cs
+++ b/Nuotti.Contracts.Tests/V1/Governance/ProductionGovernanceSeamsTests.cs
@@ -1,0 +1,83 @@
+using FluentAssertions;
+using Nuotti.Contracts.V1.Governance;
+using Xunit;
+
+namespace Nuotti.Contracts.Tests.V1.Governance;
+
+public class ProductionGovernanceSeamsTests
+{
+    [Fact]
+    public void Telemetry_correlates_safe_ids_and_redacts_secrets()
+    {
+        var session = SafeTelemetryIdentifiers.CorrelateSession("SHOW-42");
+        session.Should().StartWith("session:");
+        session.Should().NotContain("SHOW");
+
+        var text = SafeTelemetryIdentifiers.RedactSecrets("Authorization: Bearer super-secret-token password=hunter2");
+        text.Should().NotContain("super-secret-token");
+        text.Should().NotContain("hunter2");
+        text.Should().Contain("***REDACTED***");
+        SafeTelemetryIdentifiers.ContainsSecret("api_key=abc").Should().BeTrue();
+    }
+
+    [Fact]
+    public void Scoped_verbose_auto_expires()
+    {
+        var capture = new ScopedVerboseCapture();
+        var now = DateTimeOffset.Parse("2026-08-01T12:00:00Z");
+        var scope = capture.Elevate(DiagnosticVerbosity.Verbose, TimeSpan.FromMinutes(15), now, "scope-a");
+        scope.Should().Be("scope-a");
+        capture.EffectiveLevel(now).Should().Be(DiagnosticVerbosity.Verbose);
+        capture.EffectiveLevel(now.AddMinutes(16)).Should().Be(DiagnosticVerbosity.Information);
+        capture.ActiveScopeId(now.AddMinutes(16)).Should().BeNull();
+    }
+
+    [Fact]
+    public void Support_bundles_bound_and_redact_evidence()
+    {
+        var evidence = new BoundedSupportEvidence(maxItems: 2, maxCharsPerItem: 40, maxTotalChars: 60);
+        evidence.TryAdd("log-1", "token=abc123456789 and more text that will truncate").Should().BeTrue();
+        evidence.TryAdd("log-2", "second").Should().BeTrue();
+        evidence.TryAdd("log-3", "overflow").Should().BeFalse();
+        evidence.Truncated.Should().BeTrue();
+        evidence.Items.Should().HaveCount(2);
+        evidence.Items[0].Content.Should().NotContain("abc123456789");
+        evidence.RenderManifest(SafeTelemetryIdentifiers.CorrelateWorkspace("corr-1"))
+            .Should().Contain("truncated=True");
+    }
+
+    [Fact]
+    public void Signed_lease_verifies_expiry_and_integrity()
+    {
+        var issuer = new SignedLeaseIssuer(SignedLeaseIssuer.CreateKey());
+        var now = DateTimeOffset.Parse("2026-08-01T12:00:00Z");
+        var lease = issuer.Issue("agent-1", "ws-1", "S1", now.AddMinutes(30));
+        issuer.TryVerify(lease, now, out _).Should().BeTrue();
+        issuer.TryVerify(lease, now.AddHours(1), out var expired).Should().BeFalse();
+        expired.Should().Be("expired");
+
+        var tampered = lease with { SessionCode = "OTHER" };
+        issuer.TryVerify(tampered, now, out var badSig).Should().BeFalse();
+        badSig.Should().Be("invalid-signature");
+    }
+
+    [Fact]
+    public void Entitlement_and_takedown_enforce_boundaries()
+    {
+        var entitlements = new EntitlementGate();
+        entitlements.Invoking(g => g.Ensure("ws-1", EntitlementKind.DiagnosticsExport))
+            .Should().Throw<UnauthorizedAccessException>();
+        entitlements.Grant("ws-1", EntitlementKind.DiagnosticsExport);
+        entitlements.IsAllowed("ws-1", EntitlementKind.DiagnosticsExport).Should().BeTrue();
+
+        var takedown = new TakedownCaseStore();
+        var now = DateTimeOffset.UtcNow;
+        var opened = takedown.Open("ws-1", "rev_audio_1", "rights dispute", now);
+        takedown.IsBlocked("ws-1", "rev_audio_1").Should().BeFalse();
+        takedown.Enforce(opened.CaseId, now);
+        takedown.IsBlocked("ws-1", "rev_audio_1").Should().BeTrue();
+
+        RetentionBoundary.IsExpired(now.AddDays(-31), RetentionBoundary.SessionResults, now).Should().BeTrue();
+        RetentionBoundary.IsExpired(now.AddDays(-1), RetentionBoundary.SessionResults, now).Should().BeFalse();
+    }
+}

--- a/Nuotti.Contracts/V1/Governance/BoundedSupportEvidence.cs
+++ b/Nuotti.Contracts/V1/Governance/BoundedSupportEvidence.cs
@@ -1,0 +1,73 @@
+using System.Text;
+
+namespace Nuotti.Contracts.V1.Governance;
+
+public sealed record SupportEvidenceItem(string Name, string Content);
+
+/// <summary>
+/// Builds bounded support-bundle evidence with redacted identifiers and a hard size cap.
+/// </summary>
+public sealed class BoundedSupportEvidence
+{
+    public const int DefaultMaxItems = 32;
+    public const int DefaultMaxCharsPerItem = 4_000;
+    public const int DefaultMaxTotalChars = 48_000;
+
+    readonly List<SupportEvidenceItem> _items = [];
+    readonly int _maxItems;
+    readonly int _maxCharsPerItem;
+    readonly int _maxTotalChars;
+    int _totalChars;
+
+    public BoundedSupportEvidence(
+        int maxItems = DefaultMaxItems,
+        int maxCharsPerItem = DefaultMaxCharsPerItem,
+        int maxTotalChars = DefaultMaxTotalChars)
+    {
+        _maxItems = maxItems;
+        _maxCharsPerItem = maxCharsPerItem;
+        _maxTotalChars = maxTotalChars;
+    }
+
+    public IReadOnlyList<SupportEvidenceItem> Items => _items;
+    public bool Truncated { get; private set; }
+
+    public bool TryAdd(string name, string content)
+    {
+        if (_items.Count >= _maxItems || _totalChars >= _maxTotalChars)
+        {
+            Truncated = true;
+            return false;
+        }
+
+        var safeName = SafeTelemetryIdentifiers.RedactSecrets(name);
+        var safeContent = SafeTelemetryIdentifiers.RedactSecrets(content);
+        if (safeContent.Length > _maxCharsPerItem)
+        {
+            safeContent = safeContent[.._maxCharsPerItem] + "…[truncated]";
+            Truncated = true;
+        }
+
+        var remaining = _maxTotalChars - _totalChars;
+        if (safeContent.Length > remaining)
+        {
+            safeContent = safeContent[..Math.Max(0, remaining)] + "…[truncated]";
+            Truncated = true;
+        }
+
+        _items.Add(new SupportEvidenceItem(safeName, safeContent));
+        _totalChars += safeContent.Length;
+        return true;
+    }
+
+    public string RenderManifest(string correlationId)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine($"correlation={correlationId}");
+        sb.AppendLine($"items={_items.Count}");
+        sb.AppendLine($"truncated={Truncated}");
+        foreach (var item in _items)
+            sb.AppendLine($"- {item.Name} ({item.Content.Length} chars)");
+        return sb.ToString();
+    }
+}

--- a/Nuotti.Contracts/V1/Governance/EntitlementGate.cs
+++ b/Nuotti.Contracts/V1/Governance/EntitlementGate.cs
@@ -1,0 +1,33 @@
+namespace Nuotti.Contracts.V1.Governance;
+
+public enum EntitlementKind
+{
+    DiagnosticsExport,
+    AssetDownload,
+    ShowAgentPairing,
+    PublishPackage
+}
+
+/// <summary>
+/// Workspace entitlement gate independent of role membership.
+/// </summary>
+public sealed class EntitlementGate
+{
+    readonly HashSet<(string WorkspaceId, EntitlementKind Kind)> _grants = new();
+
+    public void Grant(string workspaceId, EntitlementKind kind)
+        => _grants.Add((workspaceId, kind));
+
+    public void Revoke(string workspaceId, EntitlementKind kind)
+        => _grants.Remove((workspaceId, kind));
+
+    public bool IsAllowed(string workspaceId, EntitlementKind kind)
+        => _grants.Contains((workspaceId, kind));
+
+    public void Ensure(string workspaceId, EntitlementKind kind)
+    {
+        if (!IsAllowed(workspaceId, kind))
+            throw new UnauthorizedAccessException(
+                $"Workspace '{workspaceId}' is not entitled for {kind}.");
+    }
+}

--- a/Nuotti.Contracts/V1/Governance/SafeTelemetryIdentifiers.cs
+++ b/Nuotti.Contracts/V1/Governance/SafeTelemetryIdentifiers.cs
@@ -1,0 +1,48 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace Nuotti.Contracts.V1.Governance;
+
+/// <summary>
+/// Correlates telemetry with safe identifiers and redacts PII/secrets before they leave the process.
+/// </summary>
+public static class SafeTelemetryIdentifiers
+{
+    static readonly Regex SecretPattern = new(
+        @"(?i)(?:authorization\s*[=:]\s*bearer\s+[^\s,;}]+|bearer\s+[^\s,;}]+|(?:password|secret|token|apikey|api_key|authorization)\s*[=:]\s*[^\s,;}]+)",
+        RegexOptions.Compiled);
+
+    public static string CorrelateSession(string? sessionCode)
+    {
+        if (string.IsNullOrWhiteSpace(sessionCode)) return "session:unknown";
+        return "session:" + ShortHash(sessionCode.Trim().ToUpperInvariant());
+    }
+
+    public static string CorrelateWorkspace(string? workspaceId)
+    {
+        if (string.IsNullOrWhiteSpace(workspaceId)) return "workspace:unknown";
+        return "workspace:" + ShortHash(workspaceId.Trim());
+    }
+
+    public static string CorrelateActor(string? actorId)
+    {
+        if (string.IsNullOrWhiteSpace(actorId)) return "actor:unknown";
+        return "actor:" + ShortHash(actorId.Trim());
+    }
+
+    public static string RedactSecrets(string? text)
+    {
+        if (string.IsNullOrEmpty(text)) return string.Empty;
+        return SecretPattern.Replace(text, "***REDACTED***");
+    }
+
+    public static bool ContainsSecret(string? text)
+        => !string.IsNullOrEmpty(text) && SecretPattern.IsMatch(text);
+
+    static string ShortHash(string value)
+    {
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(value));
+        return Convert.ToHexString(hash)[..12].ToLowerInvariant();
+    }
+}

--- a/Nuotti.Contracts/V1/Governance/ScopedVerboseCapture.cs
+++ b/Nuotti.Contracts/V1/Governance/ScopedVerboseCapture.cs
@@ -1,0 +1,70 @@
+namespace Nuotti.Contracts.V1.Governance;
+
+public enum DiagnosticVerbosity
+{
+    Information = 0,
+    Debug = 1,
+    Verbose = 2
+}
+
+/// <summary>
+/// Scoped Debug/Verbose capture that auto-expires. Outside the window, level falls back to Information.
+/// </summary>
+public sealed class ScopedVerboseCapture
+{
+    readonly object _gate = new();
+    DiagnosticVerbosity _baseline = DiagnosticVerbosity.Information;
+    DiagnosticVerbosity _elevated = DiagnosticVerbosity.Information;
+    DateTimeOffset? _expiresAt;
+    string? _scopeId;
+
+    public DiagnosticVerbosity EffectiveLevel(DateTimeOffset nowUtc)
+    {
+        lock (_gate)
+        {
+            if (_expiresAt is { } expires && nowUtc >= expires)
+            {
+                _elevated = _baseline;
+                _expiresAt = null;
+                _scopeId = null;
+            }
+            return _elevated;
+        }
+    }
+
+    public string? ActiveScopeId(DateTimeOffset nowUtc)
+    {
+        lock (_gate)
+        {
+            _ = EffectiveLevel(nowUtc);
+            return _scopeId;
+        }
+    }
+
+    public string Elevate(DiagnosticVerbosity level, TimeSpan ttl, DateTimeOffset nowUtc, string? scopeId = null)
+    {
+        if (level < DiagnosticVerbosity.Debug)
+            throw new ArgumentOutOfRangeException(nameof(level), "Elevation must be Debug or Verbose.");
+        if (ttl <= TimeSpan.Zero || ttl > TimeSpan.FromHours(2))
+            throw new ArgumentOutOfRangeException(nameof(ttl), "TTL must be between 0 and 2 hours.");
+
+        lock (_gate)
+        {
+            _elevated = level;
+            _expiresAt = nowUtc.Add(ttl);
+            _scopeId = scopeId ?? $"diag_{Guid.NewGuid():N}"[..16];
+            return _scopeId;
+        }
+    }
+
+    public void Clear(DateTimeOffset nowUtc)
+    {
+        lock (_gate)
+        {
+            _elevated = _baseline;
+            _expiresAt = null;
+            _scopeId = null;
+            _ = nowUtc;
+        }
+    }
+}

--- a/Nuotti.Contracts/V1/Governance/SignedLeaseIssuer.cs
+++ b/Nuotti.Contracts/V1/Governance/SignedLeaseIssuer.cs
@@ -1,0 +1,61 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Nuotti.Contracts.V1.Governance;
+
+public sealed record SignedLease(
+    string AgentId,
+    string WorkspaceId,
+    string SessionCode,
+    DateTimeOffset ExpiresAt,
+    string Signature);
+
+/// <summary>
+/// HMAC-signed Show Agent lease seam. Verifies expiry and integrity before granting control.
+/// </summary>
+public sealed class SignedLeaseIssuer(byte[] signingKey)
+{
+    public SignedLeaseIssuer(string signingKeyBase64)
+        : this(Convert.FromBase64String(signingKeyBase64))
+    {
+    }
+
+    public static byte[] CreateKey() => RandomNumberGenerator.GetBytes(32);
+
+    public SignedLease Issue(string agentId, string workspaceId, string sessionCode, DateTimeOffset expiresAt)
+    {
+        var payload = Canonical(agentId, workspaceId, sessionCode, expiresAt);
+        var signature = Sign(payload);
+        return new SignedLease(agentId, workspaceId, sessionCode, expiresAt, signature);
+    }
+
+    public bool TryVerify(SignedLease lease, DateTimeOffset nowUtc, out string? reason)
+    {
+        if (nowUtc >= lease.ExpiresAt)
+        {
+            reason = "expired";
+            return false;
+        }
+
+        var expected = Sign(Canonical(lease.AgentId, lease.WorkspaceId, lease.SessionCode, lease.ExpiresAt));
+        if (!CryptographicOperations.FixedTimeEquals(
+                Encoding.UTF8.GetBytes(expected),
+                Encoding.UTF8.GetBytes(lease.Signature)))
+        {
+            reason = "invalid-signature";
+            return false;
+        }
+
+        reason = null;
+        return true;
+    }
+
+    static string Canonical(string agentId, string workspaceId, string sessionCode, DateTimeOffset expiresAt)
+        => $"{agentId}\n{workspaceId}\n{sessionCode}\n{expiresAt.UtcDateTime:O}";
+
+    string Sign(string payload)
+    {
+        using var hmac = new HMACSHA256(signingKey);
+        return Convert.ToHexString(hmac.ComputeHash(Encoding.UTF8.GetBytes(payload))).ToLowerInvariant();
+    }
+}

--- a/Nuotti.Contracts/V1/Governance/TakedownAndRetention.cs
+++ b/Nuotti.Contracts/V1/Governance/TakedownAndRetention.cs
@@ -1,0 +1,73 @@
+namespace Nuotti.Contracts.V1.Governance;
+
+public enum TakedownStatus
+{
+    Open,
+    Enforced,
+    Released
+}
+
+public sealed record TakedownCase(
+    string CaseId,
+    string WorkspaceId,
+    string AssetRevisionId,
+    string Reason,
+    TakedownStatus Status,
+    DateTimeOffset OpenedAtUtc,
+    DateTimeOffset? EnforcedAtUtc);
+
+/// <summary>
+/// Provenance/takedown seam: enforced cases block downloads and Show Agent grants for an asset.
+/// </summary>
+public sealed class TakedownCaseStore
+{
+    readonly Dictionary<string, TakedownCase> _cases = new(StringComparer.Ordinal);
+    readonly object _gate = new();
+
+    public TakedownCase Open(string workspaceId, string assetRevisionId, string reason, DateTimeOffset nowUtc)
+    {
+        lock (_gate)
+        {
+            var id = $"td_{Guid.NewGuid():N}";
+            var opened = new TakedownCase(id, workspaceId, assetRevisionId, reason, TakedownStatus.Open, nowUtc, null);
+            _cases[id] = opened;
+            return opened;
+        }
+    }
+
+    public TakedownCase Enforce(string caseId, DateTimeOffset nowUtc)
+    {
+        lock (_gate)
+        {
+            if (!_cases.TryGetValue(caseId, out var existing))
+                throw new KeyNotFoundException(caseId);
+            var enforced = existing with { Status = TakedownStatus.Enforced, EnforcedAtUtc = nowUtc };
+            _cases[caseId] = enforced;
+            return enforced;
+        }
+    }
+
+    public bool IsBlocked(string workspaceId, string assetRevisionId)
+    {
+        lock (_gate)
+        {
+            return _cases.Values.Any(c =>
+                c.Status == TakedownStatus.Enforced
+                && c.WorkspaceId == workspaceId
+                && c.AssetRevisionId == assetRevisionId);
+        }
+    }
+}
+
+/// <summary>
+/// Retention boundary helper for datasets that must leave after a TTL.
+/// </summary>
+public static class RetentionBoundary
+{
+    public static readonly TimeSpan SessionResults = TimeSpan.FromDays(30);
+    public static readonly TimeSpan AuditLogs = TimeSpan.FromDays(30);
+    public static readonly TimeSpan SupportBundles = TimeSpan.FromDays(7);
+
+    public static bool IsExpired(DateTimeOffset capturedAtUtc, TimeSpan retention, DateTimeOffset nowUtc)
+        => nowUtc - capturedAtUtc >= retention;
+}


### PR DESCRIPTION
## Summary
- Add contract seams for safe telemetry correlation/redaction, scoped Debug/Verbose capture, bounded support evidence, entitlements, takedown/retention, and HMAC-signed Show Agent leases.
- Wire Backend governance endpoints (verbose elevate, bounded export, entitlement grant, takedown) plus download/pairing gates, signed lease issuance, and audit actions.
- Cover seams with contract tests and journey tests for export entitlement, takedown-blocked download, and verifiable signed leases.

## Test plan
- [x] `dotnet test Nuotti.Contracts.Tests --filter ProductionGovernance`
- [x] `dotnet test Nuotti.Backend.Tests --filter GovernanceJourney|ShowAgentJourney|PrivateAssetJourney`
- [ ] Spot-check Owner verbose elevate → export ZIP; takedown then download returns 403

Closes #262