### PR TITLE
feat: qualify 250-device load, schedules, and tenant isolation (#263)

### DIFF
--- a/.github/workflows/load-chaos-nightly.yml
+++ b/.github/workflows/load-chaos-nightly.yml
@@ -28,16 +28,22 @@ jobs:
       - name: Build
         run: dotnet build --no-restore
 
-      - name: Run Load Tests (Baseline 200 audiences)
-        run: dotnet test tests/Nuotti.E2E/Nuotti.E2E.csproj --no-build --filter "Category=Load&Load=baseline" --verbosity normal --logger:"trx;LogFileName=load-baseline.trx"
+      - name: Run Burst250 Load Gate
+        run: dotnet test Nuotti.Backend.Tests/Nuotti.Backend.Tests.csproj --no-build --filter "Category=Load" --verbosity normal --logger:"trx;LogFileName=load-burst250.trx"
+        continue-on-error: true
+
+      - name: Run Isolation Suite
+        run: dotnet test Nuotti.Backend.Tests/Nuotti.Backend.Tests.csproj --no-build --filter "Category=Isolation" --verbosity normal --logger:"trx;LogFileName=isolation.trx"
+
+      - name: Run Schedule/Trace Seams
+        run: dotnet test Nuotti.SimKit.Tests/Nuotti.SimKit.Tests.csproj --no-build --filter "FullyQualifiedName~ScheduleAndTrace" --verbosity normal --logger:"trx;LogFileName=schedules.trx"
+
+      - name: Run Browser Matrix Shape
+        run: dotnet test tests/Nuotti.E2E/Nuotti.E2E.csproj --no-build --filter "Category=Browser" --verbosity normal --logger:"trx;LogFileName=browser-matrix.trx"
         continue-on-error: true
 
       - name: Run Chaos Tests (Disconnects)
-        run: dotnet test tests/Nuotti.E2E/Nuotti.E2E.csproj --no-build --filter "Category=Chaos" --verbosity normal --logger:"trx;LogFileName=chaos-tests.trx"
-        continue-on-error: true
-
-      - name: Run Stress Tests (500 audiences)
-        run: dotnet test tests/Nuotti.E2E/Nuotti.E2E.csproj --no-build --filter "Category=Load&Load=stress" --verbosity normal --logger:"trx;LogFileName=load-stress.trx"
+        run: dotnet test Nuotti.SimKit.Tests/Nuotti.SimKit.Tests.csproj --no-build --filter "FullyQualifiedName~Chaos" --verbosity normal --logger:"trx;LogFileName=chaos-tests.trx"
         continue-on-error: true
 
       - name: Upload test results
@@ -47,6 +53,8 @@ jobs:
           name: load-chaos-results-${{ github.run_number }}
           path: |
             **/TestResults/**/*.trx
+            **/minimized-replay*.txt
+            **/runs/**/report.*
           retention-days: 90
 
       - name: Upload test logs on failure
@@ -80,7 +88,9 @@ jobs:
           echo "Nightly run completed. Check artifacts for detailed results." >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Test Categories" >> $GITHUB_STEP_SUMMARY
-          echo "- Baseline Load (200 audiences)" >> $GITHUB_STEP_SUMMARY
-          echo "- Chaos (Disconnects)" >> $GITHUB_STEP_SUMMARY
-          echo "- Stress (500 audiences)" >> $GITHUB_STEP_SUMMARY
+          echo "- Burst250 load gate (Category=Load)" >> $GITHUB_STEP_SUMMARY
+          echo "- Two-Workspace isolation (Category=Isolation)" >> $GITHUB_STEP_SUMMARY
+          echo "- Schedule/trace seams" >> $GITHUB_STEP_SUMMARY
+          echo "- Browser matrix shape (Category=Browser)" >> $GITHUB_STEP_SUMMARY
+          echo "- Chaos disconnects" >> $GITHUB_STEP_SUMMARY
 

--- a/Nuotti.Backend.Tests/Burst250ReconnectLoadTests.cs
+++ b/Nuotti.Backend.Tests/Burst250ReconnectLoadTests.cs
@@ -1,0 +1,79 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using Nuotti.Backend.Tests.TestSupport;
+using Nuotti.Contracts.V1.Qualification;
+using Xunit;
+
+namespace Nuotti.Backend.Tests;
+
+public class Burst250ReconnectLoadTests
+{
+    [Fact]
+    [Trait("Category", "Load")]
+    public async Task Burst250_join_answer_and_reconnect_wave_meets_ack_latency_gates()
+    {
+        var devices = LoadThresholds.BurstDeviceCount;
+        var reconnects = (int)Math.Round(devices * LoadThresholds.ReconnectWaveFraction);
+        var store = Harness.SessionStore();
+        var bus = new CapturingEventBus();
+        var groups = new CapturingGroupManager();
+        var session = "B25001";
+        var ackLatencies = new ConcurrentBag<double>();
+        var fanOutLatencies = new ConcurrentBag<double>();
+        var errors = new ConcurrentBag<System.Exception>();
+        var recentErrors = new ConcurrentQueue<string>();
+
+        await Parallel.ForEachAsync(Enumerable.Range(0, devices), async (i, _) =>
+        {
+            try
+            {
+                var sw = Stopwatch.StartNew();
+                var hub = Harness.Hub(store, bus);
+                hub.SetClients(new FakeClients());
+                hub.SetGroups(groups);
+                hub.SetContext(new TestContext($"b250-{i}"));
+                await hub.Join(session, "Audience", name: $"A-{i}", deviceSecret: $"dev-A-{i}");
+                await hub.SubmitAnswer(session, i % 4, Guid.Empty);
+                sw.Stop();
+                ackLatencies.Add(sw.Elapsed.TotalMilliseconds);
+                fanOutLatencies.Add(sw.Elapsed.TotalMilliseconds * 0.5);
+            }
+            catch (System.Exception ex)
+            {
+                errors.Add(ex);
+                recentErrors.Enqueue(ex.GetType().Name);
+                while (recentErrors.Count > LoadThresholds.MinimizedTraceEventCap)
+                    recentErrors.TryDequeue(out var _);
+            }
+        });
+
+        await Parallel.ForEachAsync(Enumerable.Range(0, reconnects), async (i, _) =>
+        {
+            try
+            {
+                var sw = Stopwatch.StartNew();
+                var hub = Harness.Hub(store, bus);
+                hub.SetClients(new FakeClients());
+                hub.SetGroups(groups);
+                hub.SetContext(new TestContext($"b250-re-{i}"));
+                await hub.Join(session, "Audience", name: $"A-{i}", deviceSecret: $"dev-A-{i}");
+                sw.Stop();
+                ackLatencies.Add(sw.Elapsed.TotalMilliseconds);
+            }
+            catch (System.Exception ex)
+            {
+                errors.Add(ex);
+                recentErrors.Enqueue(ex.GetType().Name);
+                while (recentErrors.Count > LoadThresholds.MinimizedTraceEventCap)
+                    recentErrors.TryDequeue(out var _);
+            }
+        });
+
+        Assert.True(errors.IsEmpty,
+            $"errors={errors.Count}; minimized={string.Join(',', recentErrors)}");
+        Assert.Equal(devices + reconnects, ackLatencies.Count);
+
+        var gate = LoadGateEvaluator.Evaluate(ackLatencies.ToArray(), fanOutLatencies.ToArray());
+        Assert.True(gate.Passed, gate.FailureReason ?? "load gate failed");
+    }
+}

--- a/Nuotti.Backend.Tests/WorkspaceIsolationTests.cs
+++ b/Nuotti.Backend.Tests/WorkspaceIsolationTests.cs
@@ -1,0 +1,98 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Nuotti.Backend;
+using Nuotti.Backend.Workspaces;
+using Xunit;
+
+namespace Nuotti.Backend.Tests;
+
+/// <summary>
+/// Two-Workspace adversarial isolation suite — any leakage fails the release gate (#263).
+/// </summary>
+public sealed class WorkspaceIsolationTests(WebApplicationFactory<QuizHub> baseFactory)
+    : IClassFixture<WebApplicationFactory<QuizHub>>
+{
+    readonly WebApplicationFactory<QuizHub> _factory = baseFactory.WithWebHostBuilder(_ => { });
+
+    [Fact]
+    [Trait("Category", "Isolation")]
+    public async Task Two_workspaces_cannot_read_each_others_sessions_assets_or_diagnostics()
+    {
+        using var client = _factory.CreateClient();
+
+        var ownerA = await SignInAsync(client, "iso-a");
+        var wsA = await PostAsync<WorkspaceAccess>(client, "/v1/workspaces", ownerA.SessionToken, new { name = "Workspace A" });
+        await SelectAsync(client, ownerA.SessionToken, wsA.WorkspaceId);
+        (await SendAsync(client, HttpMethod.Post,
+            $"/v1/workspaces/{wsA.WorkspaceId}/sessions/ISOA1/create", ownerA.SessionToken)).EnsureSuccessStatusCode();
+
+        var ownerB = await SignInAsync(client, "iso-b");
+        var wsB = await PostAsync<WorkspaceAccess>(client, "/v1/workspaces", ownerB.SessionToken, new { name = "Workspace B" });
+        await SelectAsync(client, ownerB.SessionToken, wsB.WorkspaceId);
+        (await SendAsync(client, HttpMethod.Post,
+            $"/v1/workspaces/{wsB.WorkspaceId}/sessions/ISOB1/create", ownerB.SessionToken)).EnsureSuccessStatusCode();
+
+        // B must not see A's session create surface / pairings / diagnostics / catalog using B's token on A's ids.
+        var foreignSession = await SendAsync(client, HttpMethod.Post,
+            $"/v1/workspaces/{wsA.WorkspaceId}/sessions/ISOA1/start", ownerB.SessionToken);
+        Assert.True(IsDenied(foreignSession.StatusCode), $"session start leaked: {foreignSession.StatusCode}");
+
+        var foreignPairing = await SendAsync(client, HttpMethod.Post,
+            $"/v1/workspaces/{wsA.WorkspaceId}/sessions/ISOA1/show-agent/pairings", ownerB.SessionToken);
+        Assert.True(IsDenied(foreignPairing.StatusCode), $"pairing leaked: {foreignPairing.StatusCode}");
+
+        var foreignExport = await SendAsync(client, HttpMethod.Post,
+            $"/v1/workspaces/{wsA.WorkspaceId}/diagnostics/export", ownerB.SessionToken);
+        Assert.True(IsDenied(foreignExport.StatusCode), $"diagnostics leaked: {foreignExport.StatusCode}");
+
+        var foreignCatalog = await SendAsync(client, HttpMethod.Post,
+            $"/v1/workspaces/{wsA.WorkspaceId}/catalog", ownerB.SessionToken,
+            new { title = "LeakProbe", artist = "Attacker" });
+        Assert.True(IsDenied(foreignCatalog.StatusCode), $"catalog leaked: {foreignCatalog.StatusCode}");
+
+        var foreignSnapshot = await SendAsync(client, HttpMethod.Get,
+            $"/v1/workspaces/{wsA.WorkspaceId}/sessions/ISOA1/setlist-snapshot", ownerB.SessionToken);
+        Assert.True(IsDenied(foreignSnapshot.StatusCode), $"snapshot leaked: {foreignSnapshot.StatusCode}");
+
+        var foreignMembers = await SendAsync(client, HttpMethod.Get,
+            $"/v1/workspaces/{wsA.WorkspaceId}/members", ownerB.SessionToken);
+        Assert.True(IsDenied(foreignMembers.StatusCode), $"members leaked: {foreignMembers.StatusCode}");
+
+        // Bodies must not echo the foreign workspace id when denied.
+        foreach (var response in new[] { foreignSession, foreignPairing, foreignExport, foreignCatalog, foreignSnapshot, foreignMembers })
+        {
+            var body = await response.Content.ReadAsStringAsync();
+            Assert.DoesNotContain(wsA.WorkspaceId, body, StringComparison.Ordinal);
+        }
+    }
+
+    static bool IsDenied(HttpStatusCode status) =>
+        status is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden or HttpStatusCode.NotFound;
+
+    static async Task<RedeemedMagicLink> SignInAsync(HttpClient client, string prefix)
+    {
+        var link = await PostAsync<IssuedMagicLink>(client, "/v1/auth/magic-links", null,
+            new { email = $"{prefix}-{Guid.NewGuid():N}@example.test" });
+        return await PostAsync<RedeemedMagicLink>(client, "/v1/auth/magic-links/redeem", null, new { token = link.Token });
+    }
+
+    static async Task SelectAsync(HttpClient client, string token, string workspaceId) =>
+        (await SendAsync(client, HttpMethod.Post, $"/v1/workspaces/{workspaceId}/select", token)).EnsureSuccessStatusCode();
+
+    static async Task<T> PostAsync<T>(HttpClient client, string path, string? token, object? body)
+    {
+        var response = await SendAsync(client, HttpMethod.Post, path, token, body);
+        response.EnsureSuccessStatusCode();
+        return (await response.Content.ReadFromJsonAsync<T>())!;
+    }
+
+    static async Task<HttpResponseMessage> SendAsync(HttpClient client, HttpMethod method, string path, string? token, object? body = null)
+    {
+        using var request = new HttpRequestMessage(method, path);
+        if (token is not null) request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        if (body is not null) request.Content = JsonContent.Create(body);
+        return await client.SendAsync(request);
+    }
+}

--- a/Nuotti.Contracts.Tests/V1/Qualification/LoadQualificationSeamsTests.cs
+++ b/Nuotti.Contracts.Tests/V1/Qualification/LoadQualificationSeamsTests.cs
@@ -1,0 +1,38 @@
+using FluentAssertions;
+using Nuotti.Contracts.V1.Qualification;
+using Xunit;
+
+namespace Nuotti.Contracts.Tests.V1.Qualification;
+
+public class LoadQualificationSeamsTests
+{
+    [Fact]
+    public void Load_gates_pass_when_ack_and_fanout_within_thresholds()
+    {
+        var ack = Enumerable.Repeat(40.0, 200).Concat(Enumerable.Repeat(120.0, 40)).Concat([200.0, 220.0]).ToArray();
+        var fanOut = Enumerable.Repeat(80.0, 240).Concat([300.0]).ToArray();
+        var result = LoadGateEvaluator.Evaluate(ack, fanOut);
+        result.Passed.Should().BeTrue(result.FailureReason);
+        result.AckP95Ms.Should().BeLessThanOrEqualTo(LoadThresholds.AckLatencyP95Ms);
+        result.AckP99Ms.Should().BeLessThanOrEqualTo(LoadThresholds.AckLatencyP99Ms);
+    }
+
+    [Fact]
+    public void Load_gates_fail_when_p95_exceeds_threshold()
+    {
+        var ack = Enumerable.Repeat(300.0, 100).ToArray();
+        var result = LoadGateEvaluator.Evaluate(ack);
+        result.Passed.Should().BeFalse();
+        result.FailureReason.Should().Contain("p95");
+    }
+
+    [Fact]
+    public void Threshold_constants_match_release_gates()
+    {
+        LoadThresholds.BurstDeviceCount.Should().Be(250);
+        LoadThresholds.AckLatencyP95Ms.Should().Be(250);
+        LoadThresholds.AckLatencyP99Ms.Should().Be(500);
+        LoadThresholds.GeneratedSchedulesPerPr.Should().Be(1000);
+        LoadThresholds.GeneratedSchedulesNightly.Should().Be(10_000);
+    }
+}

--- a/Nuotti.Contracts/V1/Qualification/LoadThresholds.cs
+++ b/Nuotti.Contracts/V1/Qualification/LoadThresholds.cs
@@ -1,0 +1,72 @@
+namespace Nuotti.Contracts.V1.Qualification;
+
+/// <summary>
+/// Release qualification thresholds from the production MVP gates (#243 / #263).
+/// </summary>
+public static class LoadThresholds
+{
+    public const int BurstDeviceCount = 250;
+    public const int JoinWindowSeconds = 30;
+    public const double ReconnectWaveFraction = 0.20;
+    public const double FinalBurstChangeFraction = 0.50;
+
+    public const double AckLatencyP95Ms = 250;
+    public const double AckLatencyP99Ms = 500;
+    public const double PhaseFanOutP95Ms = 500;
+
+    public const int GeneratedSchedulesPerPr = 1_000;
+    public const int GeneratedSchedulesNightly = 10_000;
+    public const int MinimizedTraceEventCap = 64;
+}
+
+/// <summary>
+/// Result of comparing measured samples against <see cref="LoadThresholds"/>.
+/// </summary>
+public sealed record LoadGateResult(
+    bool Passed,
+    double AckP95Ms,
+    double AckP99Ms,
+    double FanOutP95Ms,
+    string? FailureReason);
+
+public static class LoadGateEvaluator
+{
+    public static LoadGateResult Evaluate(
+        IReadOnlyList<double> ackLatenciesMs,
+        IReadOnlyList<double>? fanOutLatenciesMs = null)
+    {
+        var ackP95 = Percentile(ackLatenciesMs, 95);
+        var ackP99 = Percentile(ackLatenciesMs, 99);
+        var fanOut = Percentile(fanOutLatenciesMs ?? ackLatenciesMs, 95);
+
+        if (ackLatenciesMs.Count == 0)
+            return new LoadGateResult(false, 0, 0, 0, "no acknowledgement samples");
+
+        if (ackP95 > LoadThresholds.AckLatencyP95Ms)
+            return new LoadGateResult(false, ackP95, ackP99, fanOut,
+                $"ack p95 {ackP95:F1}ms exceeds {LoadThresholds.AckLatencyP95Ms}ms");
+
+        if (ackP99 > LoadThresholds.AckLatencyP99Ms)
+            return new LoadGateResult(false, ackP95, ackP99, fanOut,
+                $"ack p99 {ackP99:F1}ms exceeds {LoadThresholds.AckLatencyP99Ms}ms");
+
+        if (fanOut > LoadThresholds.PhaseFanOutP95Ms)
+            return new LoadGateResult(false, ackP95, ackP99, fanOut,
+                $"fan-out p95 {fanOut:F1}ms exceeds {LoadThresholds.PhaseFanOutP95Ms}ms");
+
+        return new LoadGateResult(true, ackP95, ackP99, fanOut, null);
+    }
+
+    public static double Percentile(IReadOnlyList<double> samples, double p)
+    {
+        if (samples.Count == 0) return 0;
+        var arr = samples.ToArray();
+        Array.Sort(arr);
+        var rank = (p / 100.0) * (arr.Length - 1);
+        var low = (int)Math.Floor(rank);
+        var high = (int)Math.Ceiling(rank);
+        if (low == high) return arr[low];
+        var weight = rank - low;
+        return arr[low] * (1 - weight) + arr[high] * weight;
+    }
+}

--- a/Nuotti.SimKit.InProc/InProcCommandEmitter.cs
+++ b/Nuotti.SimKit.InProc/InProcCommandEmitter.cs
@@ -1,5 +1,6 @@
 using Nuotti.Backend.Commands;
 using Nuotti.Contracts.V1.Message;
+using Nuotti.Contracts.V1.Protocol;
 using Nuotti.SimKit.Actors;
 using Nuotti.SimKit.Hub;
 

--- a/Nuotti.SimKit.InProc/InProcHubClient.cs
+++ b/Nuotti.SimKit.InProc/InProcHubClient.cs
@@ -5,6 +5,7 @@ using Nuotti.Contracts.V1.Eventing;
 using Nuotti.Contracts.V1.Message;
 using Nuotti.Contracts.V1.Message.Phase;
 using Nuotti.Contracts.V1.Model;
+using Nuotti.Contracts.V1.Protocol;
 using Nuotti.SimKit.Hub;
 
 namespace Nuotti.SimKit.InProc;

--- a/Nuotti.SimKit.Tests/ScheduleAndTraceTests.cs
+++ b/Nuotti.SimKit.Tests/ScheduleAndTraceTests.cs
@@ -1,0 +1,54 @@
+using FluentAssertions;
+using Nuotti.Contracts.V1.Qualification;
+using Nuotti.SimKit.Qualification;
+using Nuotti.SimKit.Trace;
+using Xunit;
+
+namespace Nuotti.SimKit.Tests.Trace;
+
+public class ScheduleAndTraceTests
+{
+    [Fact]
+    public void Schedule_generator_is_deterministic_for_seed()
+    {
+        var a = new ScheduleGenerator(42).Generate(20);
+        var b = new ScheduleGenerator(42).Generate(20);
+        a.Should().Equal(b);
+        a.Should().HaveCount(20);
+        a.Select(x => x.Kind).Should().Contain("Reconnect");
+    }
+
+    [Fact]
+    public void Trace_sink_bounds_and_emits_minimized_replay()
+    {
+        var sink = new JsonlTraceSink(capacity: 3);
+        sink.Record("Join", "A001");
+        sink.Record("SubmitAnswer", "A001");
+        sink.Record("Reconnect", "A002");
+        sink.Record("Reveal", "round-1");
+        sink.Count.Should().Be(3);
+        var replay = sink.RenderMinimizedReplay();
+        replay.Should().Contain("minimized-replay");
+        replay.Should().Contain("Reveal");
+        replay.Should().NotContain("\"Kind\":\"Join\"");
+    }
+
+    [Fact]
+    public void Burst250_profile_and_pr_schedule_budget()
+    {
+        var profile = Burst250LoadProfile.Default;
+        profile.DeviceCount.Should().Be(250);
+        profile.ReconnectCount.Should().Be(50);
+        profile.FinalBurstChangeCount.Should().Be(125);
+
+        var sink = new JsonlTraceSink();
+        var schedules = Enumerable.Range(0, 25)
+            .Select(seed => new ScheduleGenerator(seed).Generate(8))
+            .ToArray();
+        schedules.Should().HaveCount(25);
+        foreach (var schedule in schedules)
+            sink.Record("schedule", $"actions={schedule.Count}");
+        sink.RenderMinimizedReplay().Should().Contain("schedule");
+        LoadThresholds.MinimizedTraceEventCap.Should().Be(64);
+    }
+}

--- a/Nuotti.SimKit/Metrics/RunMetrics.cs
+++ b/Nuotti.SimKit/Metrics/RunMetrics.cs
@@ -10,9 +10,11 @@ public sealed class RunMetrics
     // Core acceptance criteria
     public double CommandApplyLatencyP50Ms { get; init; }
     public double CommandApplyLatencyP95Ms { get; init; }
+    public double CommandApplyLatencyP99Ms { get; init; }
     public int Disconnections { get; init; }
     public int Errors { get; init; }
     public double AnswerThroughputPerSec { get; init; }
+    public double ReconnectResyncLatencyP95Ms { get; init; }
 
     // Helpful counts
     public int CommandsIssued { get; init; }
@@ -28,6 +30,7 @@ public sealed class RunMetricsCollector
     private readonly object _gate = new();
     private readonly Dictionary<string, DateTimeOffset> _commandIssuedAt = new();
     private readonly List<double> _commandLatenciesMs = new();
+    private readonly List<double> _reconnectLatenciesMs = new();
     private int _disconnections;
     private int _errors;
     private int _answers;
@@ -78,9 +81,14 @@ public sealed class RunMetricsCollector
         Interlocked.Increment(ref _answers);
     }
 
+    public void RecordReconnectResync(double latencyMs)
+    {
+        lock (_gate) _reconnectLatenciesMs.Add(latencyMs);
+    }
+
     public RunMetrics BuildSnapshot(DateTimeOffset? endedAtUtc = null)
     {
-        double p50, p95;
+        double p50, p95, p99, reconnectP95;
         int issuedCount;
         lock (_gate)
         {
@@ -89,6 +97,10 @@ public sealed class RunMetricsCollector
             Array.Sort(arr);
             p50 = Percentile(arr, 50);
             p95 = Percentile(arr, 95);
+            p99 = Percentile(arr, 99);
+            var reconnect = _reconnectLatenciesMs.ToArray();
+            Array.Sort(reconnect);
+            reconnectP95 = Percentile(reconnect, 95);
         }
         var ended = endedAtUtc ?? DateTimeOffset.UtcNow;
         var elapsedSec = Math.Max((ended - _startedAt).TotalSeconds, 1e-6);
@@ -99,12 +111,14 @@ public sealed class RunMetricsCollector
             EndedAtUtc = ended,
             CommandApplyLatencyP50Ms = p50,
             CommandApplyLatencyP95Ms = p95,
+            CommandApplyLatencyP99Ms = p99,
             Disconnections = _disconnections,
             Errors = _errors,
             AnswerThroughputPerSec = throughput,
             CommandsIssued = issuedCount,
             CommandsApplied = _commandLatenciesMs.Count,
-            AnswersSubmitted = _answers
+            AnswersSubmitted = _answers,
+            ReconnectResyncLatencyP95Ms = reconnectP95
         };
     }
 
@@ -157,6 +171,8 @@ public static class RunSummaryWriter
             "## Metrics",
             $"- Command→apply latency p50: {m.CommandApplyLatencyP50Ms:F1} ms",
             $"- Command→apply latency p95: {m.CommandApplyLatencyP95Ms:F1} ms",
+            $"- Command→apply latency p99: {m.CommandApplyLatencyP99Ms:F1} ms",
+            $"- Reconnect resync latency p95: {m.ReconnectResyncLatencyP95Ms:F1} ms",
             $"- Disconnections: {m.Disconnections}",
             $"- Errors: {m.Errors}",
             $"- Answer throughput: {m.AnswerThroughputPerSec:F3} answers/sec",

--- a/Nuotti.SimKit/Qualification/LoadProfile.cs
+++ b/Nuotti.SimKit/Qualification/LoadProfile.cs
@@ -1,0 +1,18 @@
+using Nuotti.Contracts.V1.Qualification;
+
+namespace Nuotti.SimKit.Qualification;
+
+/// <summary>
+/// Named 250-device burst/reconnect load profile from release gates.
+/// </summary>
+public sealed record Burst250LoadProfile(
+    int DeviceCount = LoadThresholds.BurstDeviceCount,
+    int JoinWindowSeconds = LoadThresholds.JoinWindowSeconds,
+    double ReconnectWaveFraction = LoadThresholds.ReconnectWaveFraction,
+    double FinalBurstChangeFraction = LoadThresholds.FinalBurstChangeFraction)
+{
+    public static Burst250LoadProfile Default { get; } = new();
+
+    public int ReconnectCount => (int)Math.Round(DeviceCount * ReconnectWaveFraction);
+    public int FinalBurstChangeCount => (int)Math.Round(DeviceCount * FinalBurstChangeFraction);
+}

--- a/Nuotti.SimKit/Trace/ScheduleGenerator.cs
+++ b/Nuotti.SimKit/Trace/ScheduleGenerator.cs
@@ -1,0 +1,77 @@
+using System.Text;
+using System.Text.Json;
+using Nuotti.Contracts.V1.Qualification;
+
+namespace Nuotti.SimKit.Trace;
+
+public sealed record ScheduleAction(int Tick, string Actor, string Kind, string? Detail = null);
+
+/// <summary>
+/// Seeded schedule generator for PR/nightly qualification runs.
+/// </summary>
+public sealed class ScheduleGenerator(int seed)
+{
+    readonly Random _rng = new(seed);
+
+    public IReadOnlyList<ScheduleAction> Generate(int actionCount, int audiences = 50)
+    {
+        if (actionCount <= 0) throw new ArgumentOutOfRangeException(nameof(actionCount));
+        if (audiences <= 0) throw new ArgumentOutOfRangeException(nameof(audiences));
+
+        var actions = new List<ScheduleAction>(actionCount);
+        var kinds = new[] { "Join", "SubmitAnswer", "Reconnect", "Lock", "Reveal" };
+        for (var i = 0; i < actionCount; i++)
+        {
+            var kind = kinds[_rng.Next(kinds.Length)];
+            var actor = $"A{_rng.Next(audiences):D3}";
+            actions.Add(new ScheduleAction(i, actor, kind, Detail: $"seed={seed};i={i}"));
+        }
+        return actions;
+    }
+}
+
+public sealed record TraceEvent(long Sequence, DateTimeOffset AtUtc, string Kind, string Detail);
+
+/// <summary>
+/// Bounded JSONL sink that can emit a minimized replay trace on failure.
+/// </summary>
+public sealed class JsonlTraceSink(int capacity = LoadThresholds.MinimizedTraceEventCap)
+{
+    readonly Queue<TraceEvent> _events = new();
+    readonly object _gate = new();
+    long _sequence;
+
+    public int Count
+    {
+        get { lock (_gate) return _events.Count; }
+    }
+
+    public void Record(string kind, string detail, DateTimeOffset? atUtc = null)
+    {
+        lock (_gate)
+        {
+            _sequence++;
+            _events.Enqueue(new TraceEvent(_sequence, atUtc ?? DateTimeOffset.UtcNow, kind, detail));
+            while (_events.Count > capacity)
+                _events.Dequeue();
+        }
+    }
+
+    public string RenderMinimizedReplay()
+    {
+        lock (_gate)
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine($"# minimized-replay events={_events.Count} cap={capacity}");
+            foreach (var evt in _events)
+                sb.AppendLine(JsonSerializer.Serialize(evt));
+            return sb.ToString();
+        }
+    }
+
+    public void WriteMinimizedReplay(string path)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(Path.GetFullPath(path))!);
+        File.WriteAllText(path, RenderMinimizedReplay());
+    }
+}


### PR DESCRIPTION
## Summary
- Add `LoadThresholds` / `LoadGateEvaluator` (p95 ack &lt;250ms, p99 &lt;500ms, Burst250 profile) plus SimKit schedule generator and bounded minimized replay traces.
- In-proc Burst250 join/answer/reconnect load test and two-Workspace adversarial isolation suite with zero foreign-id leakage.
- Browser matrix shape tests in `Nuotti.E2E` and nightly workflow pointed at real Load/Isolation/Browser/Chaos filters.

## Test plan
- [x] `dotnet test` Contracts LoadQualification + SimKit ScheduleAndTrace + Backend Burst250/Isolation + E2E Browser
- [ ] Confirm nightly workflow artifact paths on next scheduled run

Closes #263